### PR TITLE
[ISSUE-463] ignore not found pvc and retry it

### DIFF
--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -130,12 +130,10 @@ func (e *Extender) FilterHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	extenderRes.FailedNodes = failedNodes
 
+	extenderRes = &schedulerapi.ExtenderFilterResult{}
 	if err := resp.Encode(extenderRes); err != nil {
 		ll.Errorf("Unable to write response %v: %v", extenderRes, err)
 	}
-
-	extenderRes = &schedulerapi.ExtenderFilterResult{}
-	ll.Debugf("Response: with empty struct")
 }
 
 // PrioritizeHandler helps with even distribution of the volumes across the nodes.

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -134,7 +134,7 @@ func (e *Extender) FilterHandler(w http.ResponseWriter, req *http.Request) {
 		ll.Errorf("Unable to write response %v: %v", extenderRes, err)
 	}
 
-	extenderRes  = &schedulerapi.ExtenderFilterResult{}
+	extenderRes = &schedulerapi.ExtenderFilterResult{}
 	ll.Debugf("Response: with empty struct")
 }
 

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -130,7 +130,6 @@ func (e *Extender) FilterHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	extenderRes.FailedNodes = failedNodes
 
-	extenderRes = &schedulerapi.ExtenderFilterResult{}
 	if err := resp.Encode(extenderRes); err != nil {
 		ll.Errorf("Unable to write response %v: %v", extenderRes, err)
 	}
@@ -246,7 +245,8 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 			err := e.k8sCache.ReadCR(ctx, v.PersistentVolumeClaim.ClaimName, pod.Namespace, pvc)
 			if err != nil {
 				ll.Errorf("Unable to read PVC %s in NS %s: %v. ", v.PersistentVolumeClaim.ClaimName, pod.Namespace, err)
-				return nil, err
+				// PVC can be created later. csi-provisioner repeat request if not error.
+				return nil, nil
 			}
 			if pvc.Spec.StorageClassName == nil {
 				continue

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -133,6 +133,9 @@ func (e *Extender) FilterHandler(w http.ResponseWriter, req *http.Request) {
 	if err := resp.Encode(extenderRes); err != nil {
 		ll.Errorf("Unable to write response %v: %v", extenderRes, err)
 	}
+
+	extenderRes  = &schedulerapi.ExtenderFilterResult{}
+	ll.Debugf("Response: with empty struct")
 }
 
 // PrioritizeHandler helps with even distribution of the volumes across the nodes.


### PR DESCRIPTION
## Purpose
### Issue #463

CSI can create PVC  later then try to find nodes for pod. If csi-provisioner get response for filter nodes with error, it'll exit with error. But if response without error and empty nodes list, csi-provisioner repeat request.
[kubernetes-csi/external-provisioner](https://github.com/kubernetes-csi/external-provisioner/blob/61317e204eb271d8f47ae7983f97abbb60cbf3a4/vendor/github.com/kubernetes-csi/csi-lib-utils/rpc/common.go#L109) link to request logic.

Skipping error if PVC not found.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
