### PR TITLE
[ISSUE-161] isSystem is overwritten

### DIFF
--- a/api/v1/drivecrd/drive_types.go
+++ b/api/v1/drivecrd/drive_types.go
@@ -68,6 +68,5 @@ func (in *Drive) Equals(drive *api.Drive) bool {
 		in.Spec.Health == drive.Health &&
 		in.Spec.Type == drive.Type &&
 		in.Spec.Size == drive.Size &&
-		in.Spec.Path == drive.Path &&
-		in.Spec.Usage == drive.Usage
+		in.Spec.Path == drive.Path
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -517,6 +517,7 @@ func (m *VolumeManager) updateDrivesCRs(ctx context.Context, drivesFromMgr []*ap
 					// copy fields which aren't reported by drive manager
 					drivePtr.UUID = driveCR.Spec.UUID
 					drivePtr.Usage = driveCR.Spec.Usage
+					drivePtr.IsSystem = driveCR.Spec.IsSystem
 
 					toUpdate := driveCR
 					toUpdate.Spec = *drivePtr


### PR DESCRIPTION
## Purpose
### [ISSUE-161](https://github.com/dell/csi-baremetal/issues/161) isSystem is overwritten due to incorrect equal method
Regression.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved
- [ ] PR validation is passed
- [ ] Custom CI is passed

## Testing
Manual testing:
```
borism1@ubuntu:/workspace/csi-baremetal$ drives | egrep 'Id|true'
Id                                     Size            Type   SN             Health   Usage    Status   System   Node
0b037d66-7418-4381-8c0d-14332670e95f   515396075520    SSD    191020FED923   GOOD     IN_USE   ONLINE   true     3a66ef80-26c6-4e3a-ba62-09dacd7c90b6
5a85a1a4-0ed3-417c-a99a-1b84d08e9db7   515396075520    SSD    191020FEB2E2   GOOD     IN_USE   ONLINE   true     04e4a4d3-c50e-494d-bb2f-63f172b13455
dcb0a24f-5807-46f3-8e6d-f6606ddec478   515396075520    SSD    191020FEB2D7   GOOD     IN_USE   ONLINE   true     70489f05-47e3-4b67-b324-93e4fd9d419a
borism1@ubuntu:/workspace/csi-baremetal$ lvgs
Id                                     Size           Status    Volumes                     Locations                                Node
f4d1c68d-bc2e-4fb5-8ee1-70ec964bbda1   324966285312   CREATED   [lv_root lv_swap lv_var ]   [0b037d66-7418-4381-8c0d-14332670e95f]   3a66ef80-26c6-4e3a-ba62-09dacd7c90b6
debd839e-1127-4fa6-8d22-4c7908b7a38e   324966285312   CREATED   [lv_root lv_swap lv_var ]   [5a85a1a4-0ed3-417c-a99a-1b84d08e9db7]   04e4a4d3-c50e-494d-bb2f-63f172b13455
8014c8c3-aa85-4bd4-8c34-f454108ff16c   324966285312   CREATED   [lv_root lv_swap lv_var ]   [dcb0a24f-5807-46f3-8e6d-f6606ddec478]   70489f05-47e3-4b67-b324-93e4fd9d419a
```

