### PR TITLE
[ISSUE-426] handling offline drive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
     line-length: 190
   funlen:
     lines: 180
-    statements: 70
+    statements: 80
   gocognit:
     min-complexity: 60
   golint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
     line-length: 190
   funlen:
     lines: 180
-    statements: 80
+    statements: 80 # by ATL-1379. Need to refactor handleDriveUpdate
   gocognit:
     min-complexity: 60
   golint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
     line-length: 190
   funlen:
     lines: 180
-    statements: 80 # by ATL-1379. Need to refactor handleDriveUpdate
+    statements: 80 # must be 70. ISSUE-431. Need to refactor handleDriveUpdate
   gocognit:
     min-complexity: 60
   golint:

--- a/pkg/base/k8s/cr_helper.go
+++ b/pkg/base/k8s/cr_helper.go
@@ -463,6 +463,7 @@ func (cs *CRHelper) UpdateVolumesOpStatusByLocation(ctx context.Context, uuid st
             if err := cs.k8sClient.UpdateCR(ctx, volume); err != nil {
                 cs.log.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
                 return err
+            }
         }
     }
 

--- a/pkg/base/k8s/cr_helper.go
+++ b/pkg/base/k8s/cr_helper.go
@@ -449,23 +449,23 @@ func (cs *CRHelper) DeleteObjectByName(ctx context.Context, name string, namespa
 	return cs.k8sClient.DeleteCR(context.Background(), obj)
 }
 
-// UpdateVolumeCRSpec reads volume CR with name volName and update it's spec to newSpec
+// UpdateVolumesOpStatusByLocation reads volume CR with with location uuid and update operational status to opStatus
 // returns nil or error in case of error
 func (cs *CRHelper) UpdateVolumesOpStatusByLocation(ctx context.Context, uuid string, opStatus string) error {
-    volumes, err := cs.GetVolumesByLocation(ctx, uuid)
-    if err != nil {
-        return err
-    }
+	volumes, err := cs.GetVolumesByLocation(ctx, uuid)
+	if err != nil {
+		return err
+	}
 
-    for _, volume := range volumes {
-    	if volume.Spec.OperationalStatus != opStatus {
-    		volume.Spec.OperationalStatus = opStatus
-            if err := cs.k8sClient.UpdateCR(ctx, volume); err != nil {
-                cs.log.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
-                return err
-            }
-        }
-    }
+	for _, volume := range volumes {
+		if volume.Spec.OperationalStatus != opStatus {
+			volume.Spec.OperationalStatus = opStatus
+			if err := cs.k8sClient.UpdateCR(ctx, volume); err != nil {
+				cs.log.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
+				return err
+			}
+		}
+	}
 
-    return nil
+	return nil
 }

--- a/pkg/base/k8s/cr_helper.go
+++ b/pkg/base/k8s/cr_helper.go
@@ -448,3 +448,23 @@ func (cs *CRHelper) DeleteObjectByName(ctx context.Context, name string, namespa
 
 	return cs.k8sClient.DeleteCR(context.Background(), obj)
 }
