### PR TITLE
[ALT-1501] Temporary reserve LVG AC after creation

### DIFF
--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -187,7 +187,7 @@ func (rh *ReservationHelper) ExtendReservations(ctx context.Context,
 	}
 
 	for _, acr := range acrToUpdate {
-		if err := rh.client.Update(ctx, acr); err != nil {
+		if err := rh.client.UpdateCR(ctx, acr); err != nil {
 			logger.Infof("Fail to update ACR %s: %s", acr.Name, err.Error())
 			return err
 		}
@@ -226,7 +226,7 @@ func (rh *ReservationHelper) Update(ctx context.Context) error {
 
 func (rh *ReservationHelper) removeACR(ctx context.Context, acr *acrcrd.AvailableCapacityReservation) error {
 	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.removeACR")
-	err := rh.client.Delete(ctx, acr)
+	err := rh.client.DeleteCR(ctx, acr)
 	if err == nil {
 		logger.Infof("ACR %s removed", acr.Name)
 		return nil
@@ -275,7 +275,7 @@ func (rh *ReservationHelper) removeACFromACRs(ctx context.Context, removedACR st
 		}
 	}
 	for _, acr := range acrToUpdate {
-		err := rh.client.Update(ctx, acr)
+		err := rh.client.UpdateCR(ctx, acr)
 		if err != nil {
 			logger.Infof("Fail to update ACR %s: %s", acr.Name, err.Error())
 			return err

--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -57,8 +57,9 @@ func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
 
 // ReservationHelper provides methods to create and release reservation
 type ReservationHelper struct {
-	logger *logrus.Entry
-	client *k8s.KubeClient
+	logger  *logrus.Entry
+	client  *k8s.KubeClient
+	updated bool
 
 	resReader ReservationReader
 	capReader CapacityReader
@@ -123,8 +124,7 @@ func (rh *ReservationHelper) CreateReservation(ctx context.Context, placingPlan 
 func (rh *ReservationHelper) ReleaseReservation(
 	ctx context.Context, volume *genV1.Volume, ac, acReplacement *accrd.AvailableCapacity) error {
 	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.ReleaseReservation")
-	err := rh.update(ctx)
-	if err != nil {
+	if err := rh.updateIfRequired(ctx); err != nil {
 		return err
 	}
 	// we should select ACR to remove from ACRs which have same size and SC as volume
@@ -143,13 +143,67 @@ func (rh *ReservationHelper) ReleaseReservation(
 	if ac == acReplacement {
 		return nil
 	}
-	if err := rh.replaceACInACR(ctx, acrToRemove.Name, ac, acReplacement); err != nil {
+	if err := rh.removeACFromACRs(ctx, acrToRemove.Name, ac); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (rh *ReservationHelper) update(ctx context.Context) error {
+// ExtendReservations allows to add additional AC to ACRs which hold parent AC
+func (rh *ReservationHelper) ExtendReservations(ctx context.Context,
+	parentAC *accrd.AvailableCapacity, additionalAC string) error {
+	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.ExtendReservations")
+	if err := rh.updateIfRequired(ctx); err != nil {
+		return err
+	}
+
+	// list of ACRs names which hold parent AC
+	acrNamesToCheck := rh.acNameToACR[parentAC.Name]
+
+	acrToCheck := make([]*acrcrd.AvailableCapacityReservation, 0, len(acrNamesToCheck))
+	for _, name := range acrNamesToCheck {
+		acr := rh.acrMap[name]
+		if acr == nil {
+			logger.Warningf("unknown AC Name in ACR.Spec.Reservations, posible bug")
+			continue
+		}
+		acrToCheck = append(acrToCheck, acr)
+	}
+
+	var acrToUpdate []*acrcrd.AvailableCapacityReservation
+
+	for _, acr := range acrToCheck {
+		alreadyExist := false
+		for _, res := range acr.Spec.Reservations {
+			if res == additionalAC {
+				alreadyExist = true
+				break
+			}
+		}
+		if !alreadyExist {
+			acr.Spec.Reservations = append(acr.Spec.Reservations, additionalAC)
+			acrToUpdate = append(acrToUpdate, acr)
+		}
+	}
+
+	for _, acr := range acrToUpdate {
+		if err := rh.client.Update(ctx, acr); err != nil {
+			logger.Infof("Fail to update ACR %s: %s", acr.Name, err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func (rh *ReservationHelper) updateIfRequired(ctx context.Context) error {
+	if rh.updated {
+		return nil
+	}
+	return rh.Update(ctx)
+}
+
+// Update do a force data update
+func (rh *ReservationHelper) Update(ctx context.Context) error {
 	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.update")
 	var err error
 	rh.acList, err = rh.capReader.ReadCapacity(ctx)
@@ -164,6 +218,8 @@ func (rh *ReservationHelper) update(ctx context.Context) error {
 	}
 	rh.acMap = buildACMap(rh.acList)
 	rh.acrMap, rh.acNameToACR = buildACRMaps(rh.acrList)
+
+	rh.updated = true
 
 	return nil
 }
@@ -183,16 +239,18 @@ func (rh *ReservationHelper) removeACR(ctx context.Context, acr *acrcrd.Availabl
 	return err
 }
 
-func (rh *ReservationHelper) replaceACInACR(ctx context.Context, removedACR string,
-	ac, acReplacement *accrd.AvailableCapacity) error {
-	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.replaceACInACR")
+func (rh *ReservationHelper) removeACFromACRs(ctx context.Context, removedACR string, ac *accrd.AvailableCapacity) error {
+	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.removeACFromACRs")
 
-	acrToUpdate, ok := rh.acNameToACR[ac.Name]
+	acrToCheck, ok := rh.acNameToACR[ac.Name]
 	if !ok {
 		logger.Infof("Can't find ACRs for AC %s", ac.Name)
 		return nil
 	}
-	for _, acrName := range acrToUpdate {
+
+	var acrToUpdate []*acrcrd.AvailableCapacityReservation
+
+	for _, acrName := range acrToCheck {
 		// ignore already removed ACR
 		if acrName == removedACR {
 			continue
@@ -201,22 +259,30 @@ func (rh *ReservationHelper) replaceACInACR(ctx context.Context, removedACR stri
 		if !ok {
 			continue
 		}
-		replaced := false
-		for i := 0; i < len(acr.Spec.Reservations); i++ {
+		removed := false
+		resLen := len(acr.Spec.Reservations)
+		for i := 0; i < resLen; i++ {
 			if acr.Spec.Reservations[i] == ac.Name {
-				acr.Spec.Reservations[i] = acReplacement.Name
-				replaced = true
+				acr.Spec.Reservations[i] = acr.Spec.Reservations[len(acr.Spec.Reservations)-1]
+				acr.Spec.Reservations = acr.Spec.Reservations[:len(acr.Spec.Reservations)-1]
+				i--
+				resLen--
+				removed = true
 			}
 		}
-		if replaced {
-			err := rh.client.Update(ctx, acr)
-			if err != nil {
-				logger.Infof("Fail to update ACR %s: %s", acr.Name, err.Error())
-				return err
-			}
-			logger.Infof("ACR %s updated", acr.Name)
+		if removed {
+			acrToUpdate = append(acrToUpdate, acr)
 		}
 	}
+	for _, acr := range acrToUpdate {
+		err := rh.client.Update(ctx, acr)
+		if err != nil {
+			logger.Infof("Fail to update ACR %s: %s", acr.Name, err.Error())
+			return err
+		}
+		logger.Infof("ACR %s updated", acr.Name)
+	}
+
 	return nil
 }
 

--- a/pkg/common/ac_operations_test.go
+++ b/pkg/common/ac_operations_test.go
@@ -38,7 +38,7 @@ func Test_recreateACToLVGSC_Success(t *testing.T) {
 	)
 
 	// there are no acs are provided
-	newAC = acOp.RecreateACToLVGSC(testCtx, apiV1.StorageClassHDDLVG)
+	newAC = acOp.RecreateACToLVGSC(testCtx, "", apiV1.StorageClassHDDLVG)
 	assert.Nil(t, newAC)
 
 	// ensure that there are 2 ACs
@@ -49,7 +49,7 @@ func Test_recreateACToLVGSC_Success(t *testing.T) {
 
 	// expect that AC with SC HDDLVG will be created and will be size of 1Tb + 100Gb
 	// testAC2 and testAC3 should be removed
-	newAC = acOp.RecreateACToLVGSC(testCtx, apiV1.StorageClassHDDLVG, testAC2, testAC3)
+	newAC = acOp.RecreateACToLVGSC(testCtx, "", apiV1.StorageClassHDDLVG, testAC2, testAC3)
 
 	// check that LVG is in creating state
 	lvgList := lvgcrd.LVGList{}

--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -173,6 +173,8 @@ func (vo *VolumeOperationsImpl) CreateVolume(ctx context.Context, v api.Volume) 
 
 		origAC := ac
 		if ac.Spec.StorageClass != v.StorageClass && util.IsStorageClassLVG(v.StorageClass) {
+			// we need to create reservation for newly created LVG AC before we sent LVG AC to kube-api
+			// this required to prevent race condition between csi-controller and scheduler extender
 			newACName := uuid.New().String()
 			if err := resHelper.ExtendReservations(ctx, origAC, newACName); err != nil {
 				return nil, status.Errorf(codes.Internal,

--- a/pkg/common/volume_operations_test.go
+++ b/pkg/common/volume_operations_test.go
@@ -254,7 +254,7 @@ func TestVolumeOperationsImpl_CreateVolume_FailRecreateAC(t *testing.T) {
 	svc.capacityManagerBuilder = capMBuilder
 	capMMock.On("PlanVolumesPlacing", ctxWithID, mock.Anything).
 		Return(buildVolumePlacingPlan(testNode1Name, &expectedVolume, &acToReturn), nil).Times(1)
-	acProvider.On("RecreateACToLVGSC", ctxWithID, requiredSC, mock.Anything).
+	acProvider.On("RecreateACToLVGSC", ctxWithID, mock.Anything, requiredSC, mock.Anything).
 		Return(nil).Times(1)
 
 	ctx := context.WithValue(testCtx, base.VolumeNamespace, testNS)

--- a/pkg/mocks/ac_operatrions.go
+++ b/pkg/mocks/ac_operatrions.go
@@ -53,8 +53,8 @@ func (a *ACOperationsMock) DeleteIfEmpty(ctx context.Context, acLocation string)
 // RecreateACToLVGSC is the mock implementation of RecreateACToLVGSC method from AvailableCapacityOperations made for simulating
 // recreation of list of ACs to LVG AC
 // Returns error if user simulates error in tests or nil
-func (a *ACOperationsMock) RecreateACToLVGSC(ctx context.Context, sc string, acs ...accrd.AvailableCapacity) *accrd.AvailableCapacity {
-	args := a.Mock.Called(ctx, sc, acs)
+func (a *ACOperationsMock) RecreateACToLVGSC(ctx context.Context, acName, sc string, acs ...accrd.AvailableCapacity) *accrd.AvailableCapacity {
+	args := a.Mock.Called(ctx, acName, sc, acs)
 	if args.Get(0) == nil {
 		return nil
 	}


### PR DESCRIPTION
Add temporary reservation for LVG AC after it was created from drive AC. This change required to prevent race condition between CSI controller and scheduler extender


## Purpose
### Issue #260

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
