### PR TITLE
Add image pull secret

### DIFF
--- a/charts/csi-baremetal-driver/templates/controller.yaml
+++ b/charts/csi-baremetal-driver/templates/controller.yaml
@@ -26,6 +26,10 @@ spec:
           {{.Values.nodeSelector.key}}: {{.Values.nodeSelector.value}}
       {{- end }}
       serviceAccount: csi-controller-sa
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       containers:
       # ********************** EXTERNAL-PROVISIONER sidecar container definition **********************

--- a/charts/csi-baremetal-driver/templates/node.yaml
+++ b/charts/csi-baremetal-driver/templates/node.yaml
@@ -27,6 +27,10 @@ spec:
       {{- end }}
       hostIPC: True
       serviceAccountName: csi-node-sa
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+       - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       containers:
       # ********************** DRIVER-REGISTRAR sidecar container definition **********************

--- a/charts/csi-baremetal-driver/values.yaml
+++ b/charts/csi-baremetal-driver/values.yaml
@@ -1,6 +1,7 @@
 # Docker registry to pull images
 global:
   registry: docker.io/objectscale
+  registrySecret:
 
 env:
   # todo get rid of this variable and use registry instead https://github.com/dell/csi-baremetal/issues/310

--- a/charts/csi-baremetal-operator/templates/csibm-controller.yaml
+++ b/charts/csi-baremetal-operator/templates/csibm-controller.yaml
@@ -14,6 +14,10 @@ spec:
         app: csi-operator
     spec:
       serviceAccount: csi-operator-sa
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       {{- if .Values.csi.deploy }}
       tolerations:

--- a/charts/csi-baremetal-operator/values.yaml
+++ b/charts/csi-baremetal-operator/values.yaml
@@ -1,3 +1,6 @@
+global:
+  registrySecret:
+
 image:
   registry: docker.io/objectscale
   tag: 0.0.13-376.008bda2

--- a/charts/csi-baremetal-scheduler-extender/templates/scheduler-extender.yaml
+++ b/charts/csi-baremetal-scheduler-extender/templates/scheduler-extender.yaml
@@ -18,6 +18,10 @@ spec:
         prometheus.io/path: '{{ .Values.metrics.path }}'
     spec:
       serviceAccountName: csi-baremetal-extender-sa
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       containers:
         - name: extender
           image: {{- if .Values.env.test }} csi-baremetal-scheduler-extender:{{ .Values.image.tag }}

--- a/charts/csi-baremetal-scheduler-extender/values.yaml
+++ b/charts/csi-baremetal-scheduler-extender/values.yaml
@@ -1,3 +1,6 @@
+global:
+  registrySecret:
+
 # Docker registry to pull images
 registry: docker.io/objectscale
 

--- a/charts/csi-baremetal-scheduler/templates/scheduler.yaml
+++ b/charts/csi-baremetal-scheduler/templates/scheduler.yaml
@@ -22,6 +22,10 @@ spec:
         version: second
     spec:
       serviceAccountName: csi-baremetal-scheduler-sa
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       containers:
         - name: scheduler
           args:

--- a/charts/csi-baremetal-scheduler/values.yaml
+++ b/charts/csi-baremetal-scheduler/values.yaml
@@ -1,3 +1,6 @@
+global:
+  registrySecret:
+
 # Docker registry to pull images
 registry: docker.io/objectscale
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,29 +42,33 @@ Installation process
     
     1.4. *kubectl*
 
-2. Deploy CSI driver
+2. Create Docker registry pull secret
+
+    ```kubectl create secret docker-registry objectscale-registry --docker-server=docker.io/objectscale --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL```
+
+3. Deploy CSI driver
         
-    2.1 Deploy CSI Node Operator 
+    3.1 Deploy CSI Node Operator 
     
-    ```helm install csi-baremetal-operator charts/csi-baremetal-operator```
+    ```helm install csi-baremetal-operator charts/csi-baremetal-operator --set global.registrySecret=objectscale-registry```
     
-    2.2 Deploy CSI Driver
+    3.2 Deploy CSI Driver
     
-    ```helm install csi-baremetal-driver charts/csi-baremetal-driver --set drivemgr.type=halmgr```
+    ```helm install csi-baremetal-driver charts/csi-baremetal-driver --set drivemgr.type=halmgr --set global.registrySecret=objectscale-registry```
     
-    2.3 Deploy Kubernetes scheduler extender
+    3.3 Deploy Kubernetes scheduler extender
     
     * Vanilla Kubernetes
     
-    ```helm install csi-baremetal-scheduler-extender charts/csi-baremetal-scheduler-extender --set patcher.enable=true```
+    ```helm install csi-baremetal-scheduler-extender charts/csi-baremetal-scheduler-extender --set patcher.enable=true --set global.registrySecret=objectscale-registry```
     
     * OpenShift
     
-    ```helm install csi-baremetal-scheduler-extender charts/csi-baremetal-scheduler-extender```
+    ```helm install csi-baremetal-scheduler-extender charts/csi-baremetal-scheduler-extender --set global.registrySecret=objectscale-registry```
     
     ```pkg/scheduler/patcher/openshift_patcher.sh --install```
     
-3. Check default storage classes available
+4. Check default storage classes available
 
     ```kubectl get storageclasses```
 


### PR DESCRIPTION
## Purpose
### Issue #333 

Image pull secret for dockehub to avoid pull limits 

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
helm install csi-baremetal-operator charts/csi-baremetal-operator --set global.registrySecret=csi-registry
helm install csi-baremetal-driver charts/csi-baremetal-driver --set global.registrySecret=csi-registry --set drivemgr.type=halmgr
helm install csi-baremetal-scheduler-extender charts/csi-baremetal-scheduler-extender --set global.registrySecret=csi-registry --set patcher.enable=true
kubectl get pods
NAME                                        READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-8694654559-gtfv6   4/4     Running   0          9m21s
csi-baremetal-node-hh2st                    4/4     Running   0          9m21s
csi-baremetal-node-jjvkx                    4/4     Running   0          9m21s
csi-baremetal-node-mjrdj                    4/4     Running   0          9m21s
csi-baremetal-node-wc6xv                    4/4     Running   0          9m21s
csi-baremetal-se-patcher-msl7g              1/1     Running   0          7m58s
csi-baremetal-se-s8zlc                      1/1     Running   0          7m58s
csi-operator-7f999cfd7c-cqxsv               1/1     Running   0          11m
```
