### PR TITLE
[ISSUE-467] Fix drive health overriding

### DIFF
--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -990,11 +990,9 @@ func (m *VolumeManager) createEventsForDriveUpdates(updates *driveUpdates) {
 			m.createEventForDriveStatusChange(
 				updDrive.CurrentState, updDrive.PreviousState.Spec.Status, updDrive.CurrentState.Spec.Status)
 		}
-		// skip HealthChange event if drive health was overridden
 		if _, ok := updDrive.CurrentState.Annotations[driveHealthOverrideAnnotation]; ok {
 			m.createEventForDriveHealthOverridden(
 				updDrive.CurrentState, updDrive.PreviousState.Spec.Health, updDrive.CurrentState.Spec.Health)
-			continue
 		}
 		if updDrive.CurrentState.Spec.Health != updDrive.PreviousState.Spec.Health {
 			m.createEventForDriveHealthChange(
@@ -1163,6 +1161,7 @@ func (m *VolumeManager) isPVCNeedFakeAttach(volumeID string) bool {
 // overrideDriveHealth replaces drive health with passed value,
 // generates error message if value is not valid
 func (m *VolumeManager) overrideDriveHealth(drive *api.Drive, overriddenHealth, driveCRName string) {
+	overriddenHealth = strings.ToUpper(overriddenHealth)
 	if (overriddenHealth == apiV1.HealthGood) ||
 		(overriddenHealth == apiV1.HealthSuspect) ||
 		(overriddenHealth == apiV1.HealthBad) ||


### PR DESCRIPTION
## Purpose
### Issue #467 

- Generate DriveHealth<Health> event after DriveHealthOverridden
- Make annotation case insensitive

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
user@user-vm ~/g/s/g/dell> kd drive 0add2a06-67fe-4d0d-a2ac-3f677749330e | grep -i health
Annotations:  health: bad
        f:Health:
          f:health:
  Health:         BAD
  Normal   DriveHealthGood           31m   csi-baremetal-node  Drive health is: GOOD, previous state: UNKNOWN.Drive Details: SN='LOOPBACK3109538064', Node='1edefc39-7dbd-4e62-81ee-0e57cf993616', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
  Warning  DriveHealthOverridden     74s   csi-baremetal-node  Drive health is overridden with: BAD, real state: GOOD.Drive Details: SN='LOOPBACK3109538064', Node='1edefc39-7dbd-4e62-81ee-0e57cf993616', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
  Error    DriveHealthFailure        74s   csi-baremetal-node  Drive health is: BAD, previous state: GOOD.Drive Details: SN='LOOPBACK3109538064', Node='1edefc39-7dbd-4e62-81ee-0e57cf993616', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''


user@user-vm ~/g/s/g/dell> kd drive 541540a6-2525-4158-b700-4ab14112a902 | grep -i health
Annotations:  health: Suspect
        f:Health:
          f:health:
  Health:         SUSPECT
  Normal   DriveHealthGood           39m   csi-baremetal-node  Drive health is: GOOD, previous state: UNKNOWN.Drive Details: SN='LOOPBACK3500502233', Node='3948b2ef-40ef-4ddf-b41d-d3f4138ac08b', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
  Warning  DriveHealthOverridden     4s    csi-baremetal-node  Drive health is overridden with: SUSPECT, real state: GOOD.Drive Details: SN='LOOPBACK3500502233', Node='3948b2ef-40ef-4ddf-b41d-d3f4138ac08b', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
  Warning  DriveHealthSuspect        4s    csi-baremetal-node  Drive health is: SUSPECT, previous state: GOOD.Drive Details: SN='LOOPBACK3500502233', Node='3948b2ef-40ef-4ddf-b41d-d3f4138ac08b', Type='HDD', Model='Test Loopback', Size='105906176', Firmware=''
```
