### PR TITLE
[ISSUE-308] kernel version choice

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -25,9 +25,10 @@ download-grpc-health-probe:
 # NOTE: Output directory for binary file should be in Docker context.
 # So we can't use csi-baremetal/build to build the image.
 base-image-node: download-grpc-health-probe
-	cp ./pkg/${NODE}/Dockerfile.build ./build/${NODE}/
+	cp ./pkg/${NODE}/Dockerfile* ./build/${NODE}/
 	cp ./build/${HEALTH_PROBE} ./build/${NODE}/
 	docker build --network host --file ./build/${NODE}/Dockerfile.build --tag ${NODE}:base ./build/${NODE}
+	docker build --network host --file ./build/${NODE}/Dockerfile-kernel-5.4.build --tag ${NODE}:base-kernel-5.4 ./build/${NODE}
 
 base-image-controller: download-grpc-health-probe
 	cp ./pkg/${CONTROLLER}/Dockerfile.build ./build/${CONTROLLER}/
@@ -39,8 +40,9 @@ image-drivemgr: base-image-drivemgr
 	docker build --network host --force-rm --tag ${REGISTRY}/${PROJECT}-${DRIVE_MANAGER_TYPE}:${TAG} ./build/${DRIVE_MANAGER}/${DRIVE_MANAGER_TYPE}
 
 image-node: base-image-node
-	cp ./pkg/${NODE}/Dockerfile ./build/${NODE}/
+	cp ./pkg/${NODE}/Dockerfile* ./build/${NODE}/
 	docker build --network host --force-rm --tag ${REGISTRY}/${PROJECT}-${NODE}:${TAG} ./build/${NODE}
+	docker build --network host --force-rm  --file ./build/${NODE}/Dockerfile-kernel-5.4 --tag ${REGISTRY}/${PROJECT}-${NODE}-kernel-5.4:${TAG} ./build/${NODE}
 
 image-controller: base-image-controller
 	cp ./pkg/${CONTROLLER}/Dockerfile ./build/${CONTROLLER}/
@@ -79,6 +81,7 @@ push-drivemgr:
 
 push-node:
 	docker push ${REGISTRY}/${PROJECT}-${NODE}:${TAG}
+	docker push ${REGISTRY}/${PROJECT}-${NODE}-kernel-5.4:${TAG}
 
 push-controller:
 	docker push ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG}
@@ -111,6 +114,7 @@ clean-image-drivemgr:
 
 clean-image-node:
 	docker rmi ${REGISTRY}/${PROJECT}-${NODE}:${TAG}
+	docker rmi ${REGISTRY}/${PROJECT}-${NODE}-kernel-5.4:${TAG}
 
 clean-image-controller:
 	docker rmi ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG}

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -51,6 +51,7 @@ test-sanity:
 kind-pull-images: kind-pull-sidecar-images
 	docker pull ${REGISTRY}/${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${NODE}:${TAG}
+	docker pull ${REGISTRY}/${PROJECT}-${NODE}-kernel-5.4:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${SCHEDULER}-${EXTENDER}:${TAG}
 	docker pull ${REGISTRY}/${PROJECT}-${EXTENDER_PATCHER}:${TAG}
@@ -76,6 +77,7 @@ kind-tag-images:
 	docker tag ${REGISTRY}/library/nginx:1.14-alpine docker.io/library/nginx:1.14-alpine
 	docker tag ${REGISTRY}/${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG} ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${NODE}:${TAG} ${PROJECT}-${NODE}:${TAG}
+	docker tag ${REGISTRY}/${PROJECT}-${NODE}-kernel-5.4:${TAG} ${PROJECT}-${NODE}-kernel-5.4:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${CONTROLLER}:${TAG} ${PROJECT}-${CONTROLLER}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${SCHEDULER}-${EXTENDER}:${TAG} ${PROJECT}-${SCHEDULER}-${EXTENDER}:${TAG}
 	docker tag ${REGISTRY}/${PROJECT}-${EXTENDER_PATCHER}:${TAG} ${PROJECT}-${EXTENDER_PATCHER}:${TAG}
@@ -92,6 +94,7 @@ kind-load-images:
 	kind load docker-image docker.io/library/nginx:1.14-alpine
 	kind load docker-image ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
 	kind load docker-image ${PROJECT}-${NODE}:${TAG}
+	kind load docker-image ${PROJECT}-${NODE}-kernel-5.4:${TAG}
 	kind load docker-image ${PROJECT}-${CONTROLLER}:${TAG}
 	kind load docker-image ${PROJECT}-${SCHEDULER}-${EXTENDER}:${TAG}
 	kind load docker-image ${PROJECT}-${EXTENDER_PATCHER}:${TAG}

--- a/charts/csi-baremetal-driver/templates/node.yaml
+++ b/charts/csi-baremetal-driver/templates/node.yaml
@@ -18,9 +18,12 @@ spec:
         prometheus.io/port: '{{ .Values.node.metrics.port }}'
         prometheus.io/path: '{{ .Values.node.metrics.path }}'
     spec:
-      {{- if or (.Values.nodeSelector.key) (.Values.nodeSelector.value)}}
       nodeSelector:
-        {{.Values.nodeSelector.key}}: {{.Values.nodeSelector.value}}
+      {{- if or (.Values.nodeSelector.key) (.Values.nodeSelector.value) }}
+        {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value }}
+      {{- end }}
+      {{- if .Values.kernel.version }}
+        nodes.csi-baremetal.dell.com/kernel-version: {{ .Values.kernel.version }}
       {{- end }}
       hostIPC: True
       serviceAccountName: csi-node-sa
