### PR TITLE
[ISSUE-254] CSI: ReservationHelper: duplicate metrics collector registration attempted

### DIFF
--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -31,27 +31,18 @@ import (
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/base/util"
 	"github.com/dell/csi-baremetal/pkg/metrics"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/dell/csi-baremetal/pkg/metrics/common"
 )
 
 // NewReservationHelper returns new instance of ReservationHelper
 func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
 	capReader CapacityReader, resReader ReservationReader) *ReservationHelper {
-	acMetrics := metrics.NewMetrics(prometheus.HistogramOpts{
-		Name:    "ac_reservation_duration",
-		Help:    "AvailableCapacity reservation duration",
-		Buckets: prometheus.ExponentialBuckets(0.005, 1.5, 10),
-	}, "method")
-	if err := prometheus.Register(acMetrics.Collect()); err != nil {
-		logger.WithField("component", "NewReservationHelper").
-			Errorf("Failed to register metric: %v", err)
-	}
 	return &ReservationHelper{
 		logger:    logger,
 		client:    client,
 		resReader: resReader,
 		capReader: capReader,
-		metric:    acMetrics,
+		metric:    common.ReservationDuration,
 	}
 }
 

--- a/pkg/metrics/common/ac_reservation.go
+++ b/pkg/metrics/common/ac_reservation.go
@@ -1,0 +1,33 @@
+/*
+Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"github.com/dell/csi-baremetal/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var ReservationDuration = metrics.NewMetrics(prometheus.HistogramOpts{
+	Name:    "ac_reservation_duration",
+	Help:    "AvailableCapacity reservation duration",
+	Buckets: prometheus.ExponentialBuckets(0.005, 1.5, 10),
+}, "method")
+
+// nolint: gochecknoinits
+func init() {
+	prometheus.MustRegister(ReservationDuration.Collect())
+}

--- a/pkg/metrics/common/ac_reservation.go
+++ b/pkg/metrics/common/ac_reservation.go
@@ -17,8 +17,9 @@ limitations under the License.
 package common
 
 import (
-	"github.com/dell/csi-baremetal/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/dell/csi-baremetal/pkg/metrics"
 )
 
 // ReservationDuration used to collect ReservationHelper methods durations

--- a/pkg/metrics/common/ac_reservation.go
+++ b/pkg/metrics/common/ac_reservation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// ReservationDuration used to collect ReservationHelper methods durations
 var ReservationDuration = metrics.NewMetrics(prometheus.HistogramOpts{
 	Name:    "ac_reservation_duration",
 	Help:    "AvailableCapacity reservation duration",

--- a/pkg/metrics/common/kubeclient.go
+++ b/pkg/metrics/common/kubeclient.go
@@ -17,8 +17,9 @@ limitations under the License.
 package common
 
 import (
-	"github.com/dell/csi-baremetal/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/dell/csi-baremetal/pkg/metrics"
 )
 
 // KubeclientDuration used to collect durations of k8s api calls


### PR DESCRIPTION
## Purpose
### Issue https://github.com/dell/csi-baremetal/issues/254

Initialization of `metrics.Metrics` is removed from `ReservationHelper` construct method to common class. Now `prometheus.Register()` is called only one time in `init()` function.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
