### PR TITLE
[ISSUE-505] Update alpine version to 3.14

### DIFF
--- a/pkg/controller/Dockerfile.build
+++ b/pkg/controller/Dockerfile.build
@@ -1,5 +1,3 @@
-FROM   alpine:3.10 
+FROM   alpine:3.14
 
 ADD     health_probe    health_probe
-
-RUN     apk add bash curl

--- a/pkg/crcontrollers/operator/Dockerfile
+++ b/pkg/crcontrollers/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM    ubuntu:20.04
+FROM    alpine:3.14
 
 LABEL   description="Baremetal CSI Operator"
 

--- a/pkg/crcontrollers/operator/controller.go
+++ b/pkg/crcontrollers/operator/controller.go
@@ -420,7 +420,7 @@ func (bmc *Controller) updateNodeLabelsAndAnnotation(k8sNode *coreV1.Node, nodeU
 	// check for annotations
 	val, ok := k8sNode.GetAnnotations()[bmc.annotationKey]
 	if bmc.externalAnnotation && !ok {
-		ll.Errorf("external annotaion %s is not accesible on node %s", bmc.annotationKey, k8sNode)
+		ll.Errorf("external annotation %s is not accessible on node %s", bmc.annotationKey, k8sNode)
 	}
 	if !bmc.externalAnnotation && ok {
 		if val == nodeUUID {
@@ -433,7 +433,7 @@ func (bmc *Controller) updateNodeLabelsAndAnnotation(k8sNode *coreV1.Node, nodeU
 		}
 	}
 	if !bmc.externalAnnotation && !ok {
-		ll.Errorf("annotaion %s is not accesible on node %s", bmc.annotationKey, k8sNode)
+		ll.Errorf("annotation %s is not accessible on node %s", bmc.annotationKey, k8sNode)
 		if k8sNode.ObjectMeta.Annotations == nil {
 			k8sNode.ObjectMeta.Annotations = make(map[string]string, 1)
 		}

--- a/pkg/node/Dockerfile-kernel-5.4.build
+++ b/pkg/node/Dockerfile-kernel-5.4.build
@@ -2,6 +2,6 @@ FROM    ubuntu:20.04
 
 ADD     health_probe    health_probe
 
-RUN     apt update --no-install-recommends -y -q; apt install --no-install-recommends -y -q curl util-linux parted xfsprogs lvm2 gdisk strace udev net-tools
+RUN     apt update --no-install-recommends -y -q; apt install --no-install-recommends -y -q util-linux parted xfsprogs lvm2 gdisk strace udev net-tools
 
 

--- a/pkg/node/Dockerfile.build
+++ b/pkg/node/Dockerfile.build
@@ -2,6 +2,6 @@ FROM    ubuntu:18.04
 
 ADD     health_probe    health_probe
 
-RUN     apt update --no-install-recommends -y -q; apt install --no-install-recommends -y -q curl util-linux parted xfsprogs lvm2 gdisk strace udev net-tools
+RUN     apt update --no-install-recommends -y -q; apt install --no-install-recommends -y -q util-linux parted xfsprogs lvm2 gdisk strace udev net-tools
 
 

--- a/pkg/scheduler/extender/Dockerfile
+++ b/pkg/scheduler/extender/Dockerfile
@@ -1,4 +1,4 @@
-FROM    ubuntu:20.04
+FROM    alpine:3.14
 
 LABEL   description="Bare-metal CSI Scheduler Extender"
 

--- a/pkg/scheduler/patcher/Dockerfile
+++ b/pkg/scheduler/patcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8-alpine3.14
 
 COPY requirements.txt main.py /patcher/
 WORKDIR /patcher

--- a/pkg/scheduler/plugin/Dockerfile
+++ b/pkg/scheduler/plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM    ubuntu:20.04
+FROM    alpine:3.14
 
 LABEL   description="Bare-metal CSI Scheduler"
 


### PR DESCRIPTION
## Purpose
### Issue #505

Need to update alpine version to the latest to close a list of security vulnerabilities

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Manually:
```
borism1@ubuntu:/workspace/csi-baremetal$ pods
NAME                                             READY   STATUS    RESTARTS   AGE     IP            NODE                 NOMINATED NODE   READINESS GATES
csi-baremetal-controller-7d88f6c7fd-qt5r7        4/4     Running   0          9m25s   10.244.2.11   kind-worker          <none>           <none>
csi-baremetal-node-controller-8667f65fb5-fqf8g   1/1     Running   0          9m26s   10.244.3.10   kind-worker2         <none>           <none>
csi-baremetal-node-kernel-5.4-9cw4l              4/4     Running   0          9m25s   10.244.2.10   kind-worker          <none>           <none>
csi-baremetal-node-kernel-5.4-dzrr2              4/4     Running   0          9m26s   10.244.1.7    kind-worker3         <none>           <none>
csi-baremetal-node-kernel-5.4-nqtrp              4/4     Running   0          9m25s   10.244.3.11   kind-worker2         <none>           <none>
csi-baremetal-operator-76db69cb75-s4dh5          1/1     Running   0          10m     10.244.2.9    kind-worker          <none>           <none>
csi-baremetal-se-dvr4j                           1/1     Running   0          9m25s   172.18.0.5    kind-control-plane   <none>           <none>
csi-baremetal-se-patcher-qk6n7                   1/1     Running   0          9m25s   10.244.0.7    kind-control-plane   <none>           <none>
web-0                                            1/1     Running   0          6m56s   10.244.3.12   kind-worker2         <none>           <none>
web-1                                            1/1     Running   0          6m56s   10.244.2.12   kind-worker          <none>           <none>
web-2                                            1/1     Running   0          6m56s   10.244.1.8    kind-worker3         <none>           <none>
borism1@ubuntu:/workspace/csi-baremetal$ pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
data-web-0   Bound    pvc-3929eb00-8e5f-4717-b251-5d114ddbf692   101Mi      RWO            csi-baremetal-sc   6m59s
data-web-1   Bound    pvc-f027adf1-905a-47a0-be96-495a3e8131e3   101Mi      RWO            csi-baremetal-sc   6m59s
data-web-2   Bound    pvc-aebf55a6-7d49-453b-b326-362206a21068   101Mi      RWO            csi-baremetal-sc   6m59s
logs-web-0   Bound    pvc-adce2b60-c4d6-49b4-a3cd-68299aa49746   101Mi      RWO            csi-baremetal-sc   6m59s
logs-web-1   Bound    pvc-4de29977-630a-40a3-86b0-58dc9a2afbbc   101Mi      RWO            csi-baremetal-sc   6m59s
logs-web-2   Bound    pvc-ae6dbbda-b453-4c86-8d2c-fc218f69ae73   101Mi      RWO            csi-baremetal-sc   6m59s
www-web-0    Bound    pvc-695400f9-d6c3-4d04-a705-2fbc8daa20a0   101Mi      RWO            csi-baremetal-sc   6m59s
www-web-1    Bound    pvc-0147b845-5e2b-49cc-ac5d-ff3f25a83417   101Mi      RWO            csi-baremetal-sc   6m59s
www-web-2    Bound    pvc-234490f0-9253-476e-9ac9-81bc0316d499   101Mi      RWO            csi-baremetal-sc   6m59s
```