@@ -57,8 +60,8 @@ spec:
             mountPath: /registration
       # ********************** csi-baremetal-node container definition **********************
       - name: node
-        image: {{- if .Values.env.test }} csi-baremetal-node:{{ default .Values.image.tag .Values.node.image.tag }}
-               {{- else }} {{ .Values.global.registry }}/csi-baremetal-node:{{ default .Values.image.tag .Values.node.image.tag }}
+        image: {{- if .Values.env.test }} csi-baremetal-node{{ if .Values.kernel.version }}-kernel-{{ .Values.kernel.version }}{{ end }}:{{ default .Values.image.tag .Values.node.image.tag }}
+               {{- else }} {{ .Values.global.registry }}/csi-baremetal-node{{ if .Values.kernel.version }} -kernel{{ .Values.kernel.version }} {{ end }}:{{ default .Values.image.tag .Values.node.image.tag }}
               {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:

--- a/charts/csi-baremetal-driver/templates/node.yaml
+++ b/charts/csi-baremetal-driver/templates/node.yaml
@@ -23,7 +23,7 @@ spec:
         {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value }}
       {{- end }}
       {{- if .Values.kernel.version }}
-        nodes.csi-baremetal.dell.com/kernel-version: {{ .Values.kernel.version }}
+        nodes.csi-baremetal.dell.com/kernel-version: '{{ .Values.kernel.version }}'
       {{- end }}
       hostIPC: True
       serviceAccountName: csi-node-sa

--- a/charts/csi-baremetal-driver/values.yaml
+++ b/charts/csi-baremetal-driver/values.yaml
@@ -15,6 +15,11 @@ nodeSelector:
   key:
   value:
 
+# to deploy on the nodes with specific the kernel version
+# kubectl get nodes -l nodes.csi-baremetal.dell.com/kernel-version=<version>
+kernel:
+  version:
+
 # logging settings
 log:
   format: text

--- a/charts/csi-baremetal-driver/values.yaml
+++ b/charts/csi-baremetal-driver/values.yaml
@@ -1,8 +1,10 @@
 # Docker registry to pull images
 global:
+  # todo remove reference to private registry https://github.com/dell/csi-baremetal/issues/310
   registry: asdrepo.isus.emc.com:9042
 
 env:
+  # todo get rid of this variable and use registry instead https://github.com/dell/csi-baremetal/issues/310
  test: false
  mountHostRoot: true
 

