### PR TITLE
Reorder image pulling

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -49,10 +49,10 @@ kind-pull-images:
 	docker pull ${REGISTRY}/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
 	docker pull ${REGISTRY}/${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	docker pull ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
+	docker pull ${BUSYBOX}:${BUSYBOX_TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${DRIVE_MANAGER}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${NODE}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG}
-	docker pull ${BUSYBOX}:${BUSYBOX_TAG}
 
 kind-tag-images:
 	docker tag ${REGISTRY}/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG} ${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}


### PR DESCRIPTION
## Purpose
Improvements for the local environment.
When we don't have images on the registry `make kind-pull-images TAG=${csiVersion} REGISTRY=${registry}` will fail.
With this change, it will fail only after pulling all "static" images. So then we can retag our local images

## PR checklist
- [ ] Add link to the JIRA issue
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with JIRAs
- [ ] All comments are resolved
- [x] PR validation passed
- [ ] Custom CI passed

## Testing
_Link to custom CI build_
