### PR TITLE
[ISSUE-150] Fix UT on cloud CI

### DIFF
--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -928,7 +928,7 @@ func Test_discoverLVGOnSystemDrive_LVGAlreadyExists(t *testing.T) {
 	lvmOps  = &mocklu.MockWrapLVM{}
 	lvmOps.On("GetVgFreeSpace", "some-name").Return(int64(2*1024*1024), nil)
 	m.lvmOps = lvmOps
-	
+
 	err = m.k8sClient.CreateCR(testCtx, lvgCR.Name, lvgCR)
 	assert.Nil(t, err)
 
@@ -944,7 +944,6 @@ func Test_discoverLVGOnSystemDrive_LVGAlreadyExists(t *testing.T) {
 	err = m.k8sClient.ReadList(testCtx, &acList)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(acList.Items))
-
 }
 
 func Test_discoverLVGOnSystemDrive_LVGCreatedACNo(t *testing.T) {


### PR DESCRIPTION
## Purpose
At the stage of trying to move CI validation, I'm noticed that test if failing.
After investigating, I've noticed that for some reason there is actual lsblk util is called instead of mock.

in the process of solving the problem I've found a few issues with the test:
- systemDrivesUUIDs was missing our LVG locations.
- increased size was not enough to create AC(min 1MB)
- mock was using the old value
- After the test AC count wasn't checked.

this PR fixes #150

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [x] All comments are resolved
- [x] PR validation is passed
- [x] Custom CI is passed

fixing #150 