### PR TITLE
Disable "2 LVM PV on one drive" because ATLDEF-83

### DIFF
--- a/test/e2e/scenarios/scheduler-test.go
+++ b/test/e2e/scenarios/scheduler-test.go
@@ -195,8 +195,8 @@ func schedulingTest(driver testsuites.TestDriver) {
 	})
 
 	ginkgo.It("2 LVM PV on one drive", func() {
+		framework.Skipf("skip test. See ATLDEF-83 for details")
 		nodes := getSchedulableNodesNamesOrSkipTest(f.ClientSet, 2)
-
 		defaultDriveCount := 0
 		node1, node2 := nodes[0], nodes[1]
 		driveSize := "250Mi"


### PR DESCRIPTION
## Purpose

Disable "2 LVM PV on one drive" because ATLDEF-83

## PR checklist
- [ ] Add link to the JIRA issue
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with JIRAs
- [ ] All comments are resolved
- [ ] PR validation passed
- [ ] Custom CI passed

## Testing
_Link to custom CI build_
