### PR TITLE
Fix CI after golang update

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -16,12 +16,12 @@ coverage:
 	go tool cover -html=coverage.out -o coverage.html
 
 test:
-	${GO_ENV_VARS} go test `go list ./... | grep -v halmgr` -race -cover ./... -coverprofile=coverage.out
+	${GO_ENV_VARS} go test `go list ./... | grep -v halmgr` -race -cover -coverprofile=coverage.out
 
 # Run tests for pr-validation with writing output to log file
 # Test are different (ginkgo, go testing, etc.) so can't use native ginkgo methods to print junit output.
 test-pr-validation:
-	${GO_ENV_VARS} go test `go list ./... | grep -v halmgr` -v -race -cover ./... -coverprofile=coverage.out > log.txt
+	${GO_ENV_VARS} go test `go list ./... | grep -v halmgr` -v -race -cover -coverprofile=coverage.out > log.txt
 
 install-junit-report:
 	${GO_ENV_VARS} go get -u github.com/jstemmer/go-junit-report


### PR DESCRIPTION
## Purpose
After updating golang version up to 1.15, golang don't make a coverprofile with ./... argument in the end. Just remove it.


## PR checklist
- [ ] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
- [ ] PR validation is passed
- [ ] Custom CI is passed

## Testing
_Link to custom CI build_
