### PR TITLE
[Issue-82] Take into account drives vid and pid when drive path is searched

### DIFF
--- a/pkg/base/linuxutils/lsblk/lsblk.go
+++ b/pkg/base/linuxutils/lsblk/lsblk.go
@@ -104,10 +104,9 @@ func (l *LSBLK) GetBlockDevices(device string) ([]BlockDevice, error) {
 	return res, nil
 }
 
-// SearchDrivePath if not defined returns drive path based on drive S/N.
+// SearchDrivePath if not defined returns drive path based on drive S/N, VID and PID.
 // Receives an instance of drivecrd.Drive struct
 // Returns drive's path based on provided drivecrd.Drive or error if something went wrong
-// TODO: check VID/PID as well - https://github.com/dell/csi-baremetal/issues/82
 func (l *LSBLK) SearchDrivePath(drive *drivecrd.Drive) (string, error) {
 	// device path might be already set by hwmgr
 	device := drive.Spec.Path

--- a/pkg/base/linuxutils/lsblk/lsblk.go
+++ b/pkg/base/linuxutils/lsblk/lsblk.go
@@ -123,15 +123,19 @@ func (l *LSBLK) SearchDrivePath(drive *drivecrd.Drive) (string, error) {
 
 	// get drive serial number
 	sn := drive.Spec.SerialNumber
+	vid := drive.Spec.VID
+	pid := drive.Spec.PID
 	for _, l := range lsblkOut {
-		if strings.EqualFold(l.Serial, sn) {
+		if strings.EqualFold(l.Serial, sn) && strings.EqualFold(l.Vendor, vid) &&
+			strings.EqualFold(l.Model, pid) {
 			device = l.Name
 			break
 		}
 	}
 
 	if device == "" {
-		return "", fmt.Errorf("unable to find drive path by S/N %s", sn)
+		errMsg := fmt.Errorf("unable to find drive path by SN %s, VID %s, PID %s", sn, vid, pid)
+		return "", errMsg
 	}
 
 	return device, nil

--- a/pkg/base/linuxutils/lsblk/lsblk_test.go
+++ b/pkg/base/linuxutils/lsblk/lsblk_test.go
@@ -126,4 +126,13 @@ func TestLSBLK_SearchDrivePath(t *testing.T) {
 	assert.Equal(t, "", res)
 	assert.NotNil(t, err)
 
+	//different VID and PID
+	e.On("RunCmd", allDevicesCmd).Return(mocks.LsblkTwoDevicesStr, "", nil)
+	sn = "hdd1" // from mocks.LsblkTwoDevicesStr
+	dCR.Spec.SerialNumber = sn
+	dCR.Spec.VID = "vendor"
+	dCR.Spec.PID = "pid"
+
+	res, err = l.SearchDrivePath(&dCR)
+	assert.NotNil(t, err)
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -487,7 +487,7 @@ func (m *VolumeManager) updateDrivesCRs(ctx context.Context, drivesFromMgr []*ap
 				break
 			}
 		}
-		if !exist {
+		if !exist && drivePtr.SerialNumber != "" {
 			// Drive CR is not exist, try to create it
 			toCreateSpec := *drivePtr
 			toCreateSpec.NodeId = m.nodeID

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -814,6 +814,20 @@ func TestVolumeManager_updatesDrivesCRs_Success(t *testing.T) {
 	assert.Equal(t, len(driveCRs), 3)
 	assert.Len(t, updates.Created, 1)
 	assert.Len(t, updates.NotChanged, 2)
+
+	driveMgrRespDrives = append(driveMgrRespDrives, &api.Drive{
+		UUID:         uuid.New().String(),
+		SerialNumber: "",
+		Health:       apiV1.HealthGood,
+		Type:         apiV1.DriveTypeHDD,
+		Size:         1024 * 1024 * 1024 * 150,
+		NodeId:       nodeID,
+	})
+	updates, err = vm.updateDrivesCRs(testCtx, driveMgrRespDrives)
+	assert.Nil(t, err)
+	driveCRs, err = vm.crHelper.GetDriveCRs(vm.nodeID)
+	assert.Nil(t, err)
+	assert.Equal(t, len(driveCRs), 3)
 }
 
 func TestVolumeManager_updatesDrivesCRs_Fail(t *testing.T) {


### PR DESCRIPTION
## Purpose
* Add Vendor and PID check in `SearchDrivePath`
* Skip drive if SN is missed in `updateDrivesCRs`
Solves https://github.com/dell/csi-baremetal/issues/82

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
- [x] PR validation is passed
- [x] Custom CI is passed

## Testing
_Link to custom CI build_
