### PR TITLE
[ISSUE-245] Expose ac reservation time in scheduler extender

### DIFF
--- a/charts/scheduler-extender/templates/scheduler-extender.yaml
+++ b/charts/scheduler-extender/templates/scheduler-extender.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         app: csi-baremetal-se
-        app.kubernetes.io/name: scheduler-extender
+        app.kubernetes.io/name: csi-baremetal
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '{{ .Values.metrics.port }}'

--- a/charts/scheduler-extender/templates/scheduler-extender.yaml
+++ b/charts/scheduler-extender/templates/scheduler-extender.yaml
@@ -11,6 +11,11 @@ spec:
     metadata:
       labels:
         app: csi-baremetal-se
+        app.kubernetes.io/name: scheduler-extender
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '{{ .Values.metrics.port }}'
+        prometheus.io/path: '{{ .Values.metrics.path }}'
     spec:
       serviceAccountName: csi-baremetal-extender-sa
       containers:
@@ -27,8 +32,15 @@ spec:
             - --certFile={{ .Values.tls.certFile }}
             - --privateKeyFile={{ .Values.tls.privateKeyFile }}
             - --usenodeannotation={{ .Values.feature.usenodeannotation }}
+            - --metrics-address=:{{ .Values.metrics.port }}
+            - --metrics-path={{ .Values.metrics.path }}
           ports:
             - containerPort: {{  .Values.port }}
+           {{- if .Values.metrics.port }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+           {{- end }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/scheduler-extender/values.yaml
+++ b/charts/scheduler-extender/values.yaml
@@ -35,3 +35,7 @@ patcher:
   interval: 60
   restore_on_shutdown: false
   config_map_name: schedulerpatcher-config
+
+metrics:
+  port: 8787
+  path: /metrics

--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -38,8 +38,9 @@ import (
 func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
 	capReader CapacityReader, resReader ReservationReader) *ReservationHelper {
 	acMetrics := metrics.NewMetrics(prometheus.HistogramOpts{
-		Name: "ac_reservation_duration",
-		Help: "AvailableCapacity reservation duration",
+		Name:    "ac_reservation_duration",
+		Help:    "AvailableCapacity reservation duration",
+		Buckets: metrics.ExtendedDefBuckets,
 	}, "method")
 	if err := prometheus.Register(acMetrics.Collect()); err != nil {
 		logger.WithField("component", "NewReservationHelper").

--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -40,7 +40,7 @@ func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
 	acMetrics := metrics.NewMetrics(prometheus.HistogramOpts{
 		Name:    "ac_reservation_duration",
 		Help:    "AvailableCapacity reservation duration",
-		Buckets: metrics.ExtendedDefBuckets,
+		Buckets: prometheus.ExponentialBuckets(0.005, 1.5, 10),
 	}, "method")
 	if err := prometheus.Register(acMetrics.Collect()); err != nil {
 		logger.WithField("component", "NewReservationHelper").

--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -30,16 +30,27 @@ import (
 	accrd "github.com/dell/csi-baremetal/api/v1/availablecapacitycrd"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/base/util"
+	"github.com/dell/csi-baremetal/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NewReservationHelper returns new instance of ReservationHelper
 func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
 	capReader CapacityReader, resReader ReservationReader) *ReservationHelper {
+	acMetrics := metrics.NewMetrics(prometheus.HistogramOpts{
+		Name: "ac_reservation_duration",
+		Help: "AvailableCapacity reservation duration",
+	}, "method")
+	if err := prometheus.Register(acMetrics.Collect()); err != nil {
+		logger.WithField("component", "NewReservationHelper").
+			Errorf("Failed to register metric: %v", err)
+	}
 	return &ReservationHelper{
 		logger:    logger,
 		client:    client,
 		resReader: resReader,
 		capReader: capReader,
+		metric:    acMetrics,
 	}
 }
 
@@ -57,10 +68,13 @@ type ReservationHelper struct {
 	acMap       ACMap
 	acrMap      ACRMap
 	acNameToACR ACNameToACRNamesMap
+
+	metric metrics.Statistic
 }
 
 // CreateReservation create reservation
 func (rh *ReservationHelper) CreateReservation(ctx context.Context, placingPlan *VolumesPlacingPlan) error {
+	defer rh.metric.EvaluateDurationForMethod("CreateReservation")()
 	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.CreateReservation")
 
 	volToAC := placingPlan.GetACsForVolumes()


### PR DESCRIPTION
## Purpose
### Issue #245 

_Describe your changes_
* Add metric endpoint HTTP handler in extender main file
* Configure helm chart to expose metrics from extender
* Add duration metric in `CreateReservation` function 

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
# HELP ac_reservation_duration AvailableCapacity reservation duration
# TYPE ac_reservation_duration histogram
ac_reservation_duration_bucket{method="CreateReservation",le="0.005"} 0
ac_reservation_duration_bucket{method="CreateReservation",le="0.0075"} 0
ac_reservation_duration_bucket{method="CreateReservation",le="0.01125"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.016875"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.0253125"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.03796875"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.05695312500000001"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.08542968750000002"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.12814453125000003"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="0.19221679687500004"} 1
ac_reservation_duration_bucket{method="CreateReservation",le="+Inf"} 1
ac_reservation_duration_sum{method="CreateReservation"} 0.009089843
ac_reservation_duration_count{method="CreateReservation"} 1
```

