### PR TITLE
[ISSUE-464] Retry patching after kube-scheduler not restarted

### DIFF
--- a/test/e2e/common/deploy.go
+++ b/test/e2e/common/deploy.go
@@ -123,13 +123,15 @@ func DeployCSI(f *framework.Framework, additionalInstallArgs string) (func(), er
 			path:      path.Join(BMDriverTestContext.ChartsDir, "csi-baremetal-deployment"),
 			namespace: f.Namespace.Name,
 		}
-		installArgs = fmt.Sprintf("--set image.tag=%s "+
+		seReadinessTimeout = 3 // Minutes
+		installArgs        = fmt.Sprintf("--set image.tag=%s "+
 			"--set image.pullPolicy=IfNotPresent "+
 			"--set driver.drivemgr.type=loopbackmgr "+
 			"--set scheduler.log.level=debug "+
 			"--set nodeController.log.level=debug "+
-			"--set driver.log.level=debug", csiVersion)
-		podWait         = 3 * time.Minute
+			"--set driver.log.level=debug "+
+			"--set scheduler.patcher.readinessTimeout=%d", csiVersion, seReadinessTimeout)
+		podWait         = 6 * time.Minute
 		sleepBeforeWait = 10 * time.Second
 	)
 


### PR DESCRIPTION
Signed-off-by: safronovD <danil_safronov@dell.com>

## Purpose
### Issue #464 

RCA:
After patching process we had the race, when kube-scheduler restarted in 8+ minutes (due to many configuration changes while csi installing/deleting). In this case kube-scheduler stacked in the patched setup from previous run and updating/recreating pod manifest wasn't affected it.
To avoid this situation new functional of repeat patching after kube-scheduler inactivity was supported in https://github.com/dell/csi-baremetal-operator/pull/47 and https://github.com/dell/csi-baremetal/pull/465. Also, we need to use this option in e2e to fix the problem

Changes:
- Set Patching retry timeout to 3 mins
- Increase deployment wait timeout to 6 mins

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Link to custom CI build_
