### PR TITLE
[ISSUE-205] Handle DeleteVolume request(s) failure

### DIFF
--- a/api/v1/drivecrd/drive_types.go
+++ b/api/v1/drivecrd/drive_types.go
@@ -74,7 +74,7 @@ func (in *Drive) Equals(drive *api.Drive) bool {
 }
 
 func (in *Drive) GetDriveDescription() string {
-	return fmt.Sprintf(" Drive Details: SN='%s', Node='%s',"+
+	return fmt.Sprintf("Drive Details: SN='%s', Node='%s',"+
 		" Type='%s', Model='%s %s',"+
 		" Size='%d', Firmware='%s'",
 		in.Spec.SerialNumber, in.Spec.NodeId, in.Spec.Type,

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -57,6 +57,8 @@ import (
 
 const volumeFinalizer = "dell.emc.csi/volume-cleanup"
 
+const deleteVolumeFailedMsg = "Failed to remove volume %s with error: %s"
+
 // eventRecorder interface for sending events
 type eventRecorder interface {
 	Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{})
@@ -414,6 +416,16 @@ func (m *VolumeManager) handleRemovingStatus(ctx context.Context, volume *volume
 	if err = m.getProvisionerForVolume(&volume.Spec).ReleaseVolume(volume.Spec); err != nil {
 		ll.Errorf("Failed to remove volume - %s. Error: %v. Set status to Failed", volume.Spec.Id, err)
 		newStatus = apiV1.Failed
+		drive := m.crHelper.GetDriveCRByUUID(volume.Spec.Location)
+		if drive != nil {
+			drive.Spec.Usage = apiV1.DriveUsageFailed
+			if err := m.k8sClient.UpdateCRWithAttempts(ctx, drive, 5); err != nil {
+				ll.Errorf("Unable to change drive %s usage status to %s, error: %v.",
+					drive.Name, drive.Spec.Usage, err)
+				return ctrl.Result{Requeue: true}, err
+			}
+			m.sendEventForDrive(drive, eventing.ErrorType, eventing.DriveReplacementFailed, deleteVolumeFailedMsg, volume.Name, err)
+		}
 	} else {
 		ll.Infof("Volume - %s was successfully removed. Set status to Removed", volume.Spec.Id)
 		newStatus = apiV1.Removed


### PR DESCRIPTION
## Purpose
closes #205 
For a drive replacement, we need to handle the situation when can't remove volume for some reason.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved
- [ ] PR validation is passed
- [ ] Custom CI is passed