### PR TITLE
[ATLDEF-73] Print execution duration to log when external tool called

### DIFF
--- a/pkg/base/command/cmdexec.go
+++ b/pkg/base/command/cmdexec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -74,7 +75,10 @@ func (e *Executor) runCmdFromCmdObj(cmd *exec.Cmd) (outStr string, errStr string
 	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+
+	cmdStartTime := time.Now()
 	err = cmd.Run()
+	cmdDuration := time.Since(cmdStartTime)
 
 	outStr, errStr = stdout.String(), stderr.String()
 	// construct log message based on output and error
@@ -86,8 +90,10 @@ func (e *Executor) runCmdFromCmdObj(cmd *exec.Cmd) (outStr string, errStr string
 		errPart = fmt.Sprintf(", Error: %v", err)
 		level = logrus.ErrorLevel
 	}
-
-	e.log.WithField("cmd", strings.Join(cmd.Args, " ")).
+	e.log.WithFields(logrus.Fields{
+		"cmd":         strings.Join(cmd.Args, " "),
+		"duration":    cmdDuration.String(),
+		"duration_ns": cmdDuration.Nanoseconds()}).
 		Logf(level, "stdout: %s%s%s", outStr, stdErrPart, errPart)
 	return outStr, errStr, err
 }


### PR DESCRIPTION
This change add command duration to debug log. This change simplify debugging
for "time related" issues.

## Purpose
_Describe your changes_

## PR checklist
- [ ] Add link to the JIRA issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with JIRAs
- [ ] All comments are resolved
- [x] PR validation passed
- [x] Custom CI passed

## Testing
_Link to custom CI build_
