### PR TITLE
[ISSUE-489] re-activate volume group on disk reinsert

### DIFF
--- a/pkg/base/linuxutils/lvm/lvm.go
+++ b/pkg/base/linuxutils/lvm/lvm.go
@@ -164,25 +164,26 @@ func (l *LVM) VGCreate(name string, pvs ...string) error {
 func (l *LVM) VGScan(name string) (bool, error) {
 	// scan and check for VG errors
 	var (
-		output  string
+		stdout  string
+		stderr  string
 		err     error
 		exp     *regexp.Regexp
 		ioError = "input/output error"
 	)
 	// do the scan
-	if output, _, err = l.e.RunCmd(VGScanCmdTmpl, command.UseMetrics(true),
+	if stdout, stderr, err = l.e.RunCmd(VGScanCmdTmpl, command.UseMetrics(true),
 		command.CmdName(strings.TrimSpace(VGScanCmdTmpl))); err != nil {
 		return false, err
 	}
-	// empty output is not expected. It must also contain VG name
-	if output == "" || !strings.Contains(output, name) {
+	// empty stdout is not expected. It must also contain VG name
+	if stdout == "" || !strings.Contains(stdout, name) {
 		return false, errTypes.ErrorNotFound
 	}
 	// find target volume group and check for IO errors
 	if exp, err = regexp.Compile(".*" + name + ".*\n*"); err != nil {
 		return false, err
 	}
-	lines := exp.FindAllString(output, -1)
+	lines := exp.FindAllString(stderr, -1)
 	for _, line := range lines {
 		if strings.Contains(strings.ToLower(line), ioError) {
 			return true, nil

--- a/pkg/base/linuxutils/lvm/lvm.go
+++ b/pkg/base/linuxutils/lvm/lvm.go
@@ -71,6 +71,7 @@ type WrapLVM interface {
 	PVCreate(dev string) error
 	PVRemove(name string) error
 	VGCreate(name string, pvs ...string) error
+	VGReactivate(name string) error
 	VGRemove(name string) error
 	LVCreate(name, size, vgName string) error
 	LVRemove(fullLVName string) error
@@ -148,6 +149,17 @@ func (l *LVM) VGCreate(name string, pvs ...string) error {
 		return nil
 	}
 	return err
+}
+
+// VGReactivate inactivates, scans and activates volume group to recover from disk missing scenario
+// Receives name of VG to re-activate
+// Returns error if something went wrong
+func (l *LVM) VGReactivate(name string) error {
+	// Inactive VG: vgchange -an <VG name>
+	// Scan Volume group: vgscan
+	// Active VG: vgchange -ay <VG name>
+	l.log.Infof("Trying to re-activate volume groups %s", name)
+	return nil
 }
 
 // VGRemove removes volume group, ignore error if VG doesn't exist

--- a/pkg/base/linuxutils/lvm/lvm.go
+++ b/pkg/base/linuxutils/lvm/lvm.go
@@ -46,6 +46,12 @@ const (
 	PVsListCmdTmpl = lvmPath + "pvdisplay --short"
 	// VGCreateCmdTmpl create VG on provided PVs cmd
 	VGCreateCmdTmpl = lvmPath + "vgcreate --yes %s %s" // add VG name and PV names
+	// VGInactivateCmdTmpl inactivates VG
+	VGInactivateCmdTmpl = lvmPath + "vgchange -an %s"
+	// VGActivateCmdTmpl activates VG
+	VGActivateCmdTmpl = lvmPath + "vgchange -ay %s"
+	// VGScanCmdTmpl scans VG
+	VGScanCmdTmpl = lvmPath + "vgscan %s"
 	// VGRemoveCmdTmpl remove VG cmd
 	VGRemoveCmdTmpl = lvmPath + "vgremove --yes %s" // add VG name
 	// AllPVsCmd returns all physical volumes on the system
@@ -158,7 +164,23 @@ func (l *LVM) VGReactivate(name string) error {
 	// Inactive VG: vgchange -an <VG name>
 	// Scan Volume group: vgscan
 	// Active VG: vgchange -ay <VG name>
-	l.log.Infof("Trying to re-activate volume groups %s", name)
+	l.log.Infof("Trying to re-activate volume group %s", name)
+	// inactivate
+	if _, _, err := l.e.RunCmd(fmt.Sprintf(VGInactivateCmdTmpl, name), command.UseMetrics(true),
+		command.CmdName(strings.TrimSpace(fmt.Sprintf(VGInactivateCmdTmpl, "")))); err != nil {
+		return err
+	}
+	// scan
+	if _, _, err := l.e.RunCmd(fmt.Sprintf(VGScanCmdTmpl, name), command.UseMetrics(true),
+		command.CmdName(strings.TrimSpace(fmt.Sprintf(VGScanCmdTmpl, "")))); err != nil {
+		return err
+	}
+	// activate
+	if _, _, err := l.e.RunCmd(fmt.Sprintf(VGActivateCmdTmpl, name), command.UseMetrics(true),
+		command.CmdName(strings.TrimSpace(fmt.Sprintf(VGActivateCmdTmpl, "")))); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/base/linuxutils/lvm/lvm_test.go
+++ b/pkg/base/linuxutils/lvm/lvm_test.go
@@ -120,19 +120,22 @@ func TestLinuxUtils_VGScan(t *testing.T) {
 	assert.Equal(t, err, expectedErr)
 
 	// IO error detected
-	e.OnCommand(cmd).Return("/dev/" + vg + "/test-lv: Input/output error", "", nil).Times(1)
+	e.OnCommand(cmd).Return("Found volume group \"" + vg + "\" using metadata type lvm2",
+		"/dev/" + vg + "/test-lv: Input/output error", nil).Times(1)
 	ok, err = l.VGScan(vg)
 	assert.True(t, ok)
 	assert.Nil(t, err)
 
 	// IO error not detected - multiple lines
-	e.OnCommand(cmd).Return(fmt.Sprintf("/dev/%s/test-lv: no errors\n/dev/other-vg/test-lv: Input/output error", vg), "", nil).Times(1)
+	e.OnCommand(cmd).Return("Found volume group \"" + vg + "\" using metadata type lvm2",
+		"/dev/%s/test-lv: no errors\n/dev/other-vg/test-lv: Input/output error", nil).Times(1)
 	ok, err = l.VGScan(vg)
 	assert.False(t, ok)
 	assert.Nil(t, err)
 
 	// IO error detected - multiple lines
-	e.OnCommand(cmd).Return(fmt.Sprintf("/dev/%s/test-lv: no errors\n/dev/%s/test-lv-2: Input/output error", vg, vg), "", nil).Times(1)
+	e.OnCommand(cmd).Return("Found volume group \"" + vg + "\" using metadata type lvm2",
+		"/dev/" + vg + "/test-lv: no errors\n/dev/" + vg + "/test-lv-2: Input/output error", nil).Times(1)
 	ok, err = l.VGScan(vg)
 	assert.True(t, ok)
 	assert.Nil(t, err)

--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -48,4 +48,8 @@ const (
 
 	FakeAttachInvolved = "FakeAttachInvolved"
 	FakeAttachCleared  = "FakeAttachCleared"
+
+	VolumeGroupScanFailed         = "VolumeGroupScanFailed"
+	VolumeGroupReactivateInvolved = "VolumeGroupReactivateInvolved"
+	VolumeGroupReactivateFailed   = "VolumeGroupReactivateFailed"
 )

--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -50,6 +50,7 @@ const (
 	FakeAttachCleared  = "FakeAttachCleared"
 
 	VolumeGroupScanFailed         = "VolumeGroupScanFailed"
+	VolumeGroupScanInvolved       = "VolumeGroupScanInvolved"
 	VolumeGroupReactivateInvolved = "VolumeGroupReactivateInvolved"
 	VolumeGroupReactivateFailed   = "VolumeGroupReactivateFailed"
 )

--- a/pkg/mocks/linuxutils/lvm.go
+++ b/pkg/mocks/linuxutils/lvm.go
@@ -53,6 +53,13 @@ func (m *MockWrapLVM) VGCreate(name string, pvs ...string) error {
 	return args.Error(0)
 }
 
+// VGReactivate is a mock implementation
+func (m *MockWrapLVM) VGReactivate(name string) error {
+	args := m.Mock.Called(name)
+
+	return args.Error(0)
+}
+
 // VGRemove is a mock implementations
 func (m *MockWrapLVM) VGRemove(name string) error {
 	args := m.Mock.Called(name)

--- a/pkg/mocks/linuxutils/lvm.go
+++ b/pkg/mocks/linuxutils/lvm.go
@@ -53,6 +53,13 @@ func (m *MockWrapLVM) VGCreate(name string, pvs ...string) error {
 	return args.Error(0)
 }
 
+// VGScan is a mock implementation
+func (m *MockWrapLVM) VGScan(name string) (bool, error) {
+	args := m.Mock.Called(name)
+
+	return args.Bool(0), args.Error(0)
+}
+
 // VGReactivate is a mock implementation
 func (m *MockWrapLVM) VGReactivate(name string) error {
 	args := m.Mock.Called(name)

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -933,6 +933,7 @@ func (m *VolumeManager) handleDriveStatusChange(ctx context.Context, drive updat
 		// check for missing disk and re-activate volume group if needed
 		if prev.Status == apiV1.DriveStatusOffline && cur.Status == apiV1.DriveStatusOnline {
 			ll.Infof("Scan volume group %s for IO errors", name)
+			m.recorder.Eventf(lvg, eventing.NormalType, eventing.VolumeGroupScanInvolved, "Check for IO errors")
 			if ok, err := m.lvmOps.VGScan(name); err != nil { //nolint:gocritic
 				ll.Errorf("Failed to scan volume group %s for IO errors: %v", name, err)
 				m.recorder.Eventf(lvg, eventing.ErrorType, eventing.VolumeGroupScanFailed, err.Error())

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -933,7 +933,7 @@ func (m *VolumeManager) handleDriveStatusChange(ctx context.Context, drive updat
 		// check for missing disk and re-activate volume group if needed
 		if prev.Status == apiV1.DriveStatusOffline && cur.Status == apiV1.DriveStatusOnline {
 			ll.Infof("Scan volume group %s for IO errors", name)
-			if ok, err := m.lvmOps.VGScan(name); err != nil {
+			if ok, err := m.lvmOps.VGScan(name); err != nil { //nolint:gocritic
 				ll.Errorf("Failed to scan volume group %s for IO errors: %v", name, err)
 				m.recorder.Eventf(lvg, eventing.ErrorType, eventing.VolumeGroupScanFailed, err.Error())
 			} else if ok {

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -808,16 +808,22 @@ func TestVolumeManager_handleDriveStatusChange(t *testing.T) {
 	drive := drive1
 	drive.UUID = driveUUID
 	drive.Health = apiV1.HealthBad
+	driveCR := &drivecrd.Drive{Spec:drive}
+
+	update := updatedDrive{
+		PreviousState: driveCR,
+		CurrentState:  driveCR,
+	}
 
 	// Check AC deletion
-	vm.handleDriveStatusChange(testCtx, &drive)
+	vm.handleDriveStatusChange(testCtx, update)
 	vol := volCR
 	vol.Spec.Location = driveUUID
 	err = vm.k8sClient.CreateCR(testCtx, testID, &vol)
 	assert.Nil(t, err)
 
 	// Check volume's health change
-	vm.handleDriveStatusChange(testCtx, &drive)
+	vm.handleDriveStatusChange(testCtx, update)
 	rVolume := &vcrd.Volume{}
 	err = vm.k8sClient.ReadCR(testCtx, testID, volCR.Namespace, rVolume)
 	assert.Nil(t, err)
@@ -828,7 +834,7 @@ func TestVolumeManager_handleDriveStatusChange(t *testing.T) {
 	err = vm.k8sClient.CreateCR(testCtx, testLVGName, &lvg)
 	assert.Nil(t, err)
 	// Check lvg's health change
-	vm.handleDriveStatusChange(testCtx, &drive)
+	vm.handleDriveStatusChange(testCtx, update)
 	updatedLVG := &lvgcrd.LogicalVolumeGroup{}
 	err = vm.k8sClient.ReadCR(testCtx, testLVGName, "", updatedLVG)
 	assert.Nil(t, err)


### PR DESCRIPTION
## Purpose
### Issue #489 

Re-activate volume group on drive transition from OFFLINE to ONLINE

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
- Simulate disk re-insert:
```
borism1@ubuntu:/workspace/csi-baremetal$ drives | grep VDH1H03D
ecdcc891-62d4-48b6-bfc1-afedba53f36b   8001000000000   HDD    VDH1H03D           UNKNOWN   IN_USE   OFFLINE   <none>   ee54707c-2252-4a6a-8bc6-40951c741615
borism1@ubuntu:/workspace/csi-baremetal$ drives | grep VDH1H03D
ecdcc891-62d4-48b6-bfc1-afedba53f36b   8001000000000   HDD    VDH1H03D           GOOD     IN_USE   ONLINE   <none>   ee54707c-2252-4a6a-8bc6-40951c741615
```
- Check for LVG events:
```
borism1@ubuntu:/workspace/csi-baremetal$ kubectl describe lvg 3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69
Name:         3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69
...
Events:
  Type     Reason                         Age   From                                                      Message
  ----     ------                         ----  ----                                                      -------
  Normal   VolumeGroupScanInvolved        7s    csi-baremetal-node, ee54707c-2252-4a6a-8bc6-40951c741615  Check for IO errors
  Warning  VolumeGroupReactivateInvolved  7s    csi-baremetal-node, ee54707c-2252-4a6a-8bc6-40951c741615  IO errors detected
```
- Restart pod to make sure that mount will pass:
```
borism1@ubuntu:/workspace/csi-baremetal$ kubectl delete pod web-3
pod "web-3" deleted
borism1@ubuntu:/workspace/csi-baremetal$ volumes | grep 3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69
default     pvc-c1919fc9-304e-4462-92ce-841f2986c6c6   1002438656   xfs    GOOD     OPERATIVE   PUBLISHED   IN_USE   3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69   ee54707c-2252-4a6a-8bc6-40951c741615
default     pvc-c665c4f6-0881-454e-b531-10883f31aa55   1002438656   xfs    GOOD     OPERATIVE   PUBLISHED   IN_USE   3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69   ee54707c-2252-4a6a-8bc6-40951c741615
default     pvc-7213ac7f-c7e3-4297-ac8f-30fd6f1e93b7   1002438656   xfs    GOOD     OPERATIVE   PUBLISHED   IN_USE   3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69   ee54707c-2252-4a6a-8bc6-40951c741615
default     pvc-b925398a-96e2-4119-bdff-b90ac5ee20ca   1002438656   xfs    GOOD     OPERATIVE   PUBLISHED   IN_USE   3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69   ee54707c-2252-4a6a-8bc6-40951c741615
default     pvc-2c6bdc9b-7519-4b7f-9ef9-130c6c3b6144   1002438656   xfs    GOOD     OPERATIVE   PUBLISHED   IN_USE   3b7d6b51-12f7-48a8-a438-1c6e3fa1ff69   ee54707c-2252-4a6a-8bc6-40951c741615
borism1@ubuntu:/workspace/csi-baremetal$ pods | grep web-3
web-3                                            1/1     Running   0          21s    192.168.195.172   provo-goop.ecs.lab.emc.com   <none>           <none>
```