### PR TITLE
[ISSUE-269] Add caching support to scheduler extender

### DIFF
--- a/charts/scheduler-extender/templates/rbac.yaml
+++ b/charts/scheduler-extender/templates/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   - apiGroups: ["baremetal-csi.dellemc.com"]
     resources: ["volumes"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["baremetal-csi.dellemc.com"]
     resources: ["availablecapacities"]
     verbs: ["get", "list"]
@@ -21,10 +21,10 @@ rules:
     verbs: ["get", "list", "create"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -47,7 +47,6 @@ import (
 // based on pod volumes requirements and Available Capacities
 type Extender struct {
 	k8sClient *k8s.KubeClient
-	crHelper  *k8s.CRHelper
 	// namespace in which Extender will be search Available Capacity
 	namespace      string
 	provisioner    string
@@ -66,7 +65,6 @@ func NewExtender(logger *logrus.Logger, namespace, provisioner string, featureCo
 	kubeClient := k8s.NewKubeClient(k8sClient, logger, namespace)
 	return &Extender{
 		k8sClient:              kubeClient,
-		crHelper:               k8s.NewCRHelper(kubeClient, logger),
 		provisioner:            provisioner,
 		featureChecker:         featureConf,
 		logger:                 logger.WithField("component", "Extender"),

--- a/pkg/scheduler/extender/extender_test.go
+++ b/pkg/scheduler/extender/extender_test.go
@@ -440,8 +440,10 @@ func setup(t *testing.T) *Extender {
 
 	featureConf := fc.NewFeatureConfig()
 	kubeClient := k8s.NewKubeClient(k, testLogger, testNs)
+	kubeCache := k8s.NewKubeCache(k, testLogger)
 	return &Extender{
 		k8sClient:              kubeClient,
+		k8sCache:               kubeCache,
 		featureChecker:         featureConf,
 		namespace:              testNs,
 		provisioner:            testProvisioner,


### PR DESCRIPTION
## Purpose 
Add caching support to scheduler extender
### Issue #269 

Extender reads PVC, Volume and StorageClass resources from auto-updated cache.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

This PR should merged to master after #274 