### PR TITLE
[ISSUE-450] Build custom kind for CI

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -111,22 +111,22 @@ kind-load-images:
 	kind load docker-image ${PROJECT}-${OPERATOR}:${TAG}
 
 prepare-kind:
-    # Get kind sources
+	# Get kind sources
 	wget -O kind-src https://codeload.github.com/kubernetes-sigs/kind/tar.gz/refs/tags/v0.11.1
 	tar -xzvf kind-src
 
-    # Add "--ipc=host" docker option and build binary
+	# Add "--ipc=host" docker option and build binary
 	patch -p0 < test/kind/kind.patch
 	cd kind-0.11.1 && make build
 
-    # Copy executive file
-    rm /usr/bin/kind
+	# Copy executive file
+	rm /usr/bin/kind
 	chmod +x kind-0.11.1/bin/kind
 	mv kind-0.11.1/bin/kind /usr/bin
 
-    # Check
+	# Check
 	kind version
 
-    # Clean workdir
+	# Clean workdir
 	rm kind-src
 	rm -rf kind-0.11.1

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -122,13 +122,24 @@ build-kind:
 	cd kind-0.11.1 && make build
 
 	# Copy file
-	mv kind-0.11.1/bin/kind .
+	cp kind-0.11.1/bin/kind test/kind
 
-copy-kind:
+	# Make executive
+	chmod +x test/kind/kind
+
+	# Check
+	test/kind/kind version
+
+	# Clean workdir
+	rm -rf kind-0.11.1
+	rm -f kind-src
+
+install-kind: build-kind
+	# Delete actual
+	rm -f /usr/bin/kind
+
 	# Copy executive file
-	rm /usr/bin/kind
-	chmod +x ./kind
-	mv ./kind /usr/bin
+	mv test/kind/kind /usr/bin
 
 	# Check
 	kind version

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -127,7 +127,7 @@ build-kind:
 copy-kind:
 	# Copy executive file
 	rm /usr/bin/kind
-	chmod +x kind-0.11.1/bin/kind
+	chmod +x ./kind
 	mv ./kind /usr/bin
 
 	# Check

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -110,9 +110,7 @@ kind-load-images:
 	kind load docker-image ${PROJECT}-${SCHEDULER}:${TAG}
 	kind load docker-image ${PROJECT}-${OPERATOR}:${TAG}
 
-prepare-kind: build-kind copy-kind
-
-build-kind:
+kind-build:
 	# Get kind sources
 	wget -O kind-src https://codeload.github.com/kubernetes-sigs/kind/tar.gz/refs/tags/v0.11.1
 	tar -xzvf kind-src
@@ -134,7 +132,7 @@ build-kind:
 	rm -rf kind-0.11.1
 	rm -f kind-src
 
-install-kind: build-kind
+kind-install: kind-build
 	# Delete actual
 	rm -f /usr/bin/kind
 

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -52,7 +52,7 @@ test-sanity:
 load-operator-image:
 	docker pull ${REGISTRY}/${PROJECT}-${OPERATOR}:${OPERATOR_VERSION}
 	docker tag ${REGISTRY}/${PROJECT}-${OPERATOR}:${OPERATOR_VERSION} ${PROJECT}-${OPERATOR}:${OPERATOR_VERSION}
