### PR TITLE
[ISSUE-375] Release reservation when volume creation stuck or failed

### DIFF
--- a/pkg/base/capacityplanner/helpers.go
+++ b/pkg/base/capacityplanner/helpers.go
@@ -34,11 +34,10 @@ import (
 
 // NewReservationHelper returns new instance of ReservationHelper
 func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
-	capReader CapacityReader, resReader ReservationReader) *ReservationHelper {
+	capReader CapacityReader) *ReservationHelper {
 	return &ReservationHelper{
 		logger:    logger,
 		client:    client,
-		resReader: resReader,
 		capReader: capReader,
 		metric:    common.ReservationDuration,
 	}
@@ -46,21 +45,11 @@ func NewReservationHelper(logger *logrus.Entry, client *k8s.KubeClient,
 
 // ReservationHelper provides methods to create and release reservation
 type ReservationHelper struct {
-	logger  *logrus.Entry
-	client  *k8s.KubeClient
-	updated bool
+	logger *logrus.Entry
+	client *k8s.KubeClient
 
-	resReader ReservationReader
 	capReader CapacityReader
-
-	acList  []accrd.AvailableCapacity
-	acrList []acrcrd.AvailableCapacityReservation
-
-	acMap       ACMap
-	acrMap      ACRMap
-	acNameToACR ACNameToACRNamesMap
-
-	metric metrics.Statistic
+	metric    metrics.Statistic
 }
 
 // UpdateReservation updates reservation CR
@@ -123,7 +112,7 @@ func (rh *ReservationHelper) ReleaseReservation(ctx context.Context, reservation
 }
 
 // Update do a force data update
-func (rh *ReservationHelper) Update(ctx context.Context) error {
+/*func (rh *ReservationHelper) Update(ctx context.Context) error {
 	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.update")
 	var err error
 	rh.acList, err = rh.capReader.ReadCapacity(ctx)
@@ -142,7 +131,7 @@ func (rh *ReservationHelper) Update(ctx context.Context) error {
 	rh.updated = true
 
 	return nil
-}
+}*/
 
 func (rh *ReservationHelper) removeACR(ctx context.Context, acr *acrcrd.AvailableCapacityReservation) error {
 	logger := util.AddCommonFields(ctx, rh.logger, "ReservationHelper.removeACR")
@@ -266,14 +255,14 @@ func buildNodeCapacityMap(acs []accrd.AvailableCapacity) NodeCapacityMap {
 	return capMap
 }
 
-func buildACMap(acs []accrd.AvailableCapacity) ACMap {
+/*func buildACMap(acs []accrd.AvailableCapacity) ACMap {
 	acMap := ACMap{}
 	for _, ac := range acs {
 		ac := ac
 		acMap[ac.Name] = &ac
 	}
 	return acMap
-}
+}*/
 
 func buildACRMaps(acrs []acrcrd.AvailableCapacityReservation) (ACRMap, ACNameToACRNamesMap) {
 	acrMAP := ACRMap{}

--- a/pkg/base/capacityplanner/helpers_test.go
+++ b/pkg/base/capacityplanner/helpers_test.go
@@ -35,7 +35,7 @@ import (
 func TestReservationHelper_CreateReservation(t *testing.T) {
 	logger := testLogger.WithField("component", "test")
 	ctx := context.Background()
-	rh := createReservationHelper(t, logger, nil, nil, getKubeClient(t))
+	rh := createReservationHelper(t, logger, nil, getKubeClient(t))
 	plan := getSimpleVolumePlacingPlan()
 
 	reservation := genV1.AvailableCapacityReservation{}
@@ -88,8 +88,7 @@ func TestReservationHelper_ReleaseReservation(t *testing.T) {
 	client := getKubeClient(t)
 	createACRsInAPi(t, client, reservationList)
 
-	rh := createReservationHelper(t, logger, getCapReaderMock(nil, testErr),
-		getResReaderMock(reservationList, testErr), client)
+	rh := createReservationHelper(t, logger, getCapReaderMock(nil, testErr), client)
 
 	// remove first
 	err := rh.ReleaseReservation(ctx, reservation, 0)
@@ -146,10 +145,9 @@ func checkACRNotExist(t *testing.T, client *k8s.KubeClient, acr *acrcrd.Availabl
 	assert.True(t, k8serrors.IsNotFound(err))
 }
 
-func createReservationHelper(t *testing.T, logger *logrus.Entry,
-	capReader CapacityReader, resReader ReservationReader, client *k8s.KubeClient) *ReservationHelper {
-	return NewReservationHelper(logger,
-		client, capReader, resReader)
+func createReservationHelper(t *testing.T, logger *logrus.Entry, capReader CapacityReader,
+	client *k8s.KubeClient) *ReservationHelper {
+	return NewReservationHelper(logger, client, capReader)
 }
 
 func getKubeClient(t *testing.T) *k8s.KubeClient {

--- a/pkg/base/capacityplanner/mocks.go
+++ b/pkg/base/capacityplanner/mocks.go
@@ -116,7 +116,7 @@ func getCapReaderMock(acList []*accrd.AvailableCapacity, err error) *CapacityRea
 	return capReaderMock
 }
 
-func getResReaderMock(acrList []*acrcrd.AvailableCapacityReservation, err error) *ReservationReaderMock {
+/*func getResReaderMock(acrList []*acrcrd.AvailableCapacityReservation, err error) *ReservationReaderMock {
 	acrListV := make([]acrcrd.AvailableCapacityReservation, len(acrList))
 	for i := 0; i < len(acrList); i++ {
 		acrListV[i] = *acrList[i]
@@ -125,4 +125,4 @@ func getResReaderMock(acrList []*acrcrd.AvailableCapacityReservation, err error)
 	resReaderMock.On("ReadReservations", mock.Anything).Return(
 		acrListV, err)
 	return resReaderMock
-}
+}*/

--- a/pkg/crcontrollers/reservation/reservationcontroller.go
+++ b/pkg/crcontrollers/reservation/reservationcontroller.go
@@ -110,7 +110,7 @@ func (c *Controller) handleReservationUpdate(ctx context.Context, log *logrus.En
 		}
 
 		if len(matchedNodes) != 0 {
-			reservationHelper := capacityplanner.NewReservationHelper(c.log, c.client, acReader, acrReader)
+			reservationHelper := capacityplanner.NewReservationHelper(c.log, c.client, acReader)
 			if err = reservationHelper.UpdateReservation(ctx, placingPlan, matchedNodes, reservation); err != nil {
 				c.log.Errorf("Failed to update reservation: %s", err.Error())
 				return ctrl.Result{Requeue: true}, err

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -229,6 +229,7 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 		// check whether volume Ephemeral or not
 		if v.CSI != nil {
 			if v.CSI.Driver == e.provisioner {
+				// TODO we shouldn't request reservation for inline volumes which already provisioned
 				request, err := e.createCapacityRequest(pod.Name, v)
 				if err != nil {
 					ll.Errorf("Unable to construct API Volume for Ephemeral volume: %v", err)


### PR DESCRIPTION
## Purpose
### Issue #375 

When volume creation stuck or failed scheduler extender can request capacity reservation again and once reserved k8s issues new **_CreateVolume_** eventually. We need to release such reservation to be able to provision new volumes.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Tested manually by failing volume creation. Example for **/dev/loop30**:
````
cp /sbin/mkfs.xfs /sbin/mkfs.xfs.backup
echo -e '#!/bin/bash\nif [[ "$1" == "/dev/loop30p1" ]]; then\n exit 1\nelse\n /sbin/mkfs.xfs.backup $1 \nfi' > /sbin/mkfs.xfs
chmod +x /sbin/mkfs.xfs
````
