### PR TITLE
[Issue-147] lvremove might failed on big scale

### DIFF
--- a/pkg/base/command/cmdexec.go
+++ b/pkg/base/command/cmdexec.go
@@ -63,15 +63,13 @@ func (e *Executor) RunCmdWithAttempts(cmd interface{}, attempts int, timeout tim
 		stdout string
 		stderr string
 		err    error
-		ticker = time.NewTicker(timeout)
 	)
-	defer ticker.Stop()
 	for i := 0; i < attempts; i++ {
 		if stdout, stderr, err := e.RunCmd(cmd); err == nil {
 			return stdout, stderr, err
 		}
 		ll.Warnf("Unable to execute cmd: %v. Attempt %d out of %d.", err, i, attempts)
-		<-ticker.C
+		<-time.After(timeout)
 	}
 	errMsg := fmt.Errorf("failed to execute command after %d attempt, error: %v", attempts, err)
 	return stdout, stderr, errMsg

--- a/pkg/base/command/cmdexec.go
+++ b/pkg/base/command/cmdexec.go
@@ -31,6 +31,7 @@ type CmdExecutor interface {
 	RunCmd(cmd interface{}) (string, string, error)
 	SetLogger(logger *logrus.Logger)
 	SetLevel(level logrus.Level)
+	RunCmdWithAttempts(cmd interface{}, attempts int) (string, string, error)
 }
 
 // Executor is the implementation of CmdExecutor based on os/exec package
