### PR TITLE
[ISSUE-96] Remove locks from kubeclient

### DIFF
--- a/api/v1/acreservationcrd/availablecapacityreservation_types.go
+++ b/api/v1/acreservationcrd/availablecapacityreservation_types.go
@@ -49,5 +49,5 @@ func (in *AvailableCapacityReservation) DeepCopyInto(out *AvailableCapacityReser
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec = out.Spec
+	out.Spec = in.Spec
 }

--- a/api/v1/availablecapacitycrd/availablecapacity_types.go
+++ b/api/v1/availablecapacitycrd/availablecapacity_types.go
@@ -49,5 +49,5 @@ func (in *AvailableCapacity) DeepCopyInto(out *AvailableCapacity) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec = out.Spec
+	out.Spec = in.Spec
 }

--- a/api/v1/csibmnodecrd/csibmnode_types.go
+++ b/api/v1/csibmnodecrd/csibmnode_types.go
@@ -49,5 +49,5 @@ func (in *CSIBMNode) DeepCopyInto(out *CSIBMNode) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec = out.Spec
+	out.Spec = in.Spec
 }

--- a/api/v1/drivecrd/drive_types.go
+++ b/api/v1/drivecrd/drive_types.go
@@ -51,7 +51,7 @@ func (in *Drive) DeepCopyInto(out *Drive) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec = out.Spec
+	out.Spec = in.Spec
 }
 
 func init() {

--- a/api/v1/lvgcrd/lvg_types.go
+++ b/api/v1/lvgcrd/lvg_types.go
@@ -50,5 +50,5 @@ func (in *LVG) DeepCopyInto(out *LVG) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec = out.Spec
+	out.Spec = in.Spec
 }

--- a/api/v1/volumecrd/volume_types.go
+++ b/api/v1/volumecrd/volume_types.go
@@ -47,7 +47,7 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec = out.Spec
+	out.Spec = in.Spec
 }
 
 func init() {

--- a/pkg/base/k8s/kubeclient.go
+++ b/pkg/base/k8s/kubeclient.go
@@ -19,7 +19,6 @@ package k8s
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -62,8 +61,6 @@ type KubeClient struct {
 	k8sCl.Client
 	log       *logrus.Entry
 	Namespace string
-	//mutex for crd request
-	sync.Mutex
 }
 
 // NewKubeClient is the constructor for KubeClient struct
@@ -81,9 +78,6 @@ func NewKubeClient(k8sclient k8sCl.Client, logger *logrus.Logger, namespace stri
 // Receives golang context, name of the created object, and object that implements k8s runtime.Object interface
 // Returns error if something went wrong
 func (k *KubeClient) CreateCR(ctx context.Context, name string, obj runtime.Object) error {
-	k.Lock()
-	defer k.Unlock()
-
 	requestUUID := ctx.Value(RequestUUID)
 	if requestUUID == nil {
 		requestUUID = DefaultVolumeID
@@ -111,9 +105,6 @@ func (k *KubeClient) CreateCR(ctx context.Context, name string, obj runtime.Obje
 // Receives golang context, name of the read object, and object pointer where to read
 // Returns error if something went wrong
 func (k *KubeClient) ReadCR(ctx context.Context, name string, obj runtime.Object) error {
-	k.Lock()
-	defer k.Unlock()
-
 	return k.Get(ctx, k8sCl.ObjectKey{Name: name, Namespace: k.Namespace}, obj)
 }
 
@@ -121,9 +112,6 @@ func (k *KubeClient) ReadCR(ctx context.Context, name string, obj runtime.Object
 // Receives golang context, and List object pointer where to read
 // Returns error if something went wrong
 func (k *KubeClient) ReadList(ctx context.Context, obj runtime.Object) error {
-	k.Lock()
-	defer k.Unlock()
-
 	return k.List(ctx, obj, k8sCl.InNamespace(k.Namespace))
 }
 
@@ -131,9 +119,6 @@ func (k *KubeClient) ReadList(ctx context.Context, obj runtime.Object) error {
 // Receives golang context and updated object that implements k8s runtime.Object interface
 // Returns error if something went wrong
 func (k *KubeClient) UpdateCR(ctx context.Context, obj runtime.Object) error {
-	k.Lock()
-	defer k.Unlock()
-
 	requestUUID := ctx.Value(RequestUUID)
 	if requestUUID == nil {
 		requestUUID = DefaultVolumeID
@@ -151,9 +136,6 @@ func (k *KubeClient) UpdateCR(ctx context.Context, obj runtime.Object) error {
 // Receives golang context and removable object that implements k8s runtime.Object interface
 // Returns error if something went wrong
 func (k *KubeClient) DeleteCR(ctx context.Context, obj runtime.Object) error {
-	k.Lock()
-	defer k.Unlock()
-
 	requestUUID := ctx.Value(RequestUUID)
 	if requestUUID == nil {
 		requestUUID = DefaultVolumeID

--- a/pkg/base/k8s/kubeclient_test.go
+++ b/pkg/base/k8s/kubeclient_test.go
@@ -294,6 +294,17 @@ var _ = Describe("Working with CRD", func() {
 			Expect(rdrive.ObjectMeta.Name).To(Equal(testUUID))
 		})
 
+		It("Create CR should be idempotent", func() {
+			err := k8sclient.CreateCR(testCtx, testACName, &testACCR)
+			Expect(err).To(BeNil())
+			err = k8sclient.CreateCR(testCtx, testACName, &testACCR)
+			Expect(err).To(BeNil())
+			rAC := &accrd.AvailableCapacity{}
+			err = k8sclient.ReadCR(testCtx, testACName, rAC)
+			Expect(err).To(BeNil())
+			Expect(rAC.ObjectMeta.Name).To(Equal(testACName))
+		})
+
 		It("Should read volumes CR List", func() {
 			err := k8sclient.CreateCR(context.Background(), testACName, &testVolume)
 			Expect(err).To(BeNil())

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -851,7 +851,7 @@ func TestVolumeManager_updatesDrivesCRs_Fail(t *testing.T) {
 
 	// CreateCR failed
 	mockK8sClient.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
-	mockK8sClient.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(testErr).Twice() // CreateCR will failed
+	mockK8sClient.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(testErr).Twice() // CreateCR will failed
 
 	d1 := drive1
 	res, err = vm.updateDrivesCRs(testCtx, []*api.Drive{&d1})


### PR DESCRIPTION
## Purpose
This PR provide multiple changes:
1. Remove mutex from Kubeclient. We don't need it anymore. This change should improve driver performance
2. Refactoring Kubeclient.CreateCR(). Additional read call was removed.
3. Fix error in DeepCopyInto implementation for CRDs. This problem became visible after mutex from Kubeclient was removed.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
- [ ] PR validation is passed
- [ ] Custom CI is passed

## Testing
_Link to custom CI build_
