### PR TITLE
[ISSUE-447] Repeat Drive Replacement procedure

### DIFF
--- a/docs/proposals/drive-replacement.md
+++ b/docs/proposals/drive-replacement.md
@@ -67,7 +67,7 @@ To trigger physical drive replacement user must put the following annotation on 
 
 *User can trigger drive releasing himself. If user annotates driveCR with `health=<SUSPECT/BAD>`, drive health will be overridden with passed value.*
 
-*DR procedure can be repeated if drive Usage is `FAILED`. User should annotate driveCR with `removing=restart` and drive-controller will switch Usage value to IN_USE. After restart the annotation will be deleted.* 
+*DR procedure can be repeated if drive Usage is `FAILED` or `RELEASED`. User should annotate driveCR with `replacement=restart` and drive-controller will switch Usage value to IN_USE. After restart the annotation will be deleted.* 
 ### Detailed workflow
 * When drive health changed from `GOOD` to `SUSPECT` or `BAD` CSI will:
   - Set drive operational status to `RELEASING`

--- a/docs/proposals/drive-replacement.md
+++ b/docs/proposals/drive-replacement.md
@@ -66,6 +66,8 @@ To trigger physical drive replacement user must put the following annotation on 
   - `driveremove.csi-baremetal/replacement: ready` - informs that drive replacement is ready
 
 *User can trigger drive releasing himself. If user annotates driveCR with `health=<SUSPECT/BAD>`, drive health will be overridden with passed value.*
+
+*DR procedure can be repeated if drive Usage is `FAILED`. User should annotate driveCR with `removing=restart` and drive-controller will switch Usage value to IN_USE. After restart the annotation will be deleted.* 
 ### Detailed workflow
 * When drive health changed from `GOOD` to `SUSPECT` or `BAD` CSI will:
   - Set drive operational status to `RELEASING`

--- a/docs/proposals/drive-replacement.md
+++ b/docs/proposals/drive-replacement.md
@@ -67,7 +67,7 @@ To trigger physical drive replacement user must put the following annotation on 
 
 *User can trigger drive releasing himself. If user annotates driveCR with `health=<SUSPECT/BAD>`, drive health will be overridden with passed value.*
 
-*DR procedure can be repeated if drive Usage is `FAILED` or `RELEASED`. User should annotate driveCR with `replacement=restart` and drive-controller will switch Usage value to IN_USE. After restart the annotation will be deleted.* 
+*DR procedure can be repeated if drive Usage is `FAILED` or `RELEASED`. User should annotate driveCR with `drive=add` and drive-controller will switch Usage value to IN_USE. After restart the annotation will be deleted.* 
 ### Detailed workflow
 * When drive health changed from `GOOD` to `SUSPECT` or `BAD` CSI will:
   - Set drive operational status to `RELEASING`

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -40,6 +40,7 @@ const (
 )
 
 const (
+	// Annotations for driveCR to perform restart process
 	driveRetryIfFailedAnnotationKey   = "removing"
 	driveRetryIfFailedAnnotationValue = "restart"
 )
@@ -222,7 +223,8 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 			return remove, nil
 		}
 	case apiV1.DriveUsageFailed:
-		//
+		// Restore drive.Usage if CR is annotated
+		// Delete the annotation to avoid event repeating
 		if value, ok := drive.GetAnnotations()[driveRetryIfFailedAnnotationKey]; ok && value == driveRetryIfFailedAnnotationValue {
 			drive.Spec.Usage = apiV1.DriveUsageInUse
 			delete(drive.Annotations, driveRetryIfFailedAnnotationKey)

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -39,6 +39,11 @@ const (
 	delete uint8 = 2
 )
 
+const (
+	driveRetryIfFailedAnnotationKey   = "restart"
+	driveRetryIfFailedAnnotationValue = "yes"
+)
+
 // NewController creates new instance of Controller structure
 // Receives an instance of base.KubeClient, node ID and logrus logger
 // Returns an instance of Controller
@@ -215,6 +220,12 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 		if drive.Spec.Status == apiV1.DriveStatusOffline {
 			// drive was removed from the system. need to clean corresponding custom resource
 			return delete, nil
+		}
+	case apiV1.DriveUsageFailed:
+		//
+		if value, ok := drive.GetAnnotations()[driveRetryIfFailedAnnotationKey]; ok && value == driveRetryIfFailedAnnotationValue {
+			drive.Spec.Usage = apiV1.DriveUsageInUse
+			toUpdate = true
 		}
 	}
 

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -41,8 +41,8 @@ const (
 
 const (
 	// Annotations for driveCR to perform restart process
-	driveRestartReplacementAnnotationKey   = "replacement"
-	driveRestartReplacementAnnotationValue = "restart"
+	driveRestartReplacementAnnotationKey   = "drive"
+	driveRestartReplacementAnnotationValue = "add"
 )
 
 // NewController creates new instance of Controller structure


### PR DESCRIPTION
## Purpose
### Issue #447 

- Reset drive Usage from FAILED or RELEASED to IN_USE if driveCR is annotated with `replacement=restart`
- Delete annotation after restart
- Rename `delete` return code to avoid substitution of build-in function

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