@@ -49,6 +50,31 @@ func (e *Executor) SetLogger(logger *logrus.Logger) {
 // Receives logrus Level
 func (e *Executor) SetLevel(level logrus.Level) {
 	e.msgLevel = level
+}
+
+// RunCmdWithAttempts runs specified command on OS with given attempts
+// Receives command as empty interface, It could be string or instance of exec.Cmd; number of attempts.
+// Returns stdout as string, stderr as string and golang error if something went wrong
+func (e *Executor) RunCmdWithAttempts(cmd interface{}, attempts int) (string, string, error) {
+	ll := e.log.WithFields(logrus.Fields{
+		"method": "RunCmdWithAttempts",
+	})
+	var (
+		stdout string
+		stderr string
+		err    error
+		ticker = time.NewTicker(500 * time.Millisecond)
+	)
+	defer ticker.Stop()
+	for i := 0; i < attempts; i++ {
+		if stdout, stderr, err := e.RunCmd(cmd); err == nil {
+			return stdout, stderr, err
+		}
+		ll.Warnf("Unable to execute cmd: %v. Attempt %d out of %d.", err, i, attempts)
+		<-ticker.C
+	}
+	errMsg := fmt.Errorf("failed to execute command after %d attempt, error: %v", attempts, err)
+	return stdout, stderr, errMsg
 }
 
 // RunCmd runs specified command on OS

--- a/pkg/base/command/cmdexec.go
+++ b/pkg/base/command/cmdexec.go
@@ -31,7 +31,7 @@ type CmdExecutor interface {
 	RunCmd(cmd interface{}) (string, string, error)
 	SetLogger(logger *logrus.Logger)
 	SetLevel(level logrus.Level)
-	RunCmdWithAttempts(cmd interface{}, attempts int) (string, string, error)
+	RunCmdWithAttempts(cmd interface{}, attempts int, timeout time.Duration) (string, string, error)
 }
 
 // Executor is the implementation of CmdExecutor based on os/exec package
@@ -52,10 +52,10 @@ func (e *Executor) SetLevel(level logrus.Level) {
 	e.msgLevel = level
 }
 
-// RunCmdWithAttempts runs specified command on OS with given attempts
-// Receives command as empty interface, It could be string or instance of exec.Cmd; number of attempts.
+// RunCmdWithAttempts runs specified command on OS with given attempts and timeout between attempts
+// Receives command as empty interface, It could be string or instance of exec.Cmd; number of attempts; timeout.
 // Returns stdout as string, stderr as string and golang error if something went wrong
-func (e *Executor) RunCmdWithAttempts(cmd interface{}, attempts int) (string, string, error) {
+func (e *Executor) RunCmdWithAttempts(cmd interface{}, attempts int, timeout time.Duration) (string, string, error) {
 	ll := e.log.WithFields(logrus.Fields{
 		"method": "RunCmdWithAttempts",
 	})
@@ -63,7 +63,7 @@ func (e *Executor) RunCmdWithAttempts(cmd interface{}, attempts int) (string, st
 		stdout string
 		stderr string
 		err    error
-		ticker = time.NewTicker(500 * time.Millisecond)
+		ticker = time.NewTicker(timeout)
 	)
 	defer ticker.Stop()
 	for i := 0; i < attempts; i++ {

--- a/pkg/base/linuxutils/lvm/lvm.go
+++ b/pkg/base/linuxutils/lvm/lvm.go
@@ -148,7 +148,7 @@ func (l *LVM) LVCreate(name, size, vgName string) error {
 // Returns error if something went wrong
 func (l *LVM) LVRemove(fullLVName string) error {
 	cmd := fmt.Sprintf(LVRemoveCmdTmpl, fullLVName)
-	_, stdErr, err := l.e.RunCmd(cmd)
+	_, stdErr, err := l.e.RunCmdWithAttempts(cmd, 5)
 	if err != nil && strings.Contains(stdErr, "Failed to find logical volume") {
 		return nil
 	}

--- a/pkg/base/linuxutils/lvm/lvm.go
+++ b/pkg/base/linuxutils/lvm/lvm.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -54,6 +55,8 @@ const (
 	LVRemoveCmdTmpl = lvmPath + "lvremove --yes %s" // add full LV name
 	// LVsInVGCmdTmpl print LVs in VG cmd
 	LVsInVGCmdTmpl = lvmPath + "lvs --select vg_name=%s -o lv_name --noheadings" // add VG name
+	// timeoutBetweenAttempts used for RunCmdWithAttempts as a timeout between calling lvremove
+	timeoutBetweenAttempts = 500 * time.Millisecond
 )
 
 // WrapLVM is an interface that encapsulates operation with system logical volume manager (/sbin/lvm)
@@ -148,7 +151,7 @@ func (l *LVM) LVCreate(name, size, vgName string) error {
 // Returns error if something went wrong
 func (l *LVM) LVRemove(fullLVName string) error {
 	cmd := fmt.Sprintf(LVRemoveCmdTmpl, fullLVName)
-	_, stdErr, err := l.e.RunCmdWithAttempts(cmd, 5)
+	_, stdErr, err := l.e.RunCmdWithAttempts(cmd, 5, timeoutBetweenAttempts)
 	if err != nil && strings.Contains(stdErr, "Failed to find logical volume") {
 		return nil
 	}

--- a/pkg/base/linuxutils/lvm/lvm_test.go
+++ b/pkg/base/linuxutils/lvm/lvm_test.go
@@ -156,15 +156,14 @@ func TestLinuxUtils_LVRemove(t *testing.T) {
 		expectedErr = errors.New("error")
 	)
 
-	e.OnCommand(cmd).Return("", "", nil).Times(1)
+	e.OnCommandWithAttempts(cmd, 5).Return("", "", nil).Times(1)
+	err = l.LVRemove(fullLVName)
+	assert.Nil(t, err)
+	e.OnCommandWithAttempts(cmd, 5).Return("", "Failed to find logical volume", expectedErr).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Nil(t, err)
 
-	e.OnCommand(cmd).Return("", "Failed to find logical volume", expectedErr).Times(1)
-	err = l.LVRemove(fullLVName)
-	assert.Nil(t, err)
-
-	e.OnCommand(cmd).Return("", "", expectedErr).Times(1)
+	e.OnCommandWithAttempts(cmd, 5).Return("", "", expectedErr).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Equal(t, expectedErr, err)
 }

--- a/pkg/base/linuxutils/lvm/lvm_test.go
+++ b/pkg/base/linuxutils/lvm/lvm_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -156,14 +157,14 @@ func TestLinuxUtils_LVRemove(t *testing.T) {
 		expectedErr = errors.New("error")
 	)
 
-	e.OnCommandWithAttempts(cmd, 5).Return("", "", nil).Times(1)
+	e.OnCommandWithAttempts(cmd, 5, 500*time.Millisecond).Return("", "", nil).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Nil(t, err)
-	e.OnCommandWithAttempts(cmd, 5).Return("", "Failed to find logical volume", expectedErr).Times(1)
+	e.OnCommandWithAttempts(cmd, 5, 500*time.Millisecond).Return("", "Failed to find logical volume", expectedErr).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Nil(t, err)
 
-	e.OnCommandWithAttempts(cmd, 5).Return("", "", expectedErr).Times(1)
+	e.OnCommandWithAttempts(cmd, 5, 500*time.Millisecond).Return("", "", expectedErr).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Equal(t, expectedErr, err)
 }

--- a/pkg/base/linuxutils/lvm/lvm_test.go
+++ b/pkg/base/linuxutils/lvm/lvm_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -157,14 +156,14 @@ func TestLinuxUtils_LVRemove(t *testing.T) {
 		expectedErr = errors.New("error")
 	)
 
-	e.OnCommandWithAttempts(cmd, 5, 500*time.Millisecond).Return("", "", nil).Times(1)
+	e.OnCommandWithAttempts(cmd, 5, timeoutBetweenAttempts).Return("", "", nil).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Nil(t, err)
-	e.OnCommandWithAttempts(cmd, 5, 500*time.Millisecond).Return("", "Failed to find logical volume", expectedErr).Times(1)
+	e.OnCommandWithAttempts(cmd, 5, timeoutBetweenAttempts).Return("", "Failed to find logical volume", expectedErr).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Nil(t, err)
 
-	e.OnCommandWithAttempts(cmd, 5, 500*time.Millisecond).Return("", "", expectedErr).Times(1)
+	e.OnCommandWithAttempts(cmd, 5, timeoutBetweenAttempts).Return("", "", expectedErr).Times(1)
 	err = l.LVRemove(fullLVName)
 	assert.Equal(t, expectedErr, err)
 }

--- a/pkg/mocks/executors.go
+++ b/pkg/mocks/executors.go
@@ -19,6 +19,7 @@ package mocks
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
@@ -53,9 +54,9 @@ func (e EmptyExecutorSuccess) RunCmd(interface{}) (string, string, error) {
 	return "", "", nil
 }
 
-// RunCmdWithAttempts simulates successful execution of a command with attempts
+// RunCmdWithAttempts simulates successful execution of a command with attempts and given timeout between attempts
 // Returns "" as stdout, "" as stderr and nil as error
-func (e EmptyExecutorSuccess) RunCmdWithAttempts(interface{}, int) (string, string, error) {
+func (e EmptyExecutorSuccess) RunCmdWithAttempts(interface{}, int, time.Duration) (string, string, error) {
 	return "", "", nil
 }
 
@@ -70,9 +71,9 @@ func (e EmptyExecutorFail) RunCmd(interface{}) (string, string, error) {
 	return "error happened", "error", errors.New("error")
 }
 
-// RunCmdWithAttempts simulates failed execution of a command with attempts
+// RunCmdWithAttempts simulates failed execution of a command with attempts and given timeout between attempts
 // Returns "error happened" as stdout, "error" as stderr and errors.New("error") as error
-func (e EmptyExecutorFail) RunCmdWithAttempts(interface{}, int) (string, string, error) {
+func (e EmptyExecutorFail) RunCmdWithAttempts(interface{}, int, time.Duration) (string, string, error) {
 	return "error happened", "error", errors.New("error")
 }
 
@@ -160,9 +161,9 @@ func (e *MockExecutor) RunCmd(cmd interface{}) (string, string, error) {
 }
 
 // RunCmdWithAttempts simulates execution of a command. Execute RunCmd.
-// Receives cmd as interface and number of attempts
+// Receives cmd as interface, number of attempts, timeout
 // Returns stdout, stderr, error for a given command
-func (e *MockExecutor) RunCmdWithAttempts(cmd interface{}, attempt int) (string, string, error) {
+func (e *MockExecutor) RunCmdWithAttempts(cmd interface{}, attempts int, timeout time.Duration) (string, string, error) {
 	return e.RunCmd(cmd)
 }
 
@@ -178,9 +179,9 @@ type GoMockExecutor struct {
 	LoggerSetter
 }
 
-// RunCmdWithAttempts simulates execution of a command with OnCommand where user can set what the method should return
-func (g *GoMockExecutor) RunCmdWithAttempts(cmd interface{}, attempt int) (string, string, error) {
-	args := g.Mock.Called(cmd.(string), attempt)
+// RunCmdWithAttempts simulates execution of a command with OnCommandWithAttempts where user can set what the method should return
+func (g *GoMockExecutor) RunCmdWithAttempts(cmd interface{}, attempts int, timeout time.Duration) (string, string, error) {
+	args := g.Mock.Called(cmd.(string), attempts, timeout)
 	return args.String(0), args.String(1), args.Error(2)
 }
 
@@ -198,8 +199,8 @@ func (g *GoMockExecutor) OnCommand(cmd string) *mock.Call {
 }
 
 // OnCommandWithAttempts is the method of mock.Mock where user can set what to return on specified command
-// For example e.OnCommandWithAttempts("/sbin/lvm pvcreate --yes /dev/sda", 5).Return("", "", errors.New("pvcreate failed"))
+// For example e.OnCommandWithAttempts("/sbin/lvm pvcreate --yes /dev/sda", 5, time.Second).Return("", "", errors.New("pvcreate failed"))
 // Returns mock.Call where need to set what to return with Return() method
-func (g *GoMockExecutor) OnCommandWithAttempts(cmd string, attempts int) *mock.Call {
-	return g.On(RunCmdWithAttempts, cmd, attempts)
+func (g *GoMockExecutor) OnCommandWithAttempts(cmd string, attempts int, timeout time.Duration) *mock.Call {
+	return g.On(RunCmdWithAttempts, cmd, attempts, timeout)
 }

--- a/pkg/mocks/executors.go
+++ b/pkg/mocks/executors.go
@@ -53,6 +53,12 @@ func (e EmptyExecutorSuccess) RunCmd(interface{}) (string, string, error) {
 	return "", "", nil
 }
 
+// RunCmdWithAttempts simulates successful execution of a command with attempts
+// Returns "" as stdout, "" as stderr and nil as error
+func (e EmptyExecutorSuccess) RunCmdWithAttempts(interface{}, int) (string, string, error) {
+	return "", "", nil
+}
+
 // EmptyExecutorFail implements CmdExecutor interface for test purposes, each command will finish with error
 type EmptyExecutorFail struct {
 	LoggerSetter
@@ -61,6 +67,12 @@ type EmptyExecutorFail struct {
 // RunCmd simulates failed execution of a command
 // Returns "error happened" as stdout, "error" as stderr and errors.New("error") as error
 func (e EmptyExecutorFail) RunCmd(interface{}) (string, string, error) {
+	return "error happened", "error", errors.New("error")
+}
+
+// RunCmdWithAttempts simulates failed execution of a command with attempts
+// Returns "error happened" as stdout, "error" as stderr and errors.New("error") as error
+func (e EmptyExecutorFail) RunCmdWithAttempts(interface{}, int) (string, string, error) {
 	return "error happened", "error", errors.New("error")
 }
 
@@ -147,13 +159,29 @@ func (e *MockExecutor) RunCmd(cmd interface{}) (string, string, error) {
 	return res.Stdout, res.Stderr, res.Err
 }
 
+// RunCmdWithAttempts simulates execution of a command. Execute RunCmd.
+// Receives cmd as interface and number of attempts
+// Returns stdout, stderr, error for a given command
+func (e *MockExecutor) RunCmdWithAttempts(cmd interface{}, attempt int) (string, string, error) {
+	return e.RunCmd(cmd)
+}
+
 // RunCmd is the name of CmdExecutor method name
-var RunCmd = "RunCmd"
+var (
+	RunCmd             = "RunCmd"
+	RunCmdWithAttempts = "RunCmdWithAttempts"
+)
 
 // GoMockExecutor implements CmdExecutor based on stretchr/testify/mock
 type GoMockExecutor struct {
 	mock.Mock
 	LoggerSetter
+}
+
+// RunCmdWithAttempts simulates execution of a command with OnCommand where user can set what the method should return
+func (g *GoMockExecutor) RunCmdWithAttempts(cmd interface{}, attempt int) (string, string, error) {
+	args := g.Mock.Called(cmd.(string), attempt)
+	return args.String(0), args.String(1), args.Error(2)
 }
 
 // RunCmd simulates execution of a command with OnCommand where user can set what the method should return
@@ -167,4 +195,11 @@ func (g *GoMockExecutor) RunCmd(cmd interface{}) (string, string, error) {
 // Returns mock.Call where need to set what to return with Return() method
 func (g *GoMockExecutor) OnCommand(cmd string) *mock.Call {
 	return g.On(RunCmd, cmd)
+}
+
+// OnCommandWithAttempts is the method of mock.Mock where user can set what to return on specified command
+// For example e.OnCommandWithAttempts("/sbin/lvm pvcreate --yes /dev/sda", 5).Return("", "", errors.New("pvcreate failed"))
+// Returns mock.Call where need to set what to return with Return() method
+func (g *GoMockExecutor) OnCommandWithAttempts(cmd string, attempts int) *mock.Call {
+	return g.On(RunCmdWithAttempts, cmd, attempts)
 }


### PR DESCRIPTION
Add `RunCmdWithAttempts` function, so we can run `lvremove` with retries

## Purpose
Solves https://github.com/dell/csi-baremetal/issues/147

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [x] All comments are resolved
- [x] PR validation is passed
- [x] Custom CI is passed

## Testing
_Link to custom CI build_
