### PR TITLE
[ATLDEF-63] fix IPv6 support for liveness probe

### DIFF
--- a/charts/baremetal-csi-plugin/templates/baremetal-csi-controller.yaml
+++ b/charts/baremetal-csi-plugin/templates/baremetal-csi-controller.yaml
@@ -61,7 +61,6 @@ spec:
         args:
         - "--endpoint=$(CSI_ENDPOINT)"
         - "--namespace=$(NAMESPACE)"
-        - "--healthip=$(POD_IP)"
         - --loglevel={{ .Values.log.level }}
         - --healthport={{ .Values.controller.health.server.port }}
         {{- if .Values.logReceiver.create  }}
@@ -106,11 +105,7 @@ spec:
         readinessProbe:
           exec:
             # have to use bash for extrapolating env var
-            command:
-              - "bash"
-              - "-c"
-              - |
-                /health_probe -addr=$POD_IP:{{ .Values.controller.health.server.port }}
+            command: ["/health_probe", "-addr=:{{ .Values.controller.health.server.port }}"]
           initialDelaySeconds: 3
           periodSeconds: 10
           successThreshold: 1

--- a/charts/baremetal-csi-plugin/templates/baremetal-csi-node.yaml
+++ b/charts/baremetal-csi-plugin/templates/baremetal-csi-node.yaml
@@ -55,7 +55,6 @@ spec:
         args:
           - "--csiendpoint=$(CSI_ENDPOINT)"
           - "--nodeid=$(KUBE_NODE_NAME)"
-          - "--healthip=$(MY_POD_IP)"
           - "--namespace=$(NAMESPACE)"
           - --loglevel={{ .Values.log.level }}
           {{- if .Values.logReceiver.create  }}
@@ -81,12 +80,7 @@ spec:
           periodSeconds: 10
         readinessProbe:
           exec:
-            # have to use bash for extrapolating env var
-            command:
-              - "bash"
-              - "-c"
-              - |
-                /health_probe -addr=$MY_POD_IP:{{ .Values.node.grpc.server.port }}
+            command: ["/health_probe", "-addr=:{{ .Values.node.grpc.server.port }}"]
           initialDelaySeconds: 3
           periodSeconds: 3
           successThreshold: 3

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -4,6 +4,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -52,8 +54,9 @@ func main() {
 	csi.RegisterControllerServer(csiControllerServer.GRPCServer, controllerService)
 	go func() {
 		logger.Info("Starting Controller Health server ...")
-		controllerHealthEndpoint := fmt.Sprintf("tcp://%s:%d", *healthIP, *healthPort)
-		if err := util.SetupAndStartHealthCheckServer(controllerService, logger, controllerHealthEndpoint); err != nil {
+		if err := util.SetupAndStartHealthCheckServer(
+			controllerService, logger,
+			"tcp://"+net.JoinHostPort(*healthIP, strconv.Itoa(*healthPort))); err != nil {
 			logger.Fatalf("Controller service failed with error: %v", err)
 		}
 	}()

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -102,8 +104,9 @@ func main() {
 
 	go func() {
 		logger.Info("Starting Node Health server ...")
-		nodeHealthEndpoint := fmt.Sprintf("tcp://%s:%d", *healthIP, base.DefaultHealthPort)
-		if err := util.SetupAndStartHealthCheckServer(csiNodeService, logger, nodeHealthEndpoint); err != nil {
+		if err := util.SetupAndStartHealthCheckServer(
+			csiNodeService, logger,
+			"tcp://"+net.JoinHostPort(*healthIP, strconv.Itoa(base.DefaultHealthPort))); err != nil {
 			logger.Fatalf("Node service failed with error: %v", err)
 		}
 	}()

--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -9,9 +9,9 @@ const (
 	// PluginVersion is a version of current CSI plugin
 	PluginVersion = "0.0.7"
 	// DefaultDriveMgrEndpoint is the default gRPC endpoint for drivemgr
-	DefaultDriveMgrEndpoint = "tcp://localhost:8888"
+	DefaultDriveMgrEndpoint = "tcp://:8888"
 	// DefaultHealthIP is the default gRPC IP for Health server
-	DefaultHealthIP = "127.0.0.1"
+	DefaultHealthIP = ""
 	// DefaultHealthPort is the default gRPC port for Health Server
 	DefaultHealthPort = 9999
 


### PR DESCRIPTION
FIX IPv6 support for liveness probe

POD_IP usage removed where it possible.

## Purpose
Liveness probe should support both IP families.

## PR checklist
- [ ] Add link to the JIRA issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with JIRAs
- [ ] All comments are resolved
- [x] PR validation passed
- [x] Custom CI passed

## Testing
_Link to custom CI build_
