### PR TITLE
[ISSUE-312] Add deployment based on os kernel version

### DIFF
--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -120,4 +120,6 @@ const (
 
 	LocateStatusOn  = int32(1)
 	LocateStatusOff = int32(0)
+
+	DockerImageKernelVersion = "5.4"
 )

--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -24,7 +24,7 @@ const (
 	DriveKind                        = "Drive"
 	CSIBMNodeKind                    = "Node"
 
-	Version = "v1"
+	Version            = "v1"
 	CSICRsGroupVersion = "csi-baremetal.dell.com"
 	APIV1Version       = "csi-baremetal.dell.com/v1"
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dell/csi-baremetal/api/v1/nodecrd"
 	"github.com/dell/csi-baremetal/pkg/base"
+	"github.com/dell/csi-baremetal/pkg/base/command"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/common"
 	"github.com/dell/csi-baremetal/pkg/crcontrollers/operator"
@@ -71,7 +72,7 @@ func main() {
 		observer  common.Observer
 	)
 	if *deploy && *version != "" {
-		installer = common.NewCSIInstaller(*version, *drivemgr, kubeClient, logger)
+		installer = common.NewCSIInstaller(*version, *drivemgr, kubeClient, command.NewExecutor(logger), logger)
 		observer = installer
 		logger.Info("Install CSI with helm")
 		go func() {

--- a/pkg/common/installer.go
+++ b/pkg/common/installer.go
@@ -83,8 +83,7 @@ func (c *CSIInstaller) install(ctx context.Context) error {
 		ll.Infof("Receive kernel version: %s", version)
 		return c.installWithHelm(version)
 	case <-ctx.Done():
-		ll.Info("Context is done, install without kernel version")
-		return c.installWithHelm("")
+		return fmt.Errorf("context is done: %v", ctx.Err())
 	}
 }
 
@@ -92,10 +91,7 @@ func (c *CSIInstaller) install(ctx context.Context) error {
 // Receive string
 // Return error
 func (c *CSIInstaller) installWithHelm(kernelVersion string) error {
-	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, c.version, c.drivemgr)
-	if kernelVersion != "" {
-		cmd = fmt.Sprintf(HelmInstallCSICmdTmpl, c.version, c.drivemgr) + fmt.Sprintf(KernelValue, kernelVersion)
-	}
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, c.version, c.drivemgr) + fmt.Sprintf(KernelValue, kernelVersion)
 	executor := command.NewExecutor(c.log.Logger)
 	if _, _, err := executor.RunCmd(cmd); err != nil {
 		return err

--- a/pkg/common/installer.go
+++ b/pkg/common/installer.go
@@ -94,7 +94,7 @@ func (c *CSIInstaller) install(ctx context.Context) error {
 	}
 }
 
-// installWithHelm tris to install helm with kernel version or without it if parameter kernelVersion is empty
+// installWithHelm tries to install helm with kernel version
 // Receive string
 // Return error
 func (c *CSIInstaller) installWithHelm(kernelVersion string) error {

--- a/pkg/common/installer.go
+++ b/pkg/common/installer.go
@@ -1,0 +1,104 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/dell/csi-baremetal/pkg/base/command"
+	"github.com/dell/csi-baremetal/pkg/base/k8s"
+)
+
+const (
+	// HelmInstallCSICmdTmpl is a template for helm command
+	HelmInstallCSICmdTmpl = "helm install csi-baremetal /csi-baremetal-driver --set image.tag=%s --set drivemgr.type=%s"
+	// KernelValue is csi driver kernel version value in charts
+	KernelValue = " --set kernel.version=%s"
+)
+
+// Observer is an interface encapsulated method for notification
+type Observer interface {
+	Notify(string)
+}
+
+// CSIInstaller represents CSI installation process with helm
+type CSIInstaller struct {
+	version    string
+	drivemgr   string
+	updated    chan string
+	kubeClient *k8s.KubeClient
+	log        *logrus.Entry
+	sync.Once
+}
+
+// NewCSIInstaller is a constructor for CSIInstaller
+func NewCSIInstaller(version string, drivemgr string, kubeClient *k8s.KubeClient, log *logrus.Logger) *CSIInstaller {
+	return &CSIInstaller{
+		version:    version,
+		drivemgr:   drivemgr,
+		kubeClient: kubeClient,
+		updated:    make(chan string),
+		log:        log.WithField("component", "CSIInstaller"),
+	}
+}
+
+// Notify send version to CSIInstaller channel
+// Receive string
+func (c *CSIInstaller) Notify(version string) {
+	c.Do(func() {
+		c.updated <- version
+	})
+}
+
+// Install tries to install CSI in go routine and wait until it send value to error channel
+// Return error
+func (c *CSIInstaller) Install() error {
+	var (
+		ctxWithTimeout, cancel = context.WithTimeout(context.Background(), time.Minute*5)
+		chanErr                = make(chan error)
+	)
+	defer cancel()
+	defer close(chanErr)
+	defer close(c.updated)
+
+	go func() {
+		chanErr <- c.install(ctxWithTimeout)
+	}()
+
+	return <-chanErr
+}
+
+// install waits until value occurs in updated channel or context id done
+// Receive context
+// Return error
+func (c *CSIInstaller) install(ctx context.Context) error {
+	ll := c.log.WithFields(logrus.Fields{
+		"method": "install",
+	})
+	select {
+	case version := <-c.updated:
+		ll.Infof("Receive kernel version: %s", version)
+		return c.installWithHelm(version)
+	case <-ctx.Done():
+		ll.Info("Context is done, install without kernel version")
+		return c.installWithHelm("")
+	}
+}
+
+// installWithHelm tris to install helm with kernel version or without it if parameter kernelVersion is empty
+// Receive string
+// Return error
+func (c *CSIInstaller) installWithHelm(kernelVersion string) error {
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, c.version, c.drivemgr)
+	if kernelVersion != "" {
+		cmd = fmt.Sprintf(HelmInstallCSICmdTmpl, c.version, c.drivemgr) + fmt.Sprintf(KernelValue, kernelVersion)
+	}
+	executor := command.NewExecutor(c.log.Logger)
+	if _, _, err := executor.RunCmd(cmd); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/common/installer_test.go
+++ b/pkg/common/installer_test.go
@@ -1,0 +1,147 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/dell/csi-baremetal/api/v1"
+	"github.com/dell/csi-baremetal/pkg/base/k8s"
+	"github.com/dell/csi-baremetal/pkg/mocks"
+)
+
+func TestCSIInstaller_install_success(t *testing.T) {
+	var (
+		drivemgr = "basemgr"
+		version  = "green"
+		testNS   = "default"
+		logger   = logrus.New()
+		wg       sync.WaitGroup
+	)
+	kubeClient, err := k8s.GetFakeKubeClient(testNS, logger)
+	assert.Nil(t, err)
+	mockExec := &mocks.GoMockExecutor{}
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, version, drivemgr)
+	mockExec.On("RunCmd", cmd).Return("", "", nil)
+	installer := NewCSIInstaller(version, drivemgr, kubeClient, mockExec, logger)
+	wg.Add(1)
+	go func() {
+		err = installer.install(context.Background())
+		wg.Done()
+	}()
+	installer.Notify("4.15")
+	wg.Wait()
+	assert.Nil(t, err)
+}
+
+func TestCSIInstaller_install_failed(t *testing.T) {
+	var (
+		drivemgr = "basemgr"
+		version  = "green"
+		testNS   = "default"
+		logger   = logrus.New()
+		wg       sync.WaitGroup
+	)
+	kubeClient, err := k8s.GetFakeKubeClient(testNS, logger)
+	assert.Nil(t, err)
+	mockExec := &mocks.GoMockExecutor{}
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, version, drivemgr)
+	mockExec.On("RunCmd", cmd).Return("", "", nil)
+	installer := NewCSIInstaller(version, drivemgr, kubeClient, mockExec, logger)
+	wg.Add(1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		err = installer.install(ctx)
+		wg.Done()
+	}()
+	wg.Wait()
+	assert.NotNil(t, err)
+}
+
+func TestCSIInstaller_installWithHelm_success(t *testing.T) {
+	var (
+		drivemgr      = "basemgr"
+		version       = "green"
+		testNS        = "default"
+		logger        = logrus.New()
+		kernelVersion = "4.15"
+	)
+	kubeClient, err := k8s.GetFakeKubeClient(testNS, logger)
+	assert.Nil(t, err)
+	mockExec := &mocks.GoMockExecutor{}
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, version, drivemgr)
+	mockExec.On("RunCmd", cmd).Return("", "", nil).Times(1)
+	installer := NewCSIInstaller(version, drivemgr, kubeClient, mockExec, logger)
+	err = installer.installWithHelm(kernelVersion)
+	assert.Nil(t, err)
+}
+
+func TestCSIInstaller_installWithHelm_success_kernel_image(t *testing.T) {
+	var (
+		drivemgr      = "basemgr"
+		version       = "green"
+		testNS        = "default"
+		logger        = logrus.New()
+		kernelVersion = "5.4"
+	)
+	kubeClient, err := k8s.GetFakeKubeClient(testNS, logger)
+	assert.Nil(t, err)
+	mockExec := &mocks.GoMockExecutor{}
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, version, drivemgr) + fmt.Sprintf(KernelValue, v1.DockerImageKernelVersion)
+	mockExec.On("RunCmd", cmd).Return("", "", nil).Times(1)
+	installer := NewCSIInstaller(version, drivemgr, kubeClient, mockExec, logger)
+	err = installer.installWithHelm(kernelVersion)
+	assert.Nil(t, err)
+}
+
+func TestCSIInstaller_installWithHelm_failed(t *testing.T) {
+	var (
+		drivemgr      = "basemgr"
+		version       = "green"
+		testNS        = "default"
+		logger        = logrus.New()
+		kernelVersion = "4.15"
+	)
+	kubeClient, err := k8s.GetFakeKubeClient(testNS, logger)
+	assert.Nil(t, err)
+	mockExec := &mocks.GoMockExecutor{}
+	cmd := fmt.Sprintf(HelmInstallCSICmdTmpl, version, drivemgr)
+	mockExec.On("RunCmd", cmd).Return("", "", fmt.Errorf("error")).Times(1)
+	installer := NewCSIInstaller(version, drivemgr, kubeClient, mockExec, logger)
+	err = installer.installWithHelm(kernelVersion)
+	assert.NotNil(t, err)
+}
+
+func TestNewCSIInstaller_convertKernelVersion(t *testing.T) {
+	var (
+		test1    = "4"
+		test2    = "4.14"
+		test3    = "5.4.0"
+		drivemgr = "basemgr"
+		version  = "green"
+		logger   = logrus.New()
+	)
+
+	kubeClient, err := k8s.GetFakeKubeClient(testNS, logger)
+	assert.Nil(t, err)
+	installer := NewCSIInstaller(version, drivemgr, kubeClient, &mocks.GoMockExecutor{}, logger)
+	_, err = installer.convertKernelVersion(test1)
+	assert.NotNil(t, err)
+
+	_, err = installer.convertKernelVersion(test1)
+	assert.NotNil(t, err)
+
+	kernelVersion, err := installer.convertKernelVersion(test2)
+	assert.Nil(t, err)
+	assert.Equal(t, 4.14, kernelVersion)
+
+	kernelVersion, err = installer.convertKernelVersion(test3)
+	assert.Nil(t, err)
+	assert.Equal(t, 5.4, kernelVersion)
+}