+
+// UpdateVolumeCRSpec reads volume CR with name volName and update it's spec to newSpec
+// returns nil or error in case of error
+func (cs *CRHelper) UpdateVolumesOpStatusByLocation(ctx context.Context, uuid string, opStatus string) error {
+    volumes, err := cs.GetVolumesByLocation(ctx, uuid)
+    if err != nil {
+        return err
+    }
+
+    for _, volume := range volumes {
+    	if volume.Spec.OperationalStatus != opStatus {
+    		volume.Spec.OperationalStatus = opStatus
+            if err := cs.k8sClient.UpdateCR(ctx, volume); err != nil {
+                cs.log.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
+                return err
+        }
+    }
+
+    return nil
+}

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -143,8 +143,8 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
             }
 
             for _, vol := range volumes {
-                vol.OperationalStatus = apiV1.OperationalStatusMissing
-                if err := c.client.UpdateCR(ctx, &vol); err != nil {
+                vol.Spec.OperationalStatus = apiV1.OperationalStatusMissing
+                if err := c.client.UpdateCR(ctx, vol); err != nil {
                     log.Errorf("Unable to update operational status for volume ID %s: %s", vol.Spec.Id, err)
             	    return ignore, err
                 }

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -125,7 +125,7 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, drive *drivecrd.Drive, id string) (error) {
+func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, drive *ddrivecrd.Drive) (uint8, error) {
 	// get drive fields
 	status := drive.Spec.GetStatus()
 	usage := drive.Spec.GetUsage()

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -143,13 +143,13 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
             }
 
             for _, vol := range volumes {
-                volume.OperationalStatus = apiV1.OperationalStatusMissing
-                if err := cs.k8sClient.UpdateCR(ctxWithID, &volume); err != nil {
-                    ll.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
-            	    isError = true
+                vol.OperationalStatus = apiV1.OperationalStatusMissing
+                if err := cs.k8sClient.UpdateCR(ctx, &vol); err != nil {
+                    log.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
+            	    return ignore, err
                 }
             }
-            return update, nil
+            return ignore, nil
         }
 	}
 

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -127,13 +127,12 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, drive *drivecrd.Drive) (uint8, error) {
 	// get drive fields
-	status := drive.Spec.GetStatus()
 	usage := drive.Spec.GetUsage()
 	health := drive.Spec.GetHealth()
 	id := drive.Spec.GetUUID()
 
 	// handle offline status
-	if status == apiV1.DriveStatusOffline {
+	if drive.Spec.Status == apiV1.DriveStatusOffline {
 		if err := c.crHelper.UpdateVolumesOpStatusByLocation(ctx, id, apiV1.OperationalStatusMissing); err != nil {
 			return ignore, err
 		}
@@ -216,7 +215,7 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 			toUpdate = true
 		}
 	case apiV1.DriveUsageRemoved:
-		if usage == apiV1.DriveUsageRemoved {
+		if drive.Spec.Status == apiV1.DriveStatusOffline {
 			// drive was removed from the system. need to clean corresponding custom resource
 			return delete, nil
 		}

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -132,11 +132,11 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 	health := drive.Spec.GetHealth()
 	id := drive.Spec.GetUUID()
 
-    // handle offline status
+	// handle offline status
 	if status == apiV1.DriveStatusOffline {
-        if err := c.crHelper.UpdateVolumesOpStatusByLocation(ctx, id, apiV1.OperationalStatusMissing); err != nil {
-            return ignore, err
-        }
+		if err := c.crHelper.UpdateVolumesOpStatusByLocation(ctx, id, apiV1.OperationalStatusMissing); err != nil {
+			return ignore, err
+		}
 	}
 
 	// check whether update is required
@@ -216,11 +216,10 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 			toUpdate = true
 		}
 	case apiV1.DriveUsageRemoved:
-        if usage == apiV1.DriveUsageRemoved {
-            // drive was removed from the system. need to clean corresponding custom resource
-        	return delete, nil
-        }
-        break
+		if usage == apiV1.DriveUsageRemoved {
+			// drive was removed from the system. need to clean corresponding custom resource
+			return delete, nil
+		}
 	}
 
 	if toUpdate {

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -125,7 +125,7 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, drive *ddrivecrd.Drive) (uint8, error) {
+func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, drive *drivecrd.Drive) (uint8, error) {
 	// get drive fields
 	status := drive.Spec.GetStatus()
 	usage := drive.Spec.GetUsage()

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -144,8 +144,8 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 
             for _, vol := range volumes {
                 vol.OperationalStatus = apiV1.OperationalStatusMissing
-                if err := cs.k8sClient.UpdateCR(ctx, &vol); err != nil {
-                    log.Errorf("Unable to update operational status for volume ID %s: %s", volume.Spec.Id, err)
+                if err := c.client.UpdateCR(ctx, &vol); err != nil {
+                    log.Errorf("Unable to update operational status for volume ID %s: %s", vol.Spec.Id, err)
             	    return ignore, err
                 }
             }

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -140,7 +140,6 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 
 	// check whether update is required
 	toUpdate := false
-
 	switch usage {
 	case apiV1.DriveUsageInUse:
 		if health == apiV1.HealthSuspect || health == apiV1.HealthBad {

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -934,7 +934,7 @@ func (m *VolumeManager) handleDriveStatusChange(ctx context.Context, drive *api.
 		// initiate volume release
 		// TODO need to check for specific annotation instead
 		if vol.Spec.Health == apiV1.HealthBad || vol.Spec.Health == apiV1.HealthSuspect {
-			if vol.Spec.UsageUsage == apiV1.VolumeUsageInUse {
+			if vol.Spec.Usage == apiV1.VolumeUsageInUse {
 				vol.Spec.Usage = apiV1.VolumeUsageReleasing
 			}
 		}

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -934,7 +934,7 @@ func (m *VolumeManager) handleDriveStatusChange(ctx context.Context, drive *api.
 		// initiate volume release
 		// TODO need to check for specific annotation instead
 		if vol.Spec.Health == apiV1.HealthBad || vol.Spec.Health == apiV1.HealthSuspect {
-			if vol.Spec.Usage == apiV1.VolumeUsageInUse {
+			if vol.Spec.UsageUsage == apiV1.VolumeUsageInUse {
 				vol.Spec.Usage = apiV1.VolumeUsageReleasing
 			}
 		}


### PR DESCRIPTION
### Issue #426 

Handle OFFLINE drive status. If drive is offline, volume operational status move to MISSING. 

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Manually, disk was removed from system, and Operational status moved to MISSING

```
:~# kubectl describe volume pvc-485b80b1-d088-4616-ac20-90e50354d3a2 | grep Status
        f:CSIStatus:
        f:OperationalStatus:
  CSI Status:          PUBLISHED
  Operational Status:  MISSING
```

