### PR TITLE
[ISSUE-262] loopbackmgr system drive error

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -53,9 +53,6 @@ const (
 	// DefaultRequeueForVolume is the interval for volume reconcile
 	DefaultRequeueForVolume = 5 * time.Second
 
-	// SystemDriveAsLocation is the const to fill Location field in CRs if the location based on system drive
-	SystemDriveAsLocation = "system drive"
-
 	// DefaultFsType FS type that used by default
 	DefaultFsType = "xfs"
 

--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -436,7 +436,7 @@ func (vo *VolumeOperationsImpl) deleteLVGIfVolumesNotExistOrUpdate(lvg *lvgcrd.L
 		"volumeID": volID,
 	})
 
-	drivesUUIDs := append(vo.k8sClient.GetSystemDriveUUIDs(), base.SystemDriveAsLocation)
+	drivesUUIDs := vo.k8sClient.GetSystemDriveUUIDs()
 	// if only one volume remains - remove AC first and LVG then
 	if len(lvg.Spec.VolumeRefs) == 1 && !util.ContainsString(drivesUUIDs, lvg.Spec.Locations[0]) {
 		if err := vo.k8sClient.DeleteCR(context.Background(), ac); err != nil {

--- a/pkg/crcontrollers/lvg/lvgcontroller.go
+++ b/pkg/crcontrollers/lvg/lvgcontroller.go
@@ -200,7 +200,7 @@ func (c *Controller) handleLVGRemoving(lvg *lvgcrd.LVG) (ctrl.Result, error) {
 	// update AC size that point on that LVG
 	c.increaseACSize(lvg.Spec.Locations[0], lvg.Spec.Size)
 
-	drivesUUIDs := append(c.k8sClient.GetSystemDriveUUIDs(), base.SystemDriveAsLocation)
+	drivesUUIDs := c.k8sClient.GetSystemDriveUUIDs()
 	if !util.ContainsString(drivesUUIDs, lvg.Spec.Locations[0]) {
 		// cleanup LVM artifacts
 		if err := c.removeLVGArtifacts(lvg.Name); err != nil {

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -906,7 +906,12 @@ func (m *VolumeManager) discoverLVGOnSystemDrive() error {
 	ll := m.log.WithField("method", "discoverLVGOnSystemDrive")
 
 	if len(m.systemDrivesUUIDs) == 0 {
-		return errors.New("system drive is not defined")
+		// system drive is not detected by drive manager
+		// this is not an issue but might be configuration choice
+		ll.Warningf("System drive is not detected by drive manager")
+		// skipping LVM check for system drive
+		m.discoverSystemLVG = false
+		return nil
 	}
 
 	var (

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -628,10 +628,7 @@ func (m *VolumeManager) updateDrivesCRs(ctx context.Context, drivesFromMgr []*ap
 			driveCRs = append(driveCRs, *driveCR)
 		}
 	}
-	// If CSI can't find system disks, it appends "system drive" to systemDrivesUUIDs slice and uses it as a location for LVG
-	if len(m.systemDrivesUUIDs) == 0 {
-		m.systemDrivesUUIDs = append(m.systemDrivesUUIDs, base.SystemDriveAsLocation)
-	}
+
 	// that means that it is a first round and drives are discovered first time
 	if firstIteration {
 		return updates, nil

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -899,7 +899,7 @@ func Test_discoverLVGOnSystemDrive_LVGAlreadyExists(t *testing.T) {
 		lvgCR = m.k8sClient.ConstructLVGCR("some-name", api.LogicalVolumeGroup{
 			Name:      "some-name",
 			Node:      m.nodeID,
-			Locations: []string{base.SystemDriveAsLocation},
+			Locations: []string{"some-uuid"},
 		})
 		lvgList = lvgcrd.LVGList{}
 		acList  = accrd.AvailableCapacityList{}


### PR DESCRIPTION
## Purpose
### Issue #262 

When deploying CSI locally there are repeating errors in the logs:
```
Feb  8 03:59:42.412 [ERRO] [VolumeManager] [Discover] unable to inspect system LVG: drives.baremetal-csi.dellemc.com "system drive" not found
Feb  8 04:00:13.453 [ERRO] [VolumeManager] [Discover] unable to inspect system LVG: drives.baremetal-csi.dellemc.com "system drive" not found
Feb  8 04:00:43.492 [ERRO] [VolumeManager] [Discover] unable to inspect system LVG: drives.baremetal-csi.dellemc.com "system drive" not found
...
```
They are caused by `loopbackmgr` not reported information about system drive. For real drive manager such configuration is also supported and we should skip checking LVM setting on system drive.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_In progress_
