### PR TITLE
[ISSUE-106] Skip allocation for LVG in FAILED state by resetting AC size

### DIFF
--- a/pkg/base/error/types.go
+++ b/pkg/base/error/types.go
@@ -1,0 +1,6 @@
+package error
+
+import "errors"
+
+// ErrorNotFound indicates that requested object wasn't found
+var ErrorNotFound = errors.New("not found")

--- a/pkg/base/k8s/cr_helper_test.go
+++ b/pkg/base/k8s/cr_helper_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/dell/csi-baremetal/api/v1"
 	accrd "github.com/dell/csi-baremetal/api/v1/availablecapacitycrd"
 	"github.com/dell/csi-baremetal/api/v1/volumecrd"
+	errTypes "github.com/dell/csi-baremetal/pkg/base/error"
 )
 
 func setup() *CRHelper {
@@ -41,12 +42,13 @@ func TestCRHelper_GetACByLocation(t *testing.T) {
 	err := ch.k8sClient.CreateCR(testCtx, expectedAC.Name, &expectedAC)
 	assert.Nil(t, err)
 
-	currentAC := ch.GetACByLocation(testACCR.Spec.Location)
-	assert.NotNil(t, currentAC)
+	currentAC, err := ch.GetACByLocation(testACCR.Spec.Location)
+	assert.Nil(t, err)
 	assert.Equal(t, expectedAC.Spec, currentAC.Spec)
 
 	// expected nil because of empty string as a location
-	assert.Nil(t, ch.GetACByLocation(""))
+	currentAC, err = ch.GetACByLocation("")
+	assert.Equal(t, err, errTypes.ErrorNotFound)
 }
 
 func TestCRHelper_GetVolumeByLocation(t *testing.T) {

--- a/pkg/crcontrollers/lvg/lvgcontroller.go
+++ b/pkg/crcontrollers/lvg/lvgcontroller.go
@@ -46,6 +46,7 @@ const lvgFinalizer = "dell.emc.csi/lvg-cleanup"
 // Controller is the LVG custom resource Controller for serving VG operations on Node side in Reconcile loop
 type Controller struct {
 	k8sClient *k8s.KubeClient
+	crHelper  *k8s.CRHelper
 
 	listBlk lsblk.WrapLsblk
 	lvmOps  lvm.WrapLVM
@@ -63,6 +64,7 @@ func NewController(k8sClient *k8s.KubeClient, nodeID string, log *logrus.Logger)
 	e.SetLogger(log)
 	return &Controller{
 		k8sClient: k8sClient,
+		crHelper:  k8s.NewCRHelper(k8sClient, log),
 		node:      nodeID,
 		log:       log.WithField("component", "Controller"),
 		e:         e,
@@ -95,17 +97,23 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return c.handleLVGRemoving(lvg)
 	case !util.ContainsString(lvg.ObjectMeta.Finalizers, lvgFinalizer):
 		return c.appendFinalizer(lvg)
-	case lvg.Spec.Status == apiV1.Creating:
-		ll.Info("Creating LVG")
-		return c.handlerLVGCreation(lvg)
 	// if lvg.Spec.VolumeRefs == 0 it means that LVG just being created
 	// for lvg on non-system drive finalizer should be removed during handleLVGRemoving stage
 	// here controller removes finalizer for lvg on system drive, for that lvg VolumeRefs != 0
 	case !util.HasNameWithPrefix(lvg.Spec.VolumeRefs) && len(lvg.Spec.VolumeRefs) != 0:
 		return c.removeFinalizer(lvg)
-	default:
-		return ctrl.Result{}, nil
 	}
+
+	// check for LVG state
+	switch lvg.Spec.Status {
+	case apiV1.Creating:
+		ll.Info("Creating LVG")
+		return c.handlerLVGCreation(lvg)
+	case apiV1.Failed:
+		c.resetACSizeOfLVG(lvg.Name)
+	}
+
+	return ctrl.Result{}, nil
 }
 
 // appendFinalizer appends finalizer to the LVG CR (update CR)
@@ -323,4 +331,21 @@ func (c *Controller) increaseACSize(driveID string, size int64) {
 	}
 
 	ll.Errorf("Corresponding AC for drive ID %s not found", driveID)
+}
+
+// resetACSize sets size of corresponding AC to 0 to avoid further allocations
+func (c *Controller) resetACSizeOfLVG(lvgName string) {
+	// read AC
+	if ac := c.crHelper.GetACByLocation(lvgName); ac != nil {
+		// update if not null already
+		if ac.Spec.Size != 0 {
+			ac.Spec.Size = 0
+			if err := c.k8sClient.UpdateCR(context.Background(), ac); err != nil {
+				c.log.Errorf("Unable to set AC CR %s size to 0, error: %v.", ac.Name, err)
+			}
+		}
+		return
+	}
+
+	c.log.Errorf("AC CR for LVG %s not found", lvgName)
 }


### PR DESCRIPTION
## Purpose
### Issue #106 
Skip allocation for LVG in FAILED state by resetting AC size
```
borism1@ubuntu:/workspace/csi-baremetal$ ac | grep 38a63540-48a3-4f08-a33f-7f3fde4c4382
fa9171c6-b72a-4009-b239-88abdb198dfd   84934656    HDDLVG         38a63540-48a3-4f08-a33f-7f3fde4c4382   2fd0ef69-d1a5-4faa-bf20-c8e4251de2de
/workspace/csi-baremetal$ lvgs
Id                                     Size        Status    Volumes                                                                                                                        Locations                                Node
38a63540-48a3-4f08-a33f-7f3fde4c4382   210763776   CREATED   [pvc-c3ec92df-18e5-419b-9daf-8419bae3a6f8 pvc-3fb2c138-b441-408e-b1f9-1e23e135b68b pvc-703e4c57-6409-442c-93b4-9e790dc4497c]   [691fd88b-f5b3-46ab-939c-83cace9189d7]   2fd0ef69-d1a5-4faa-bf20-c8e4251de2de

/workspace/csi-baremetal$ lvgs
Id                                     Size        Status   Volumes                                                                                                                        Locations                                Node
38a63540-48a3-4f08-a33f-7f3fde4c4382   210763776   FAILED   [pvc-c3ec92df-18e5-419b-9daf-8419bae3a6f8 pvc-3fb2c138-b441-408e-b1f9-1e23e135b68b pvc-703e4c57-6409-442c-93b4-9e790dc4497c]   [691fd88b-f5b3-46ab-939c-83cace9189d7]   2fd0ef69-d1a5-4faa-bf20-c8e4251de2de

/workspace/csi-baremetal$ ac | grep 38a63540-48a3-4f08-a33f-7f3fde4c4382
fa9171c6-b72a-4009-b239-88abdb198dfd   <none>      HDDLVG         38a63540-48a3-4f08-a33f-7f3fde4c4382   2fd0ef69-d1a5-4faa-bf20-c8e4251de2de
```

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
_In progress_
