### PR TITLE
[ISSUE-134] Fix issue with loopback devices cleanup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -142,7 +142,7 @@ make kind-pull-images TAG=${CSI_VERSION} REGISTRY=${REGISTRY}
 make kind-tag-images TAG=${CSI_VERSION} REGISTRY=${REGISTRY}
 make kind-load-images TAG=${CSI_VERSION} REGISTRY=${REGISTRY}
 ```
-* E2E tests need yaml files with baremetal-csi resources (plugin, controller, rbac). To create yaml files use helm command:
+* E2E tests need yaml files with csi-baremetal resources (plugin, controller, rbac). To create yaml files use helm command:
 ```
 helm template charts/csi-baremetal-driver \
     --output-dir /tmp --set image.tag=${CSI_VERSION} \
@@ -160,7 +160,7 @@ metadata:
   namespace: default
   name: loopback-config
   labels:
-    app: baremetal-csi-node
+    app: csi-baremetal-node
 data:
   config.yaml: |-
     defaultDrivePerNodeCount: 8

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,10 +73,10 @@ Installation process
 Usage
 ------
  
-Use `baremetal-csi-sc` storage class for PVC in PVC manifest or in persistentVolumeClaimTemplate section if you need to 
+Use `csi-baremetal-sc` storage class for PVC in PVC manifest or in persistentVolumeClaimTemplate section if you need to 
 provision PV bypassing LVM. Size of the resulting PV will be equal to the size of underlying physical drive.
 
-Use `baremetal-csi-sc-hddlvg` or `baremetal-csi-sc-ssdlvg` storage classes for PVC in PVC manifest or in 
+Use `csi-baremetal-sc-hddlvg` or `csi-baremetal-sc-ssdlvg` storage classes for PVC in PVC manifest or in 
 persistentVolumeClaimTemplate section if you need to provision PVC based on the logical volume. Size of the resulting PV
 will be equal to the size of PVC.
 

--- a/docs/proposals/node_replacement.md
+++ b/docs/proposals/node_replacement.md
@@ -18,7 +18,7 @@ Node UI is reported as part of Topology struct during [NodeGetInfo](https://gith
 ```
 topology := csi.Topology{
         Segments: map[string]string{
-            "baremetal-csi/nodeid": s.nodeID,
+            "csi-baremetal/nodeid": s.nodeID,
         },
 }
 ```
@@ -28,7 +28,7 @@ Node ID also is being used as a marker for topology constraints during CreateVol
 .........................
 Node Affinity:    
   Required Terms: 
-    Term 0:        baremetal-csi/nodeid in [567a2c26-6124-49ff-b950-eaabc2a50c6e]
+    Term 0:        csi-baremetal/nodeid in [567a2c26-6124-49ff-b950-eaabc2a50c6e]
 ```
 
 In other words if some PV had been provisioned on some NODE_A and is used by POD_X, then POD_X could be scheduled only on NODE_A.

--- a/test/e2e/scenarios/bare-metal-testdriver.go
+++ b/test/e2e/scenarios/bare-metal-testdriver.go
@@ -295,7 +295,7 @@ func getNodePodsNames(f *framework.Framework) ([]string, error) {
 	}
 	podsNames := make([]string, 0)
 	for _, pod := range pods.Items {
-		if strings.Contains(pod.Name, "baremetal-csi-node") {
+		if strings.Contains(pod.Name, "csi-baremetal-node") {
 			podsNames = append(podsNames, pod.Name)
 		}
 	}

--- a/test/e2e/scenarios/controller-node-fail.go
+++ b/test/e2e/scenarios/controller-node-fail.go
@@ -86,7 +86,7 @@ func controllerNodeFailTest(driver testsuites.TestDriver) {
 		deployment, err := f.ClientSet.AppsV1().Deployments(ns).Get(ControllerName, metav1.GetOptions{})
 		Expect(deployment).ToNot(BeNil())
 
-		// try to find baremetal-csi-controller pod, expect 1 controller pod
+		// try to find csi-baremetal-controller pod, expect 1 controller pod
 		podList, err := e2edep.GetPodsForDeployment(f.ClientSet, deployment)
 		framework.ExpectNoError(err)
 		Expect(podList).ToNot(BeNil())

--- a/test/e2e/scenarios/drive-health-change.go
+++ b/test/e2e/scenarios/drive-health-change.go
@@ -48,7 +48,7 @@ var (
 	pvcName = "baremetal-csi-pvc"
 )
 
-// DefineDriveHealthChangeTestSuite defines custom baremetal-csi e2e tests
+// DefineDriveHealthChangeTestSuite defines custom csi-baremetal e2e tests
 func DefineDriveHealthChangeTestSuite(driver testsuites.TestDriver) {
 	ginkgo.Context("Baremetal-csi drive health change tests", func() {
 		// It consists of two steps.

--- a/test/e2e/scenarios/node-reboot.go
+++ b/test/e2e/scenarios/node-reboot.go
@@ -32,7 +32,7 @@ import (
 	"github.com/dell/csi-baremetal/test/e2e/common"
 )
 
-// DefineNodeRebootTestSuite defines custom baremetal-csi node reboot test
+// DefineNodeRebootTestSuite defines custom csi-baremetal node reboot test
 func DefineNodeRebootTestSuite(driver testsuites.TestDriver) {
 	ginkgo.Context("Baremetal-csi node reboot test", func() {
 		defineNodeRebootTest(driver)

--- a/test/e2e/scenarios/stress-test.go
+++ b/test/e2e/scenarios/stress-test.go
@@ -36,7 +36,7 @@ import (
 
 var stsName = "stress-test-sts"
 
-// DefineStressTestSuite defines custom baremetal-csi stress test
+// DefineStressTestSuite defines custom csi-baremetal stress test
 func DefineStressTestSuite(driver testsuites.TestDriver) {
 	ginkgo.Context("Baremetal-csi stress test", func() {
 		// Test scenario:


### PR DESCRIPTION
## Purpose
### Issue #134 

CSI renaming caused regression for the following CI tests:
```
CSI Suite.[sig-storage] CSI Volumes [Driver: csi-baremetal] Baremetal-csi driver different SCs tests should create Pod with PVC with SSD type
CSI Suite.[sig-storage] CSI Volumes [Driver: csi-baremetal] Baremetal-csi driver scheduling tests Scheduler should respect SC
```

RCA: `CleanupLoopbackDevices` still looking for `baremetal-csi-node` pods to cleanup loopback devices from previous tests.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Custom CI passed