-	kind load docker-image ${PROJECT}-${OPERATOR}:${OPERATOR_VERSION}
+	$(KIND) load docker-image ${PROJECT}-${OPERATOR}:${OPERATOR_VERSION}
 
 kind-pull-images: kind-pull-sidecar-images
 	docker pull ${REGISTRY}/${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -93,22 +93,22 @@ kind-tag-images:
 	docker tag ${REGISTRY}/${PROJECT}-${OPERATOR}:${TAG} ${PROJECT}-${OPERATOR}:${TAG}
 
 kind-load-images:
-	kind load docker-image ${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
-	kind load docker-image ${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
-	kind load docker-image ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
-	kind load docker-image ${CSI_RESIZER}:${CSI_RESIZER_TAG}
-	kind load docker-image ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
-	kind load docker-image ${BUSYBOX}:${BUSYBOX_TAG}
-	kind load docker-image docker.io/library/nginx:1.14-alpine
-	kind load docker-image docker.io/library/centos:latest
-	kind load docker-image ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
-	kind load docker-image ${PROJECT}-${NODE}:${TAG}
-	kind load docker-image ${PROJECT}-${NODE}-kernel-5.4:${TAG}
-	kind load docker-image ${PROJECT}-${CONTROLLER}:${TAG}
-	kind load docker-image ${PROJECT}-${SCHEDULER}-${EXTENDER}:${TAG}
-	kind load docker-image ${PROJECT}-${EXTENDER_PATCHER}:${TAG}
-	kind load docker-image ${PROJECT}-${SCHEDULER}:${TAG}
-	kind load docker-image ${PROJECT}-${OPERATOR}:${TAG}
+	$(KIND) load docker-image ${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
+	$(KIND) load docker-image ${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
+	$(KIND) load docker-image ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
+	$(KIND) load docker-image ${CSI_RESIZER}:${CSI_RESIZER_TAG}
+	$(KIND) load docker-image ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
+	$(KIND) load docker-image ${BUSYBOX}:${BUSYBOX_TAG}
+	$(KIND) load docker-image docker.io/library/nginx:1.14-alpine
+	$(KIND) load docker-image docker.io/library/centos:latest
+	$(KIND) load docker-image ${PROJECT}-${LOOPBACK_DRIVE_MGR}:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${NODE}:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${NODE}-kernel-5.4:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${CONTROLLER}:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${SCHEDULER}-${EXTENDER}:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${EXTENDER_PATCHER}:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${SCHEDULER}:${TAG}
+	$(KIND) load docker-image ${PROJECT}-${OPERATOR}:${TAG}
 
 kind-build:
 	# Get kind sources
@@ -116,17 +116,17 @@ kind-build:
 	tar -xzvf kind-src
 
 	# Add "--ipc=host" docker option and build binary
-	patch -p0 < test/kind/kind.patch
+	patch -p0 < $(KIND_DIR)/kind.patch
 	cd kind-0.11.1 && make build
 
 	# Copy file
-	cp kind-0.11.1/bin/kind test/kind
+	cp kind-0.11.1/bin/kind $(KIND_DIR)
 
 	# Make executive
-	chmod +x test/kind/kind
+	chmod +x $(KIND)
 
 	# Check
-	test/kind/kind version
+	$(KIND) version
 
 	# Clean workdir
 	rm -rf kind-0.11.1
@@ -137,7 +137,13 @@ kind-install: kind-build
 	rm -f /usr/bin/kind
 
 	# Copy executive file
-	mv test/kind/kind /usr/bin
+	mv $(KIND) /usr/bin
 
 	# Check
 	kind version
+
+kind-create-cluster:
+	$(KIND) create cluster --config $(KIND_DIR)/kind.yaml --image kindest/node:v1.18.19
+
+kind-delete-cluster:
+	$(KIND) delete cluster

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -111,17 +111,22 @@ kind-load-images:
 	kind load docker-image ${PROJECT}-${OPERATOR}:${TAG}
 
 prepare-kind:
-
+    # Get kind sources
 	wget -O kind-src https://codeload.github.com/kubernetes-sigs/kind/tar.gz/refs/tags/v0.11.1
 	tar -xzvf kind-src
 
+    # Add "--ipc=host" docker option and build binary
 	patch -p0 < test/kind/kind.patch
 	cd kind-0.11.1 && make build
 
+    # Copy executive file
+    rm /usr/bin/kind
 	chmod +x kind-0.11.1/bin/kind
 	mv kind-0.11.1/bin/kind /usr/bin
 
+    # Check
 	kind version
 
+    # Clean workdir
 	rm kind-src
 	rm -rf kind-0.11.1

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -110,7 +110,9 @@ kind-load-images:
 	kind load docker-image ${PROJECT}-${SCHEDULER}:${TAG}
 	kind load docker-image ${PROJECT}-${OPERATOR}:${TAG}
 
-prepare-kind:
+prepare-kind: build-kind copy-kind
+
+build-kind:
 	# Get kind sources
 	wget -O kind-src https://codeload.github.com/kubernetes-sigs/kind/tar.gz/refs/tags/v0.11.1
 	tar -xzvf kind-src
@@ -119,14 +121,14 @@ prepare-kind:
 	patch -p0 < test/kind/kind.patch
 	cd kind-0.11.1 && make build
 
+	# Copy file
+	mv kind-0.11.1/bin/kind .
+
+copy-kind:
 	# Copy executive file
 	rm /usr/bin/kind
 	chmod +x kind-0.11.1/bin/kind
-	mv kind-0.11.1/bin/kind /usr/bin
+	mv ./kind /usr/bin
 
 	# Check
 	kind version
-
-	# Clean workdir
-	rm kind-src
-	rm -rf kind-0.11.1

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -109,3 +109,19 @@ kind-load-images:
 	kind load docker-image ${PROJECT}-${EXTENDER_PATCHER}:${TAG}
 	kind load docker-image ${PROJECT}-${SCHEDULER}:${TAG}
 	kind load docker-image ${PROJECT}-${OPERATOR}:${TAG}
+
+prepare-kind:
+
+	wget -O kind-src https://codeload.github.com/kubernetes-sigs/kind/tar.gz/refs/tags/v0.11.1
+	tar -xzvf kind-src
+
+	patch -p0 < test/kind/kind.patch
+	cd kind-0.11.1 && make build
+
+	chmod +x kind-0.11.1/bin/kind
+	mv kind-0.11.1/bin/kind /usr/bin
+
+	kind version
+
+	rm kind-src
+	rm -rf kind-0.11.1

--- a/test/kind/kind.patch
+++ b/test/kind/kind.patch
@@ -1,0 +1,11 @@
+--- ./kind-0.11.1/pkg/cluster/internal/providers/docker/provision.go	2021-05-28 02:18:13.000000000 +0300
++++ ./kind-0.11.1/pkg/cluster/internal/providers/docker/patched_provision.go	2021-06-30 17:25:58.317297835 +0300
+@@ -243,6 +243,8 @@
+ 		"--volume", "/var",
+ 		// some k8s things want to read /lib/modules
+ 		"--volume", "/lib/modules:/lib/modules:ro",
++		// ipc host
++		"--ipc", "host",
+ 	},
+ 		args...,
+ 	)

--- a/test/kind/kind.patch
+++ b/test/kind/kind.patch
@@ -1,5 +1,5 @@
---- ./kind-0.11.1/pkg/cluster/internal/providers/docker/provision.go	2021-05-28 02:18:13.000000000 +0300
-+++ ./kind-0.11.1/pkg/cluster/internal/providers/docker/patched_provision.go	2021-06-30 17:25:58.317297835 +0300
+--- kind-0.11.1/pkg/cluster/internal/providers/docker/provision.go	2021-07-02 15:32:23.872508147 +0300
++++ kind-0.11.1-patched/pkg/cluster/internal/providers/docker/provision.go	2021-06-30 18:57:28.806000000 +0300
 @@ -243,6 +243,8 @@
  		"--volume", "/var",
  		// some k8s things want to read /lib/modules
@@ -9,3 +9,14 @@
  	},
  		args...,
  	)
+--- kind-0.11.1/pkg/cmd/kind/version/version.go	2021-05-28 02:18:13.000000000 +0300
++++ kind-0.11.1-patched/pkg/cmd/kind/version/version.go	2021-07-02 15:31:45.440367546 +0300
+@@ -50,7 +50,7 @@
+ }
+ 
+ // VersionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
+-const VersionCore = "0.11.1"
++const VersionCore = "0.11.1-patched"
+ 
+ // VersionPreRelease is the pre-release portion of the kind CLI version per
+ // Semantic Versioning 2.0.0

