### PR TITLE
[AK8S-1262] Use volume with type emptyDir for CSI socket

### DIFF
--- a/charts/baremetal-csi-plugin/templates/baremetal-csi-controller.yaml
+++ b/charts/baremetal-csi-plugin/templates/baremetal-csi-controller.yaml
@@ -141,7 +141,5 @@ spec:
             name: {{ .Release.Name }}-logs-config
       {{- end }}
       - name: socket-dir
-        hostPath:
-          path: /var/baremetal-csi/controller
-          type: DirectoryOrCreate
+        emptyDir:
 {{- end }}


### PR DESCRIPTION
This help prevent issue with selinux permissions in Openshift

## PR checklist
- [x] Add link to the JIRA issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with JIRAs
- [ ] All comments are resolved
- [x] PR validation passed
- [x] Custom CI passed

## Testing
_Link to custom CI build_
