### PR TITLE
[ISSUE-232] Don't use LVG for volumes with ANY storage type 

### DIFF
--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -100,6 +100,7 @@ const (
 	LocationTypeNVMe  = "NVME"
 
 	// CSI StorageClass
+	// For volumes with storage class 'ANY' CSI will pick any AC except LVG AC
 	StorageClassAny       = "ANY"
 	StorageClassHDD       = "HDD"
 	StorageClassSSD       = "SSD"

--- a/charts/baremetal-csi-plugin/templates/baremetal-csi-sc.yaml
+++ b/charts/baremetal-csi-plugin/templates/baremetal-csi-sc.yaml
@@ -8,5 +8,5 @@ provisioner: baremetal-csi  # CSI driver name
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  storageType: ANY
+  storageType: ANY # With ANY storage type CSI allocates volumes on top of ANY physical drive (non LVG)
   fsType: xfs

--- a/pkg/base/capacityplanner/planner_test.go
+++ b/pkg/base/capacityplanner/planner_test.go
@@ -164,7 +164,7 @@ func TestCapacityManager(t *testing.T) {
 		testACS := []*accrd.AvailableCapacity{
 			getTestAC(testNode1, testSmallSize, apiV1.StorageClassSSD),
 			getTestAC(testNode1, testSmallSize, apiV1.StorageClassHDD),
-			getTestAC(testNode1, testSmallSize, apiV1.StorageClassHDDLVG),
+			getTestAC(testNode1, testSmallSize, apiV1.StorageClassNVMe),
 		}
 		plan, err := callPlanVolumesPlacing(getCapReaderMock(testACS, nil), testVols)
 		assert.NotNil(t, plan)
@@ -177,6 +177,17 @@ func TestCapacityManager(t *testing.T) {
 			}
 			assert.Len(t, usedAC, len(testVols))
 		}
+	})
+	t.Run("ANY StorageClass with LVG AC", func(t *testing.T) {
+		testVols := []*genV1.Volume{
+			getTestVol(testNode1, testSmallSize, apiV1.StorageClassAny),
+		}
+		testACS := []*accrd.AvailableCapacity{
+			getTestAC(testNode1, testSmallSize, apiV1.StorageClassHDDLVG),
+		}
+		plan, err := callPlanVolumesPlacing(getCapReaderMock(testACS, nil), testVols)
+		assert.Nil(t, plan)
+		assert.Nil(t, err)
 	})
 	t.Run("Find AC on multiple nodes", func(t *testing.T) {
 		testVols := []*genV1.Volume{

--- a/pkg/scheduler/extender/extender_test.go
+++ b/pkg/scheduler/extender/extender_test.go
@@ -342,8 +342,8 @@ func TestExtender_filterSuccess(t *testing.T) {
 				{StorageClass: v1.StorageClassAny, Size: 150 * int64(util.GBYTE)},
 				{StorageClass: v1.StorageClassAny, Size: 100 * int64(util.GBYTE)},
 			},
-			ExpectedNodeNames: []string{node3Name},
-			Msg:               "Volumes: HDDLVG[150Gb], SSDLVG[100Gb]; Expected nodes: [NODE-3]",
+			ExpectedNodeNames: []string{},
+			Msg:               "Volumes: HDDLVG[150Gb], SSDLVG[100Gb]; Expected nodes: []",
 		},
 		{
 			Volumes: []*genV1.Volume{

--- a/pkg/scheduler/patcher/main.py
+++ b/pkg/scheduler/patcher/main.py
@@ -87,6 +87,9 @@ def run():
         manifest.load()
         manifest.patch()
 
+        # todo on a first run we need to change inode for a scheduler config to trigger pod restart to make sure
+        # <todo> that configuration delivered. this is also affects e2e tests, refer for details -
+        # <todo> https://github.com/dell/csi-baremetal/issues/236
         if manifest.changed:
             manifest.backup()
             manifest.flush()
@@ -101,8 +104,11 @@ class GracefulKiller:
         self.restore = restore
         self.file = file
 
+    # restore original configuration if restore parameter passed
     def exit_gracefully(self, signum, frame):
+        log.info('handling signal {}...'.format(signum))
         if self.restore:
+            log.info('restoring original scheduler config...')
             self.file.restore()
             sys.exit(0)
 

--- a/test/e2e/common/deploy-plugin-components.go
+++ b/test/e2e/common/deploy-plugin-components.go
@@ -137,7 +137,7 @@ func waitForRestart(c clientset.Interface, fu func() (func(), error)) (func(), e
 			msg := "Scheduler restart NOT detected yet"
 			e2elog.Logf(msg)
 			if time.Now().After(deadline) {
-				e2elog.Logf("Scheduler restart NOT detected after %d minutes. Continue.",
+				e2elog.Logf("Scheduler didn't receive extender configuration after %f minutes. Continue...",
 					restartWaitTimeout.Minutes())
 				break
 			}


### PR DESCRIPTION
## Purpose
### Issue #232

To avoid race conditions on AC (ANY ang LVG) CSI will not allocate volumes with storage type ANY on top of LVG

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
```
borism1@ubuntu:/workspace/csi-baremetal$ ac
Id                                     Size        StorageClass   Location                               Node
0144c673-b7f5-45c6-97ec-fffa0320331c   210763776   HDD            3e4d9010-1821-40c2-8341-3491868e0dd1   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
1037b0a9-7b43-49b8-a489-b53a837ee418   210763776   HDD            4b3a144e-40f8-4580-9c72-d97abb755179   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
1e5568b5-3862-45cf-8224-2389d8a63d7d   210763776   HDD            c539a7ec-f91b-40ad-84e8-fc2488cfb9e6   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
0253843d-6f0f-4567-a206-bd717380deb3   210763776   HDD            b81421ae-5ed6-4847-bc8f-9e51b6af2ac9   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
bae5375b-ab36-4c66-bfc7-90656ba02b47   210763776   HDD            c274ed80-8397-4573-8cf6-45bfd6a3f404   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
d80e1ddc-aee3-48e2-8387-78b2221a88e6   210763776   HDD            01de68e8-2160-4a26-a8bc-1cd2a56d8174   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed

borism1@ubuntu:/workspace/csi-baremetal$ pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS              AGE
data-web-0   Bound    pvc-b069f47f-76e9-4956-8e14-e2c19cddb07d   120Mi      RWO            baremetal-csi-sc-hddlvg   116s
data-web-1   Bound    pvc-1b01ff66-2b70-4696-a66a-fc54b8731555   120Mi      RWO            baremetal-csi-sc-hddlvg   116s
logs-web-0   Bound    pvc-38e70529-b35b-46a1-8018-429e4ac31a34   120Mi      RWO            baremetal-csi-sc-hddlvg   116s
logs-web-1   Bound    pvc-1284c711-fbfe-4eb0-bd3d-1ec20fb24519   120Mi      RWO            baremetal-csi-sc-hddlvg   116s
www-web-0    Bound    pvc-7eb8a405-6fb8-468d-9c10-1971c7e7ed60   120Mi      RWO            baremetal-csi-sc-hddlvg   116s
www-web-1    Bound    pvc-4e3e2100-cfb3-47a3-8a37-e4f486b4cd49   120Mi      RWO            baremetal-csi-sc-hddlvg   116s

borism1@ubuntu:/workspace/csi-baremetal$ ac
Id                                     Size       StorageClass   Location                               Node
0144c673-b7f5-45c6-97ec-fffa0320331c   <none>     HDD            3e4d9010-1821-40c2-8341-3491868e0dd1   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
1037b0a9-7b43-49b8-a489-b53a837ee418   <none>     HDD            4b3a144e-40f8-4580-9c72-d97abb755179   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
1e5568b5-3862-45cf-8224-2389d8a63d7d   <none>     HDD            c539a7ec-f91b-40ad-84e8-fc2488cfb9e6   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
219c2310-46ee-495f-a62f-69d189dc6ff5   84934656   HDDLVG         efe44a60-b42e-46ae-baf6-d799c2a1a9da   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
4d31cea9-300c-4035-a785-f3f819cc2806   84934656   HDDLVG         d23f20c2-d8f9-48a2-8aaf-865a5081f83c   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
530d49d9-56cc-4683-8429-7bf0364bbdb9   84934656   HDDLVG         65d440b5-2f4d-4a07-816a-1188ac33bb88   59da8bc3-2021-4e94-a1e6-1ea4b7cebcdb
0253843d-6f0f-4567-a206-bd717380deb3   <none>     HDD            b81421ae-5ed6-4847-bc8f-9e51b6af2ac9   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
9e722a3d-b8db-4476-8554-72f03caecbb6   84934656   HDDLVG         86d204f8-7b54-4271-bdda-db725ebdb912   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
bae5375b-ab36-4c66-bfc7-90656ba02b47   <none>     HDD            c274ed80-8397-4573-8cf6-45bfd6a3f404   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
c7db6451-8fd3-4f0f-8809-0431e724ba28   84934656   HDDLVG         23f5dc5c-510b-4b00-88b4-19fd5cc59149   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
d80e1ddc-aee3-48e2-8387-78b2221a88e6   <none>     HDD            01de68e8-2160-4a26-a8bc-1cd2a56d8174   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed
ff6ee175-52b8-4bed-9784-3c9e287198fb   84934656   HDDLVG         928ca984-9f88-4519-bb3a-ef449dd3f7e1   c87f2a0d-d4d4-4d7d-b3cf-5135196de6ed

borism1@ubuntu:/workspace/csi-baremetal$ pvc
NAME             STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS              AGE
data-web-0       Bound     pvc-b069f47f-76e9-4956-8e14-e2c19cddb07d   120Mi      RWO            baremetal-csi-sc-hddlvg   17m
data-web-1       Bound     pvc-1b01ff66-2b70-4696-a66a-fc54b8731555   120Mi      RWO            baremetal-csi-sc-hddlvg   17m
data-web-new-0   Pending                                                                        baremetal-csi-sc          11s
logs-web-0       Bound     pvc-38e70529-b35b-46a1-8018-429e4ac31a34   120Mi      RWO            baremetal-csi-sc-hddlvg   17m
logs-web-1       Bound     pvc-1284c711-fbfe-4eb0-bd3d-1ec20fb24519   120Mi      RWO            baremetal-csi-sc-hddlvg   17m
logs-web-new-0   Pending                                                                        baremetal-csi-sc          11s
www-web-0        Bound     pvc-7eb8a405-6fb8-468d-9c10-1971c7e7ed60   120Mi      RWO            baremetal-csi-sc-hddlvg   17m
www-web-1        Bound     pvc-4e3e2100-cfb3-47a3-8a37-e4f486b4cd49   120Mi      RWO            baremetal-csi-sc-hddlvg   17m
www-web-new-0    Pending                                                                        baremetal-csi-sc          11s

borism1@ubuntu:/workspace/csi-baremetal$ kubectl describe sts web-new
Name:               web-new
...
Volume Claims:
  Name:          www
  StorageClass:  baremetal-csi-sc
  Labels:        <none>
  Annotations:   <none>
  Capacity:      60Mi
  Access Modes:  [ReadWriteOnce]
  Name:          data
  StorageClass:  baremetal-csi-sc
  Labels:        <none>
  Annotations:   <none>
  Capacity:      60Mi
  Access Modes:  [ReadWriteOnce]
  Name:          logs
  StorageClass:  baremetal-csi-sc
  Labels:        <none>
  Annotations:   <none>

borism1@ubuntu:/workspace/csi-baremetal$ kubectl describe pod web-new-0
Name:               web-new-0
Events:
  Type     Reason            Age        From               Message
  ----     ------            ----       ----               -------
  Warning  FailedScheduling  <unknown>  default-scheduler  0/3 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 2 Node doesn't contain required amount of AvailableCapacity.
  Warning  FailedScheduling  <unknown>  default-scheduler  0/3 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 2 Node doesn't contain required amount of AvailableCapacity.
  Warning  FailedScheduling  <unknown>  default-scheduler  0/3 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 2 Node doesn't contain required amount of AvailableCapacity.
  Warning  FailedScheduling  <unknown>  default-scheduler  0/3 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 2 Node doesn't contain required amount of AvailableCapacity.
  Warning  FailedScheduling  <unknown>  default-scheduler  0/3 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 2 Node doesn't contain required amount of AvailableCapacity.
```
CI tested partially - only LVG tests.