--- a/test/kind/kind.yaml
+++ b/test/kind/kind.yaml
@@ -4,8 +4,10 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 # the control plane node config
 - role: control-plane
+  image: kindest/node:v1.18.19
 # the two workers
 - role: worker
+  image: kindest/node:v1.18.19
   extraMounts:
   - hostPath: /dev
     containerPath: /dev
@@ -16,6 +18,7 @@ nodes:
   - hostPath: /run/lock
     containerPath: /run/lock
 - role: worker
+  image: kindest/node:v1.18.19
   extraMounts:
   - hostPath: /dev
     containerPath: /dev
@@ -26,6 +29,7 @@ nodes:
   - hostPath: /run/lock
     containerPath: /run/lock
 - role: worker
+  image: kindest/node:v1.18.19
   extraMounts:
     - hostPath: /dev
       containerPath: /dev
@@ -36,6 +40,7 @@ nodes:
     - hostPath: /run/lock
       containerPath: /run/lock
 - role: worker
+  image: kindest/node:v1.18.19
   extraMounts:
     - hostPath: /dev
       containerPath: /dev
@@ -46,6 +51,7 @@ nodes:
     - hostPath: /run/lock
       containerPath: /run/lock
 - role: worker
+  image: kindest/node:v1.18.19
   extraMounts:
     - hostPath: /dev
       containerPath: /dev
@@ -56,6 +62,7 @@ nodes:
     - hostPath: /run/lock
       containerPath: /run/lock
 - role: worker
+  image: kindest/node:v1.18.19
   extraMounts:
     - hostPath: /dev
       containerPath: /dev

--- a/variables.mk
+++ b/variables.mk
@@ -71,5 +71,9 @@ GOPROXY_PART    := GOPROXY=https://proxy.golang.org,direct
 METRICS_PACKAGE := github.com/dell/csi-baremetal/pkg/metrics
 LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH}"
 
+### Kind
+KIND_DIR := test/kind
+KIND     := ${KIND_DIR}/kind
+
 # override some of variables, optional file
 -include variables.override.mk


### PR DESCRIPTION
## Purpose
### Issue #450 

Create new make targets:
- kind-build - patch and build custom kind version locally
- kind-create-cluster - create kind cluster using custom kind with kind.conf for CI
- kind-delete-cluster - delete kind cluster
- kind-install - update kind in /usr/bin (for internal use)

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
