### PR TITLE
[ISSUE-483] Race condition between Extender and Controller on disk replacement

### DIFF
--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -441,8 +441,9 @@ func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context
 		}
 	}
 
-	// if LogicalVolumeGroup wasn't deleted increase AC size
-	if !isDeleted {
+	// if LogicalVolumeGroup wasn't deleted and health of volume is GOOD increase AC size
+	// We don't increase AC size for unhealthy volume to avoid new allocations on top of unhealthy drive/lvg
+	if !isDeleted && volumeCR.Spec.Health == apiV1.HealthGood {
 		// Increase size of AC using volume size
 		acCR.Spec.Size += volumeCR.Spec.Size
 		if err = vo.k8sClient.UpdateCRWithAttempts(ctx, &acCR, 5); err != nil {


### PR DESCRIPTION
## Purpose
### Issue #483

Don't release capacity of unhealthy volume

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing

- Mark drive as failed
```
borism1@ubuntu:/workspace/csi-baremetal$ kubectl get drives | grep 8e78d923-a33d-40a6-8130-90d4113b8d4c
8e78d923-a33d-40a6-8130-90d4113b8d4c   VDH1599D           GOOD     HDD    4b3d480d-f892-4b9d-9bcb-16bfda076134   8001000000000   14
borism1@ubuntu:/workspace/csi-baremetal$ 
borism1@ubuntu:/workspace/csi-baremetal$ kubectl get volume | grep pvc-2dafca9f-34d7-4e8f-9d50-722c80d3faa6
pvc-2dafca9f-34d7-4e8f-9d50-722c80d3faa6   GOOD     4b3d480d-f892-4b9d-9bcb-16bfda076134   8001000000000   8e78d923-a33d-40a6-8130-90d4113b8d4c   HDD             PUBLISHED

borism1@ubuntu:/workspace/csi-baremetal$ kubectl get ac | grep 8e78d923-a33d-40a6-8130-90d4113b8d4c
33076f01-010a-43dd-836a-53868ce8866a   8e78d923-a33d-40a6-8130-90d4113b8d4c   4b3d480d-f892-4b9d-9bcb-16bfda076134   HDD             

borism1@ubuntu:/workspace/csi-baremetal$ kubectl describe ac 33076f01-010a-43dd-836a-53868ce8866a | grep Generation
  Generation:          4

borism1@ubuntu:/workspace/csi-baremetal$ kubectl annotate drive 8e78d923-a33d-40a6-8130-90d4113b8d4c health=bad
drive.csi-baremetal.dell.com/8e78d923-a33d-40a6-8130-90d4113b8d4c annotated

borism1@ubuntu:/workspace/csi-baremetal$ kubectl get drives | grep 8e78d923-a33d-40a6-8130-90d4113b8d4c
8e78d923-a33d-40a6-8130-90d4113b8d4c   VDH1599D           BAD      HDD    4b3d480d-f892-4b9d-9bcb-16bfda076134   8001000000000   14
borism1@ubuntu:/workspace/csi-baremetal$ kubectl get volumes | grep 8e78d923-a33d-40a6-8130-90d4113b8d4c
pvc-2dafca9f-34d7-4e8f-9d50-722c80d3faa6   BAD      4b3d480d-f892-4b9d-9bcb-16bfda076134   8001000000000   8e78d923-a33d-40a6-8130-90d4113b8d4c   HDD             PUBLISHED
```
- Delete PVC+Pod 
```
borism1@ubuntu:/workspace/csi-baremetal$ kubectl delete pvc logs-web-2 --wait=false
persistentvolumeclaim "logs-web-2" deleted
borism1@ubuntu:/workspace/csi-baremetal$ kubectl delete pod web-2 --wait=false
pod "web-2" deleted
borism1@ubuntu:/workspace/csi-baremetal$ kubectl get volumes | grep 8e78d923-a33d-40a6-8130-90d4113b8d4c
borism1@ubuntu:/workspace/csi-baremetal$ 
```
- AC size is nil, CR wasn't modified on volume deletion:
```
borism1@ubuntu:/workspace/csi-baremetal$ kubectl get ac | grep 8e78d923-a33d-40a6-8130-90d4113b8d4c
33076f01-010a-43dd-836a-53868ce8866a   8e78d923-a33d-40a6-8130-90d4113b8d4c   4b3d480d-f892-4b9d-9bcb-16bfda076134   HDD 
borism1@ubuntu:/workspace/csi-baremetal$ kubectl describe ac 33076f01-010a-43dd-836a-53868ce8866a | grep Generation
  Generation:          4
```