### PR TITLE
[ISSUE-240] Implement metrics for volumemgr.Discovery

### DIFF
--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -72,7 +72,7 @@ func NewVolumeOperationsImpl(k8sClient *k8s.KubeClient, logger *logrus.Logger, c
 	volumeMetrics := metrics.NewMetrics(prometheus.HistogramOpts{
 		Name:    "volume_operations_duration",
 		Help:    "Volume operations methods duration",
-		Buckets: prometheus.ExponentialBuckets(0.005, 1.5, 25),
+		Buckets: metrics.ExtendedDefBuckets,
 	}, "method")
 	if err := prometheus.Register(volumeMetrics.Collect()); err != nil {
 		logger.WithField("component", "NewVolumeOperationsImpl").

--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -73,7 +73,7 @@ func NewVolumeOperationsImpl(k8sClient *k8s.KubeClient, logger *logrus.Logger, c
 		Name:    "volume_operations_duration",
 		Help:    "Volume operations methods duration",
 		Buckets: prometheus.ExponentialBuckets(0.005, 1.5, 25),
-	})
+	}, "method")
 	if err := prometheus.Register(volumeMetrics.Collect()); err != nil {
 		logger.WithField("component", "NewVolumeOperationsImpl").
 			Errorf("Failed to register metric: %v", err)
@@ -95,7 +95,7 @@ func NewVolumeOperationsImpl(k8sClient *k8s.KubeClient, logger *logrus.Logger, c
 // Receives golang context and api.Volume which is Spec of Volume CR to create
 // Returns api.Volume instance that took the place of chosen by SearchAC method AvailableCapacity CR
 func (vo *VolumeOperationsImpl) CreateVolume(ctx context.Context, v api.Volume) (*api.Volume, error) {
-	defer vo.metrics.EvaluateDuration("CreateVolume")()
+	defer vo.metrics.EvaluateDurationForMethod("CreateVolume")()
 	ll := vo.log.WithFields(logrus.Fields{
 		"method":   "CreateVolume",
 		"volumeID": v.Id,
@@ -241,7 +241,7 @@ func (vo *VolumeOperationsImpl) createCapacityManager(capReader capacityplanner.
 // Receives golang context and a volume ID to delete
 // Returns error if something went wrong or Volume with volumeID wasn't found
 func (vo *VolumeOperationsImpl) DeleteVolume(ctx context.Context, volumeID string) error {
-	defer vo.metrics.EvaluateDuration("DeleteVolume")()
+	defer vo.metrics.EvaluateDurationForMethod("DeleteVolume")()
 	ll := vo.log.WithFields(logrus.Fields{
 		"method":   "DeleteVolume",
 		"volumeID": volumeID,
@@ -292,7 +292,7 @@ func (vo *VolumeOperationsImpl) DeleteVolume(ctx context.Context, volumeID strin
 // remove Volume CR and if volume was in LVG SC - update corresponding AC CR
 // does not return anything because that method does not change real drive on the node
 func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string) {
-	defer vo.metrics.EvaluateDuration("UpdateCRsAfterVolumeDeletion")()
+	defer vo.metrics.EvaluateDurationForMethod("UpdateCRsAfterVolumeDeletion")()
 	ll := vo.log.WithFields(logrus.Fields{
 		"method":   "UpdateCRsAfterVolumeDeletion",
 		"volumeID": ctx.Value(base.RequestUUID),
@@ -370,7 +370,7 @@ func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context
 // WaitStatus check volume status until it will be reached one of the statuses
 // return error if context is done or volume reaches failed status, return nil if reached status != failed
 func (vo *VolumeOperationsImpl) WaitStatus(ctx context.Context, volumeID string, statuses ...string) error {
-	defer vo.metrics.EvaluateDuration("WaitStatus")()
+	defer vo.metrics.EvaluateDurationForMethod("WaitStatus")()
 	ll := vo.log.WithFields(logrus.Fields{
 		"method":   "WaitStatus",
 		"volumeID": volumeID,

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/eventing"
 	"github.com/dell/csi-baremetal/pkg/events"
+	metricsC "github.com/dell/csi-baremetal/pkg/metrics/common"
 )
 
 // Controller to reconcile drive custom resource
@@ -78,6 +79,7 @@ func (c *Controller) filterCRs(obj runtime.Object) bool {
 
 // Reconcile reconciles Drive custom resources
 func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	defer metricsC.ReconcileDuration.EvaluateDurationForType("node_drive_controller")()
 	// read name
 	driveName := req.Name
 	// TODO why do we need 60 seconds here?

--- a/pkg/crcontrollers/lvg/lvgcontroller.go
+++ b/pkg/crcontrollers/lvg/lvgcontroller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/lsblk"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/lvm"
 	"github.com/dell/csi-baremetal/pkg/base/util"
+	metricsC "github.com/dell/csi-baremetal/pkg/metrics/common"
 )
 
 const lvgFinalizer = "dell.emc.csi/lvg-cleanup"
@@ -79,6 +80,7 @@ func NewController(k8sClient *k8s.KubeClient, nodeID string, log *logrus.Logger)
 // LVG.ObjectMeta.DeletionTimestamp is not zero and VG is not placed on system drive.
 // Returns reconcile result as ctrl.Result or error if something went wrong
 func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	defer metricsC.ReconcileDuration.EvaluateDurationForType("node_lvg_controller")()
 	ll := c.log.WithFields(logrus.Fields{
 		"method":  "Reconcile",
 		"LVGName": req.Name,

--- a/pkg/metrics/common/reconcile.go
+++ b/pkg/metrics/common/reconcile.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/dell/csi-baremetal/pkg/metrics"
+)
+
+// ReconcileDuration used to collect durations of reconcile loops
+var ReconcileDuration = metrics.NewMetrics(prometheus.HistogramOpts{
+	Name:    "reconcile_duration_seconds",
+	Help:    "duration of the each reconcile loop",
+	Buckets: metrics.ExtendedDefBuckets,
+}, "type")
+
+// nolint: gochecknoinits
+func init() {
+	prometheus.MustRegister(ReconcileDuration.Collect())
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,8 +28,10 @@ type Statistic interface {
 	Collect() prometheus.Collector
 	EvaluateDuration(labels prometheus.Labels) func()
 	EvaluateDurationForMethod(method string) func()
+	EvaluateDurationForType(t string) func()
 }
 
+// ExtendedDefBuckets is a default buckets used for csi driver
 var ExtendedDefBuckets = []float64{.025, .05, .1, .5, 1, 3, 5, 10, 15, 30, 45, 90, 180}
 
 // Metrics is a structure, which encapsulate prometheus histogram structure. It used for volume operation metrics
@@ -54,6 +56,11 @@ func (m *Metrics) EvaluateDuration(labels prometheus.Labels) func() {
 // EvaluateDurationForMethod of the method call
 func (m *Metrics) EvaluateDurationForMethod(method string) func() {
 	return m.EvaluateDuration(prometheus.Labels{"method": method})
+}
+
+// EvaluateDurationForType evaluate function call with "type" label
+func (m *Metrics) EvaluateDurationForType(t string) func() {
+	return m.EvaluateDuration(prometheus.Labels{"type": t})
 }
 
 // Collect returns prometheus.Collector slice with OperationsDuration histogram

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,8 +26,11 @@ import (
 // Statistic is a common interface for histogram metrics
 type Statistic interface {
 	Collect() prometheus.Collector
-	EvaluateDuration(method string) func()
+	EvaluateDuration(labels prometheus.Labels) func()
+	EvaluateDurationForMethod(method string) func()
 }
+
+var ExtendedDefBuckets = []float64{.025, .05, .1, .5, 1, 3, 5, 10, 15, 30, 45, 90, 180}
 
 // Metrics is a structure, which encapsulate prometheus histogram structure. It used for volume operation metrics
 type Metrics struct {
@@ -35,19 +38,22 @@ type Metrics struct {
 }
 
 // NewMetrics initializes operations duration metrics
-func NewMetrics(opts prometheus.HistogramOpts) *Metrics {
-	return &Metrics{OperationsDuration: prometheus.NewHistogramVec(opts, []string{"method"})}
+func NewMetrics(opts prometheus.HistogramOpts, labels ...string) *Metrics {
+	return &Metrics{OperationsDuration: prometheus.NewHistogramVec(opts, labels)}
 }
 
-// EvaluateDuration evaluate duration from start for given method and put it into histogram
-// Receive method name as a string, start time ad time.Time
-func (m *Metrics) EvaluateDuration(method string) func() {
+// EvaluateDuration evaluate duration from start for a given method and put it into histogram
+// Receive prometheus.Labels.
+func (m *Metrics) EvaluateDuration(labels prometheus.Labels) func() {
 	start := time.Now()
 	return func() {
-		m.OperationsDuration.With(prometheus.Labels{
-			"method": method,
-		}).Observe(time.Since(start).Seconds())
+		m.OperationsDuration.With(labels).Observe(time.Since(start).Seconds())
 	}
+}
+
+// EvaluateDurationForMethod of the method call
+func (m *Metrics) EvaluateDurationForMethod(method string) func() {
+	return m.EvaluateDuration(prometheus.Labels{"method": method})
 }
 
 // Collect returns prometheus.Collector slice with OperationsDuration histogram

--- a/pkg/node/provisioners/utilwrappers/partition_operations.go
+++ b/pkg/node/provisioners/utilwrappers/partition_operations.go
@@ -75,7 +75,7 @@ func NewPartitionOperationsImpl(e command.CmdExecutor, log *logrus.Logger) *Part
 	var partMetrics = metrics.NewMetrics(prometheus.HistogramOpts{
 		Name:    "partition_operations_duration",
 		Help:    "partition operations methods duration",
-		Buckets: prometheus.ExponentialBuckets(0.5, 1.2, 20),
+		Buckets: metrics.ExtendedDefBuckets,
 	}, "method")
 	if err := prometheus.Register(partMetrics.Collect()); err != nil {
 		log.WithField("component", "NewPartitionOperationsImpl").

--- a/pkg/node/provisioners/utilwrappers/partition_operations.go
+++ b/pkg/node/provisioners/utilwrappers/partition_operations.go
@@ -76,7 +76,7 @@ func NewPartitionOperationsImpl(e command.CmdExecutor, log *logrus.Logger) *Part
 		Name:    "partition_operations_duration",
 		Help:    "partition operations methods duration",
 		Buckets: prometheus.ExponentialBuckets(0.5, 1.2, 20),
-	})
+	}, "method")
 	if err := prometheus.Register(partMetrics.Collect()); err != nil {
 		log.WithField("component", "NewPartitionOperationsImpl").
 			Errorf("Failed to register metric: %v", err)
@@ -91,7 +91,7 @@ func NewPartitionOperationsImpl(e command.CmdExecutor, log *logrus.Logger) *Part
 // PreparePartition completely creates and prepares partition p on node
 // After that FS could be created on partition
 func (d *PartitionOperationsImpl) PreparePartition(p Partition) (*Partition, error) {
-	defer d.metrics.EvaluateDuration("PreparePartition")()
+	defer d.metrics.EvaluateDurationForMethod("PreparePartition")()
 	ll := d.log.WithFields(logrus.Fields{
 		"method":   "PreparePartition",
 		"volumeID": p.PartUUID,
@@ -145,7 +145,7 @@ func (d *PartitionOperationsImpl) PreparePartition(p Partition) (*Partition, err
 
 // ReleasePartition completely removes partition p
 func (d *PartitionOperationsImpl) ReleasePartition(p Partition) error {
-	defer d.metrics.EvaluateDuration("ReleasePartition")()
+	defer d.metrics.EvaluateDurationForMethod("ReleasePartition")()
 	d.log.WithFields(logrus.Fields{
 		"method":   "ReleasePartition",
 		"volumeID": p.PartUUID,
@@ -164,7 +164,7 @@ func (d *PartitionOperationsImpl) ReleasePartition(p Partition) error {
 // SearchPartName search (with retries) partition with UUID partUUID on device and returns partition name
 // e.g. "1" for /dev/sda1, "p1n1" for /dev/loopbackp1n1
 func (d *PartitionOperationsImpl) SearchPartName(device, partUUID string) string {
-	defer d.metrics.EvaluateDuration("SearchPartName")()
+	defer d.metrics.EvaluateDurationForMethod("SearchPartName")()
 	ll := d.log.WithFields(logrus.Fields{
 		"method":   "SearchPartName",
 		"volumeID": partUUID,

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -54,6 +54,7 @@ import (
 	"github.com/dell/csi-baremetal/pkg/common"
 	"github.com/dell/csi-baremetal/pkg/eventing"
 	"github.com/dell/csi-baremetal/pkg/metrics"
+	metricsC "github.com/dell/csi-baremetal/pkg/metrics/common"
 	p "github.com/dell/csi-baremetal/pkg/node/provisioners"
 	"github.com/dell/csi-baremetal/pkg/node/provisioners/utilwrappers"
 )
@@ -159,7 +160,6 @@ func NewVolumeManager(
 	logger *logrus.Logger,
 	k8sclient *k8s.KubeClient,
 	recorder eventRecorder, nodeID string) *VolumeManager {
-
 	driveMgrDuration := metrics.NewMetrics(prometheus.HistogramOpts{
 		Name:    "discovery_duration_seconds",
 		Help:    "duration of the discovery method for the drive manager",
@@ -212,6 +212,7 @@ func (m *VolumeManager) SetProvisioners(provs map[p.VolumeType]p.Provisioner) {
 // Volume.Spec.CSIStatus is Removing.
 // Returns reconcile result as ctrl.Result or error if something went wrong
 func (m *VolumeManager) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	defer metricsC.ReconcileDuration.EvaluateDurationForType("node_volume_controller")()
 	m.volMu.LockKey(req.Name)
 	ll := m.log.WithFields(logrus.Fields{
 		"method":   "Reconcile",


### PR DESCRIPTION
## Purpose
#240

Implement metrics collection for node > volumemgr.Discovery

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

Testing:
```
root@baremetal-csi-node-hl2fd:/# curl -s http://127.0.0.1:8787/metrics  2>&1 | grep discovery
# HELP discovery_drive_count last drive count discovered
# TYPE discovery_drive_count gauge
discovery_drive_count 5
# HELP discovery_duration_seconds duration of the discovery method for the drive manager
# TYPE discovery_duration_seconds histogram
discovery_duration_seconds_bucket{le="0.005"} 0
discovery_duration_seconds_bucket{le="0.01"} 0
discovery_duration_seconds_bucket{le="0.025"} 0
discovery_duration_seconds_bucket{le="0.05"} 16
discovery_duration_seconds_bucket{le="0.1"} 33
discovery_duration_seconds_bucket{le="0.25"} 43
discovery_duration_seconds_bucket{le="0.5"} 43
discovery_duration_seconds_bucket{le="1"} 44
discovery_duration_seconds_bucket{le="2.5"} 44
discovery_duration_seconds_bucket{le="5"} 44
discovery_duration_seconds_bucket{le="10"} 44
discovery_duration_seconds_bucket{le="+Inf"} 45
discovery_duration_seconds_sum 112.37385219999997
discovery_duration_seconds_count 45
```

```
...
reconcile_duration_seconds_bucket{type="node_drive_controller",le="45"} 5
reconcile_duration_seconds_bucket{type="node_drive_controller",le="90"} 5
reconcile_duration_seconds_bucket{type="node_drive_controller",le="180"} 5
reconcile_duration_seconds_bucket{type="node_drive_controller",le="+Inf"} 5
reconcile_duration_seconds_sum{type="node_drive_controller"} 1.069513454
reconcile_duration_seconds_count{type="node_drive_controller"} 5
reconcile_duration_seconds_bucket{type="node_volume_controller",le="0.025"} 5
reconcile_duration_seconds_bucket{type="node_volume_controller",le="0.05"} 5
reconcile_duration_seconds_bucket{type="node_volume_controller",le="0.1"} 5
reconcile_duration_seconds_bucket{type="node_volume_controller",le="0.5"} 5
...
```
