### PR TITLE
[ISSUE-174] manually pull and load nginx image for e2e tests

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -67,7 +67,7 @@ kind-tag-images:
 	docker tag ${REGISTRY}/${CSI_ATTACHER}:${CSI_ATTACHER_TAG} ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	docker tag ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG} ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	docker tag ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG} ${BUSYBOX}:${BUSYBOX_TAG}
-        docker tag ${REGISTRY}/library/nginx:1.14-alpine docker.io/library/nginx:1.14-alpine
+	docker tag ${REGISTRY}/library/nginx:1.14-alpine docker.io/library/nginx:1.14-alpine
 	docker tag ${REGISTRY}/${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG} ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${NODE}:${TAG} ${PROJECT}-${NODE}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG} ${PROJECT}-${CONTROLLER}:${TAG}

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -52,6 +52,7 @@ kind-pull-images:
 	docker pull ${REGISTRY}/${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	docker pull ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	docker pull ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG}
+	docker pull ${REGISTRY}/library/nginx:1.14-alpine
 	docker pull ${REGISTRY}/${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${NODE}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG}
@@ -61,11 +62,12 @@ kind-pull-images:
 	docker pull ${REGISTRY}/${PROJECT}-${CSI_BM_NODE}:${TAG}
 
 kind-tag-images:
-	docker tag ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG} ${BUSYBOX}:${BUSYBOX_TAG}
 	docker tag ${REGISTRY}/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG} ${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
 	docker tag ${REGISTRY}/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG} ${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
 	docker tag ${REGISTRY}/${CSI_ATTACHER}:${CSI_ATTACHER_TAG} ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	docker tag ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG} ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
+	docker tag ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG} ${BUSYBOX}:${BUSYBOX_TAG}
+        docker tag ${REGISTRY}/library/nginx:1.14-alpine docker.io/library/nginx:1.14-alpine
 	docker tag ${REGISTRY}/${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG} ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${NODE}:${TAG} ${PROJECT}-${NODE}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG} ${PROJECT}-${CONTROLLER}:${TAG}
@@ -79,10 +81,11 @@ kind-load-images:
 	kind load docker-image ${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
 	kind load docker-image ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	kind load docker-image ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
+	kind load docker-image ${BUSYBOX}:${BUSYBOX_TAG}
+	kind load docker-image docker.io/library/nginx:1.14-alpine
 	kind load docker-image ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	kind load docker-image ${PROJECT}-${NODE}:${TAG}
 	kind load docker-image ${PROJECT}-${CONTROLLER}:${TAG}
-	kind load docker-image ${BUSYBOX}:${BUSYBOX_TAG}
 	kind load docker-image ${PROJECT}-${EXTENDER}:${TAG}
 	kind load docker-image ${PROJECT}-${EXTENDER_PATCHER}:${TAG}
 	kind load docker-image ${PROJECT}-${SCHEDULER}:${TAG}


### PR DESCRIPTION
## Purpose
Pull the image from the registry and load it to the nodes.

fixes #174
also closes #173 in the CI files.
## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
- [ ] PR validation is passed
- [ ] Custom CI is passed

## Testing
_Link to custom CI build_
