### PR TITLE
[ISSUE-441] Override Drive Health via annotation

### DIFF
--- a/docs/proposals/drive-replacement.md
+++ b/docs/proposals/drive-replacement.md
@@ -64,6 +64,8 @@ Negotiation between CSI and Operator is optional and will be done though annotat
 #### User
 To trigger physical drive replacement user must put the following annotation on the corresponding Drive custom resource:
   - `driveremove.csi-baremetal/replacement: ready` - informs that drive replacement is ready
+
+*User can trigger drive releasing himself. If user annotates driveCR with `health=<SUSPECT/BAD>`, drive health will be overridden with passed value.*
 ### Detailed workflow
 * When drive health changed from `GOOD` to `SUSPECT` or `BAD` CSI will:
   - Set drive operational status to `RELEASING`

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -126,9 +126,6 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, drive *drivecrd.Drive) (uint8, error) {
-	// check whether update is required
-	var toUpdate = false
-
 	// handle offline/online drive status
 	if err := c.handleDriveStatus(ctx, drive); err != nil {
 		return ignore, err
@@ -139,6 +136,8 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 	health := drive.Spec.GetHealth()
 	id := drive.Spec.GetUUID()
 
+	// check whether update is required
+	toUpdate := false
 	switch usage {
 	case apiV1.DriveUsageInUse:
 		if health == apiV1.HealthSuspect || health == apiV1.HealthBad {

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -39,10 +39,6 @@ const (
 	delete uint8 = 2
 )
 
-const (
-	driveHealthOverrideAnnotation = "health"
-)
-
 // NewController creates new instance of Controller structure
 // Receives an instance of base.KubeClient, node ID and logrus logger
 // Returns an instance of Controller
@@ -136,10 +132,6 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 	// handle offline/online drive status
 	if err := c.handleDriveStatus(ctx, drive); err != nil {
 		return ignore, err
-	}
-
-	if isOverrided := c.overrideDriveHealth(drive, log); isOverrided {
-		toUpdate = true
 	}
 
 	// get drive fields
@@ -257,38 +249,6 @@ func (c *Controller) handleDriveStatus(ctx context.Context, drive *drivecrd.Driv
 		}
 	}
 	return nil
-}
-
-func (c *Controller) overrideDriveHealth(drive *drivecrd.Drive, log *logrus.Entry) bool {
-	var (
-		newHealth string
-		oldHealth = drive.Spec.Health
-	)
-	value, ok := drive.Annotations[driveHealthOverrideAnnotation]
-	if !ok {
-		return false
-	}
-
-	switch value {
-	case apiV1.HealthSuspect:
-		newHealth = apiV1.HealthSuspect
-	case apiV1.HealthBad:
-		newHealth = apiV1.HealthBad
-	default:
-		log.Warningf("Drive %s has health annotation, but value %s is not %s or %s. Health is not overrided.", drive.Name, value, apiV1.HealthSuspect, apiV1.HealthBad)
-		return false
-	}
-
-	if newHealth == oldHealth {
-		return false
-	}
-
-	drive.Spec.Health = newHealth
-
-	eventMsg := fmt.Sprintf("Drive health %s is overrided with %s", oldHealth, newHealth)
-	c.eventRecorder.Eventf(drive, eventing.WarningType, eventing.DriveHealthOverrided, eventMsg)
-
-	return true
 }
 
 func (c *Controller) checkAllVolsRemoved(volumes []*volumecrd.Volume) bool {

--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -44,4 +44,5 @@ const (
 	DriveSuccessfullyReplaced = "DriveSuccessfullyReplaced"
 	DriveHasData              = "DriveHasData"
 	DriveClean                = "DriveClean"
+	DriveHealthOverrided      = "DriveHealthOverrided"
 )

--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -44,5 +44,5 @@ const (
 	DriveSuccessfullyReplaced = "DriveSuccessfullyReplaced"
 	DriveHasData              = "DriveHasData"
 	DriveClean                = "DriveClean"
-	DriveHealthOverrided      = "DriveHealthOverrided"
+	DriveHealthOverridden     = "DriveHealthOverridden"
 )

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -68,6 +68,8 @@ const (
 	fakeAttachAnnotation = "pv.attach.kubernetes.io/ignore-if-inaccessible"
 	fakeAttachAllowKey   = "yes"
 
+	// Annotation key for health overriding
+	// Discover function replaces drive health with passed value if the annotation is set
 	driveHealthOverrideAnnotation = "health"
 )
 
@@ -1042,6 +1044,7 @@ func (m *VolumeManager) createEventForDriveStatusChange(
 		statusMsgTemplate, currentStatus, prevStatus)
 }
 
+// createEventForDriveHealthOverridden creates DriveHealthOverridden with Warning type
 func (m *VolumeManager) createEventForDriveHealthOverridden(
 	drive *drivecrd.Drive, realHealth, overriddenHealth string) {
 	msgTemplate := "Drive health is overridden with: %s, real state: %s."
@@ -1157,6 +1160,8 @@ func (m *VolumeManager) isPVCNeedFakeAttach(volumeID string) bool {
 	return false
 }
 
+// overrideDriveHealth replaces drive health with passed value
+// generates error if value is not BAD or SUSPECT
 func (m *VolumeManager) overrideDriveHealth(drive *api.Drive, overriddenHealth, driveCRName string) {
 	if (overriddenHealth == apiV1.HealthSuspect) || (overriddenHealth == apiV1.HealthBad) {
 		drive.Health = overriddenHealth

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1161,7 +1161,7 @@ func (m *VolumeManager) overrideDriveHealth(drive *api.Drive, overriddenHealth, 
 	if (overriddenHealth == apiV1.HealthSuspect) || (overriddenHealth == apiV1.HealthBad) {
 		drive.Health = overriddenHealth
 	} else {
-		m.log.Warningf("Drive %s has health annotation, but value %s is not %s or %s. Health is not overrided.",
+		m.log.Errorf("Drive %s has health annotation, but value %s is not %s or %s. Health is not overridden.",
 			driveCRName, overriddenHealth, apiV1.HealthSuspect, apiV1.HealthBad)
 	}
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -990,6 +990,7 @@ func (m *VolumeManager) createEventsForDriveUpdates(updates *driveUpdates) {
 		}
 		// skip HealthChange event if drive health was overridden
 		if updDrive.CurrentState.Annotations[driveHealthOverrideAnnotation] != updDrive.PreviousState.Annotations[driveHealthOverrideAnnotation] {
+			m.log.Errorf("OVER")
 			m.createEventForDriveHealthOverridden(
 				updDrive.CurrentState, updDrive.PreviousState.Spec.Health, updDrive.CurrentState.Spec.Health)
 			continue

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1160,13 +1160,18 @@ func (m *VolumeManager) isPVCNeedFakeAttach(volumeID string) bool {
 	return false
 }
 
-// overrideDriveHealth replaces drive health with passed value
-// generates error if value is not BAD or SUSPECT
+// overrideDriveHealth replaces drive health with passed value,
+// generates error message if value is not valid
 func (m *VolumeManager) overrideDriveHealth(drive *api.Drive, overriddenHealth, driveCRName string) {
-	if (overriddenHealth == apiV1.HealthSuspect) || (overriddenHealth == apiV1.HealthBad) {
+	if (overriddenHealth == apiV1.HealthGood) ||
+		(overriddenHealth == apiV1.HealthSuspect) ||
+		(overriddenHealth == apiV1.HealthBad) ||
+		(overriddenHealth == apiV1.HealthUnknown) {
+		m.log.Warnf("Drive %s has health annotation. Health %s has been overridden with %s.",
+			driveCRName, drive.Health, overriddenHealth)
 		drive.Health = overriddenHealth
 	} else {
-		m.log.Errorf("Drive %s has health annotation, but value %s is not %s or %s. Health is not overridden.",
-			driveCRName, overriddenHealth, apiV1.HealthSuspect, apiV1.HealthBad)
+		m.log.Errorf("Drive %s has health annotation, but value %s is not %s/%s/%s/%s. Health is not overridden.",
+			driveCRName, overriddenHealth, apiV1.HealthGood, apiV1.HealthSuspect, apiV1.HealthBad, apiV1.HealthUnknown)
 	}
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1159,7 +1159,7 @@ func (m *VolumeManager) isPVCNeedFakeAttach(volumeID string) bool {
 }
 
 func (m *VolumeManager) overrideDriveHealth(drive *api.Drive, overriddenHealth, driveCRName string) {
-	if overriddenHealth == apiV1.HealthSuspect && overriddenHealth == apiV1.HealthBad {
+	if (overriddenHealth == apiV1.HealthSuspect) || (overriddenHealth == apiV1.HealthBad) {
 		drive.Health = overriddenHealth
 	} else {
 		m.log.Warningf("Drive %s has health annotation, but value %s is not %s or %s. Health is not overrided.",

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -989,8 +989,7 @@ func (m *VolumeManager) createEventsForDriveUpdates(updates *driveUpdates) {
 				updDrive.CurrentState, updDrive.PreviousState.Spec.Status, updDrive.CurrentState.Spec.Status)
 		}
 		// skip HealthChange event if drive health was overridden
-		if updDrive.CurrentState.Annotations[driveHealthOverrideAnnotation] != updDrive.PreviousState.Annotations[driveHealthOverrideAnnotation] {
-			m.log.Errorf("OVER")
+		if _, ok := updDrive.CurrentState.Annotations[driveHealthOverrideAnnotation]; ok {
 			m.createEventForDriveHealthOverridden(
 				updDrive.CurrentState, updDrive.PreviousState.Spec.Health, updDrive.CurrentState.Spec.Health)
 			continue

--- a/test/e2e/common/deploy.go
+++ b/test/e2e/common/deploy.go
@@ -103,7 +103,7 @@ func DeployOperator(f *framework.Framework) (func(), error) {
 	return cleanup, nil
 }
 
-// DeployCSIWithArgs deploys csi-baremetal-deployment with CmdHelmExecutor
+// DeployCSI deploys csi-baremetal-deployment with CmdHelmExecutor
 // After install - waiting all pods ready, checking kubernetes-scheduler restart
 // Cleanup - deleting csi-chart, cleaning all csi custom resources
 // Helm command - "helm install csi-baremetal <CHARTS_DIR>/csi-baremetal-deployment


### PR DESCRIPTION
## Purpose
### Issue #441

- Override Drive Health if `health` annotation is set
- Generate event `DriveHealthOverridden`
- Generate event `DriveHealth<>` after deleting annotation

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
```
user@user-vm ~/g/s/g/d/csi-baremetal-operator (master)> kubectl annotate drive 11a64144-c873-435f-b8c5-51aa05268593 health=SUSPECT
drive.csi-baremetal.dell.com/11a64144-c873-435f-b8c5-51aa05268593 annotated

user@user-vm ~/g/s/g/d/csi-baremetal-operator (master)> kubectl get events --sort-by='.lastTimestamp' | grep LOOPBACK2955441738
3m27s       Normal    DriveDiscovered            drive/05bfbccd-0526-4167-8c98-090590f6b67d           New drive discovered SN: LOOPBACK2955441738, Node: 77a7e96c-ee8e-4e35-9110-938686735333.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
3m27s       Normal    DriveHealthGood            drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive health is: GOOD, previous state: UNKNOWN.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
2m27s       Warning   DriveHealthOverridden      drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive health is overridden with: SUSPECT, real state: GOOD.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
2m27s       Normal    DriveReadyForReplacement   drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive is ready for replacement, Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''

user@user-vm ~/g/s/g/d/csi-baremetal-operator (master) [1]> kubectl annotate drive 05bfbccd-0526-4167-8c98-090590f6b67d health-
drive.csi-baremetal.dell.com/05bfbccd-0526-4167-8c98-090590f6b67d annotated

user@user-vm ~/g/s/g/d/csi-baremetal-operator (master)> kubectl get events --sort-by='.lastTimestamp' | grep LOOPBACK2955441738
3m27s       Normal    DriveDiscovered            drive/05bfbccd-0526-4167-8c98-090590f6b67d           New drive discovered SN: LOOPBACK2955441738, Node: 77a7e96c-ee8e-4e35-9110-938686735333.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
3m27s       Normal    DriveHealthGood            drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive health is: GOOD, previous state: UNKNOWN.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
2m27s       Warning   DriveHealthOverridden      drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive health is overridden with: SUSPECT, real state: GOOD.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
2m27s       Normal    DriveReadyForReplacement   drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive is ready for replacement, Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
56s         Normal    DriveHealthGood            drive/05bfbccd-0526-4167-8c98-090590f6b67d           Drive health is: GOOD, previous state: SUSPECT.Drive Details: SN='LOOPBACK2955441738', Node='77a7e96c-ee8e-4e35-9110-938686735333', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
```

