### PR TITLE
[ISSUE-186] Issue with drive removed=true was caused by resizing

### DIFF
--- a/pkg/drivemgr/loopbackmgr/loopbackmgr.go
+++ b/pkg/drivemgr/loopbackmgr/loopbackmgr.go
@@ -350,16 +350,10 @@ func (mgr *LoopBackManager) overrideDevicesFromNodeConfig(deviceCount int, devic
 					// If not then we may not rebind device and save existing devicePath
 					if mgrDevice.devicePath != "" {
 						switch {
-						// If size changed when we need to detach loop device and delete appropriate file
-						case device.Size != mgrDevice.Size && device.Size != "":
-							ll.Infof("Size of device changes from %s to %s", mgrDevice.Size, device.Size)
-							mgr.deleteLoopbackDevice(mgrDevice)
-						// If device Size is not specified and size of existing drive is not equal default size from config
-						case mgr.config != nil && device.Size == "" && mgr.config.DefaultDriveSize != "" &&
-							mgrDevice.Size != mgr.config.DefaultDriveSize:
-							ll.Infof("Size of device changes from %s to %s", mgrDevice.Size, mgr.config.DefaultDriveSize)
-							mgr.deleteLoopbackDevice(mgrDevice)
-							device.Size = mgr.config.DefaultDriveSize
+						// Drive expand is not supported
+						case device.Size != mgrDevice.Size || device.Size != "":
+							ll.Warningf("Size of device changed or not set. Resizing not supported.")
+							device.Size = mgrDevice.Size
 						default:
 							device.devicePath = mgrDevice.devicePath
 						}

--- a/pkg/drivemgr/loopbackmgr/loopbackmgr_test.go
+++ b/pkg/drivemgr/loopbackmgr/loopbackmgr_test.go
@@ -219,9 +219,10 @@ func TestLoopBackManager_overrideDevicesFromSetConfigWithSize(t *testing.T) {
 
 	assert.Nil(t, err)
 
+	// resizing is not supported
 	for _, device := range manager.devices {
 		if device.SerialNumber == testSN {
-			assert.Equal(t, device.Size, "30Mi")
+			assert.Equal(t, device.Size, "40Mi")
 		}
 	}
 
@@ -277,7 +278,8 @@ func TestLoopBackManager_overrideDeviceWithSizeChanging(t *testing.T) {
 	}
 
 	manager.overrideDevicesFromNodeConfig(defaultNumberOfDevices, devices)
-	assert.Equal(t, manager.devices[indexOfDeviceToOverride].Size, newSize)
+	// resizing is not supported
+	assert.Equal(t, defaultSize, manager.devices[indexOfDeviceToOverride].Size)
 }
 
 func TestLoopBackManager_GetDrivesList(t *testing.T) {


### PR DESCRIPTION
## Purpose
### [ISSUE-186](url) Loopback manager must simulate disk pull
For DR feature we need to simulate OFFLINE drive state. When size wasn't set in config-map loopback drive manager tried to resize drive by deleting backed device which is incorrect. Loopback manager was introduced to simulate behavior of JBOD disks, resizing is not supported for them.

```
ubuntu:/workspace/csi-baremetal$ drives
Id                                     Size        Type   SN                   Health   Status    Node
03c12aca-7d19-4d15-9f2d-fed4b97dd5ce   104857600   HDD    LOOPBACK2592861090   BAD      OFFLINE   2fd0ef69-d1a5-4faa-bf20-c8e4251de2de
a9b688ba-ed2d-47ce-ac31-3307a1dd5f31   104857600   HDD    LOOPBACK3917998044   GOOD     ONLINE    2fd0ef69-d1a5-4faa-bf20-c8e4251de2de
21db1e5e-c24f-4f7f-96b2-f76890f664b9   104857600   HDD    LOOPBACK3790095334   GOOD     ONLINE    2fd0ef69-d1a5-4faa-bf20-c8e4251de2de
```

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
- [x] PR validation is passed
- [x] Custom CI is passed

## Testing
_In progress_