--- a/pkg/base/util/parser.go
+++ b/pkg/base/util/parser.go
@@ -49,7 +49,7 @@ func GetOSNameAndVersion(osInfo string) (name, version string, err error) {
 
 // GetKernelVersion receives string with the kernel version information in the following format:
 // "X.Y.Z-<Number>-<Description>". For example, "5.4.0-66-generic"
-// returns kernel version - major, minor and patch. For example, "5.4.0"
+// returns kernel version - major and minor. For example, "5.4"
 func GetKernelVersion(kernelVersion string) (version string, err error) {
 	// check input parameter
 	if len(kernelVersion) == 0 {
@@ -57,7 +57,7 @@ func GetKernelVersion(kernelVersion string) (version string, err error) {
 	}
 
 	// extract kernel version - x.y.z
-	version = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+`).FindString(kernelVersion)
+	version = regexp.MustCompile(`^[0-9]+\.[0-9]+`).FindString(kernelVersion)
 	if len(version) == 0 {
 		return "", errTypes.ErrorFailedParsing
 	}

--- a/pkg/base/util/parser_test.go
+++ b/pkg/base/util/parser_test.go
@@ -65,20 +65,20 @@ func TestGetKernelVersion(t *testing.T) {
 	assert.Equal(t, version, "")
 
 	// ubuntu 19
-	kernel := "5.4.0"
-	version, err = GetKernelVersion(kernel + "-66-generic")
+	kernel := "5.4"
+	version, err = GetKernelVersion(kernel + ".0-66-generic")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, version, kernel)
 
 	// ubuntu 18
-	kernel = "4.15.0"
-	version, err = GetKernelVersion(kernel + "-76-generic")
+	kernel = "4.15"
+	version, err = GetKernelVersion(kernel + ".0-76-generic")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, version, kernel)
 
 	// rhel coreos 4.6
-	kernel = "4.18.0"
-	version, err = GetKernelVersion(kernel + "-193.41.1.el8_2.x86_64")
+	kernel = "4.18"
+	version, err = GetKernelVersion(kernel + ".0-193.41.1.el8_2.x86_64")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, version, kernel)
 }

--- a/pkg/crcontrollers/operator/controller_test.go
+++ b/pkg/crcontrollers/operator/controller_test.go
@@ -64,7 +64,7 @@ var (
 
 	osName    = "ubuntu"
 	osVersion = "18.04"
-	kernelVersion = "4.15.0"
+	kernelVersion = "4.15"
 	testNode1 = coreV1.Node{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:        "node-1",
@@ -427,7 +427,7 @@ func Test_checkAnnotationAndLabels(t *testing.T) {
 			currentOsVersionLabelValue: osVersion,
 			targetOsVersionLabelValue:  "19.10",
 			currentKernelVersionLabelValue: kernelVersion,
-			targetKernelVersionLabelValue: "5.4.0",
+			targetKernelVersionLabelValue: "5.4",
 		},
 	}
 

--- a/pkg/node/Dockerfile-kernel-5.4
+++ b/pkg/node/Dockerfile-kernel-5.4
@@ -1,0 +1,9 @@
+FROM    node:base-kernel-5.4
+
+LABEL   description="Bare-metal CSI Node Service"
+
+ADD     node  node
+
+EXPOSE  9999
+
+ENTRYPOINT ["/node"]

--- a/pkg/node/Dockerfile-kernel-5.4.build
+++ b/pkg/node/Dockerfile-kernel-5.4.build
@@ -1,0 +1,7 @@
+FROM    ubuntu:20.04
+
+ADD     health_probe    health_probe
+
+RUN     apt update --no-install-recommends -y -q; apt install --no-install-recommends -y -q curl util-linux parted xfsprogs lvm2 gdisk strace udev net-tools
+
+

--- a/test/app/nginx.yaml
+++ b/test/app/nginx.yaml
@@ -4,7 +4,7 @@ metadata:
   name: web
 spec:
   serviceName: "nginx"
-  replicas: 1
+  replicas: 2
   podManagementPolicy: Parallel
   selector:
     matchLabels:


### PR DESCRIPTION
## Purpose
### Issue #308 

Ability to deploy CSI with the new node selector based on node kernel version and pick the right image for csi-node service:
```
helm install csi-baremetal-driver charts/csi-baremetal-driver --set kernel.version=5.4 ...
```

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Tested deployment locally:
```
ubuntu:/workspace/csi-baremetal$ kubectl describe pod csi-baremetal-node-5plht | grep Image:
    Image:         csi-node-driver-registrar:v1.0.1-gke.0
    Image:         csi-baremetal-node-kernel-5.4:0.0.13-372.44ef5e4
    Image:         csi-baremetal-loopbackmgr:0.0.13-372.44ef5e4
    Image:         livenessprobe:v2.1.0
```
