### PR TITLE
[ISSUE-280] Fix AvailableCapacity size computation for LVM

### DIFF
--- a/pkg/base/capacityplanner/common.go
+++ b/pkg/base/capacityplanner/common.go
@@ -38,3 +38,13 @@ func AlignSizeByPE(size int64) int64 {
 	}
 	return size + alignement
 }
+
+// SubtractLVMMetadataSize subtracts LVM metadata size from raw drive size
+func SubtractLVMMetadataSize(size int64) int64 {
+	reminder := size % DefaultPESize
+	result := size - reminder
+	if reminder < LvgDefaultMetadataSize {
+		return result - DefaultPESize
+	}
+	return result
+}

--- a/pkg/base/capacityplanner/common_test.go
+++ b/pkg/base/capacityplanner/common_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacityplanner
+
+import "testing"
+
+func TestSubtractLVMMetadataSize(t *testing.T) {
+	type args struct {
+		size int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{
+			name: "500MiB",
+			args: args{
+				size: 524288000,
+			},
+			want: 520093696,
+		},
+		{
+			name: "501MiB",
+			args: args{
+				size: 525336576,
+			},
+			want: 524288000,
+		},
+		{
+			name: "502MiB",
+			args: args{
+				size: 526385152,
+			},
+			want: 524288000,
+		},
+		{
+			name: "500.5MiB",
+			args: args{
+				size: 524812288,
+			},
+			want: 520093696,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubtractLVMMetadataSize(tt.args.size); got != tt.want {
+				t.Errorf("SubtractLVMMetadataSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/base/capacityplanner/planner_test.go
+++ b/pkg/base/capacityplanner/planner_test.go
@@ -220,20 +220,6 @@ func TestCapacityManager(t *testing.T) {
 			assert.Equal(t, testACS[0], plan.GetACForVolume(testNode1, testVols[0]))
 		}
 	})
-	t.Run("Using sub class for LVG", func(t *testing.T) {
-		testVols := []*genV1.Volume{
-			getTestVol("", testSmallSize, apiV1.StorageClassHDDLVG),
-		}
-		testACS := []*accrd.AvailableCapacity{
-			getTestAC(testNode1, testSmallSize+LvgDefaultMetadataSize, apiV1.StorageClassHDD),
-		}
-		plan, err := callPlanVolumesPlacing(getCapReaderMock(testACS, nil), testVols)
-		assert.NotNil(t, plan)
-		assert.Nil(t, err)
-		if plan != nil {
-			assert.Equal(t, testACS[0], plan.GetACForVolume(testNode1, testVols[0]))
-		}
-	})
 	t.Run("Multiple LVM volumes on same drive", func(t *testing.T) {
 		testVols := []*genV1.Volume{
 			getTestVol("", testSmallSize, apiV1.StorageClassHDDLVG),

--- a/pkg/common/ac_operations.go
+++ b/pkg/common/ac_operations.go
@@ -27,6 +27,7 @@ import (
 	apiV1 "github.com/dell/csi-baremetal/api/v1"
 	accrd "github.com/dell/csi-baremetal/api/v1/availablecapacitycrd"
 	"github.com/dell/csi-baremetal/pkg/base"
+	"github.com/dell/csi-baremetal/pkg/base/capacityplanner"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 )
 
@@ -73,7 +74,7 @@ func (a *ACOperationsImpl) RecreateACToLVGSC(ctx context.Context, acName, newSC 
 	var lvgSize int64
 	for i, ac := range acs {
 		lvgLocations[i] = ac.Spec.Location
-		lvgSize += ac.Spec.Size
+		lvgSize += capacityplanner.SubtractLVMMetadataSize(ac.Spec.Size)
 	}
 
 	var (

--- a/pkg/common/ac_operations_test.go
+++ b/pkg/common/ac_operations_test.go
@@ -57,7 +57,9 @@ func Test_recreateACToLVGSC_Success(t *testing.T) {
 	assert.Equal(t, 1, len(lvgList.Items))
 	lvg := lvgList.Items[0]
 	assert.Equal(t, apiV1.Creating, lvg.Spec.Status)
-	assert.Equal(t, testAC2.Spec.Size+testAC3.Spec.Size, lvg.Spec.Size)
+	assert.Equal(t,
+		capacityplanner.SubtractLVMMetadataSize(testAC2.Spec.Size)+
+			capacityplanner.SubtractLVMMetadataSize(testAC3.Spec.Size), lvg.Spec.Size)
 	assert.Equal(t, testAC2.Spec.NodeId, lvg.Spec.Node)
 	assert.Equal(t, 2, len(lvg.Spec.Locations))
 	expectedLocation := []string{testAC2.Spec.Location, testAC3.Spec.Location}


### PR DESCRIPTION
## Purpose Fix AvailableCapacity size computation for LVM
### Issue #280 

Add SubtractLVMMetadataSize function, which allows to correctly calculate capacity which will be available after LVM creation (when default Metadata and PE size used)

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