--- a/pkg/crcontrollers/operator/controller.go
+++ b/pkg/crcontrollers/operator/controller.go
@@ -456,9 +456,9 @@ func (bmc *Controller) updateNodeLabelsAndAnnotation(k8sNode *coreV1.Node, goalV
 			ll.Infof("Setting label %s=%s on node %s", common.NodeKernelVersionLabelKey, version, k8sNode.Name)
 			k8sNode.Labels[common.NodeKernelVersionLabelKey] = version
 			toUpdate = true
-		}
-		if bmc.observer != nil {
-			bmc.observer.Notify(version)
+			if bmc.observer != nil {
+				bmc.observer.Notify(version)
+			}
 		}
 	} else {
 		ll.Errorf("Failed to obtain Kernel version information: %s", err)

--- a/pkg/crcontrollers/operator/controller.go
+++ b/pkg/crcontrollers/operator/controller.go
@@ -39,6 +39,7 @@ import (
 	nodecrd "github.com/dell/csi-baremetal/api/v1/nodecrd"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/base/util"
+	observer "github.com/dell/csi-baremetal/pkg/common"
 	"github.com/dell/csi-baremetal/pkg/crcontrollers/operator/common"
 )
 
@@ -61,8 +62,8 @@ type Controller struct {
 	// it is used in Node CR deletion for avoiding recreation
 	enabledForNode map[string]bool
 	enabledMu      sync.RWMutex
-
-	log *logrus.Entry
+	observer       observer.Observer
+	log            *logrus.Entry
 }
 
 type label struct {
@@ -92,13 +93,14 @@ func (nc *nodesMapping) put(k8sNodeName, bmNodeName string) {
 }
 
 // NewController returns instance of Controller
-func NewController(nodeSelector string, k8sClient *k8s.KubeClient, logger *logrus.Logger) (*Controller, error) {
+func NewController(nodeSelector string, k8sClient *k8s.KubeClient, observer observer.Observer, logger *logrus.Logger) (*Controller, error) {
 	c := &Controller{
 		k8sClient: k8sClient,
 		cache: nodesMapping{
 			k8sToBMNode: make(map[string]string),
 			bmToK8sNode: make(map[string]string),
 		},
+		observer:       observer,
 		enabledForNode: make(map[string]bool, 3), // a little optimization, if cluster has 3 worker nodes this map won't be extended
 		log:            logger.WithField("component", "Controller"),
 	}
@@ -454,6 +456,9 @@ func (bmc *Controller) updateNodeLabelsAndAnnotation(k8sNode *coreV1.Node, goalV
 			ll.Infof("Setting label %s=%s on node %s", common.NodeKernelVersionLabelKey, version, k8sNode.Name)
 			k8sNode.Labels[common.NodeKernelVersionLabelKey] = version
 			toUpdate = true
+		}
+		if bmc.observer != nil {
+			bmc.observer.Notify(version)
 		}
 	} else {
 		ll.Errorf("Failed to obtain Kernel version information: %s", err)

--- a/pkg/crcontrollers/operator/controller_test.go
+++ b/pkg/crcontrollers/operator/controller_test.go
@@ -62,10 +62,10 @@ var (
 		},
 	}
 
-	osName    = "ubuntu"
-	osVersion = "18.04"
+	osName        = "ubuntu"
+	osVersion     = "18.04"
 	kernelVersion = "4.15"
-	testNode1 = coreV1.Node{
+	testNode1     = coreV1.Node{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:        "node-1",
 			Namespace:   testNS,
@@ -93,7 +93,7 @@ func TestNewCSIBMController(t *testing.T) {
 	assert.Nil(t, err)
 
 	t.Run("Node selector is empty", func(t *testing.T) {
-		c, err := NewController("", k8sClient, testLogger)
+		c, err := NewController("", k8sClient, nil, testLogger)
 		assert.Nil(t, err)
 		assert.Nil(t, c.nodeSelector)
 		assert.NotNil(t, c)
@@ -108,7 +108,7 @@ func TestNewCSIBMController(t *testing.T) {
 			value = "value"
 		)
 
-		c, err := NewController("key:value", k8sClient, testLogger)
+		c, err := NewController("key:value", k8sClient, nil, testLogger)
 		assert.Nil(t, err)
 		assert.NotNil(t, c)
 		assert.NotNil(t, c.cache)
@@ -119,7 +119,7 @@ func TestNewCSIBMController(t *testing.T) {
 	})
 
 	t.Run("Node selector is wrong", func(t *testing.T) {
-		c, err := NewController("key:dfdf:value", k8sClient, testLogger)
+		c, err := NewController("key:dfdf:value", k8sClient, nil, testLogger)
 		assert.Nil(t, c)
 		assert.NotNil(t, err)
 	})
@@ -397,37 +397,37 @@ func Test_reconcileForCSIBMNode(t *testing.T) {
 
 func Test_checkAnnotationAndLabels(t *testing.T) {
 	testCases := []struct {
-		description                string
-		currentAnnotationValue     string
-		targetAnnotationValue      string
-		currentOsNameLabelValue    string
-		targetOsNameLabelValue     string
-		currentOsVersionLabelValue string
-		targetOsVersionLabelValue  string
+		description                    string
+		currentAnnotationValue         string
+		targetAnnotationValue          string
+		currentOsNameLabelValue        string
+		targetOsNameLabelValue         string
+		currentOsVersionLabelValue     string
+		targetOsVersionLabelValue      string
 		currentKernelVersionLabelValue string
 		targetKernelVersionLabelValue  string
 	}{
 		{
-			description:                "Node has required annotation and labels",
-			currentAnnotationValue:     "aaaa-bbbb",
-			targetAnnotationValue:      "aaaa-bbbb",
-			currentOsNameLabelValue:    osName,
-			targetOsNameLabelValue:     osName,
-			currentOsVersionLabelValue: osVersion,
-			targetOsVersionLabelValue:  osVersion,
+			description:                    "Node has required annotation and labels",
+			currentAnnotationValue:         "aaaa-bbbb",
+			targetAnnotationValue:          "aaaa-bbbb",
+			currentOsNameLabelValue:        osName,
+			targetOsNameLabelValue:         osName,
+			currentOsVersionLabelValue:     osVersion,
+			targetOsVersionLabelValue:      osVersion,
 			currentKernelVersionLabelValue: kernelVersion,
-			targetKernelVersionLabelValue: kernelVersion,
+			targetKernelVersionLabelValue:  kernelVersion,
 		},
 		{
-			description:                "Node has required annotation and labels with wrong values",
-			currentAnnotationValue:     "aaaa-bbbb",
-			targetAnnotationValue:      "ffff-dddd",
-			currentOsNameLabelValue:    osName,
-			targetOsNameLabelValue:     osName,
-			currentOsVersionLabelValue: osVersion,
-			targetOsVersionLabelValue:  "19.10",
+			description:                    "Node has required annotation and labels with wrong values",
+			currentAnnotationValue:         "aaaa-bbbb",
+			targetAnnotationValue:          "ffff-dddd",
+			currentOsNameLabelValue:        osName,
+			targetOsNameLabelValue:         osName,
+			currentOsVersionLabelValue:     osVersion,
+			targetOsVersionLabelValue:      "19.10",
 			currentKernelVersionLabelValue: kernelVersion,
-			targetKernelVersionLabelValue: "5.4",
+			targetKernelVersionLabelValue:  "5.4",
 		},
 	}
 
@@ -515,7 +515,7 @@ func setup(t *testing.T) *Controller {
 	k8sClient, err := k8s.GetFakeKubeClient(testNS, testLogger)
 	assert.Nil(t, err)
 
-	c, err := NewController("", k8sClient, testLogger)
+	c, err := NewController("", k8sClient, nil, testLogger)
 	assert.Nil(t, err)
 	return c
 }


### PR DESCRIPTION
## Purpose
### Issue #312 

_Describe your changes_

1) Add `CSIInstaller` structure and `Observer` interface
2) `CSIInstaller` implements `Observer` interface
3) `CSIInstaller` contains functions:
* `Notify` receives kernel version and sends it to `updated` channel
* `Install` calls install function in go routine and waits until it returns error value
* `install` waits until  `updated` channel received version or until context is done
* `intallWithHelm` installs CSI using Helm cmd
4) BM controller calls `Notify` when it gets kernel version for node
5) `Install` function is called in operator main 

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
