### PR TITLE
[ATLDEF-82] fix for ci

### DIFF
--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -103,9 +103,8 @@ func (vo *VolumeOperationsImpl) CreateVolume(ctx context.Context, v api.Volume) 
 		if ac == nil {
 			if util.IsStorageClassLVG(v.StorageClass) {
 				subSC := util.GetSubStorageClass(v.StorageClass)
-				// increase wanted size for additional costs
-				requiredBytes += LvgDefaultMetadataSize
-				ac = vo.acProvider.SearchAC(ctxWithID, v.NodeId, requiredBytes, subSC) // search volume for LVG in subSC
+				// requiredBytes increase wanted size for additional costs
+				ac = vo.acProvider.SearchAC(ctxWithID, v.NodeId, requiredBytes+LvgDefaultMetadataSize, subSC) // search volume for LVG in subSC
 			}
 			if ac == nil {
 				ll.Errorf("There is no suitable drive for volume with sc %s.", sc)


### PR DESCRIPTION
## Purpose
SearchAC method should take into account LvgDefaultMetadataSize, but we shouldn't append LvgDefaultMetadataSize to the volume's requiredSize. 

## PR checklist
- [ ] Add link to the JIRA issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with JIRAs
- [ ] All comments are resolved
- [x] PR validation passed
- [ ] Custom CI passed

## Testing
_Link to custom CI build_
