### PR TITLE
[ISSUE-509] Add verbose kubectl output for LVG and ACR

### DIFF
--- a/api/v1/acreservationcrd/availablecapacityreservation_types.go
+++ b/api/v1/acreservationcrd/availablecapacityreservation_types.go
@@ -28,6 +28,8 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName={acr,acrs}
 // +kubebuilder:printcolumn:name="NAMESPACE",type="string",JSONPath=".spec.Namespace",description="Pod namespace"
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".spec.Status",description="Status of AvailableCapacityReservation"
+// +kubebuilder:printcolumn:name="REQUESTED NODES",type="string",JSONPath=".spec.NodeRequests.Requested",description="List of requested nodes",priority=1
+// +kubebuilder:printcolumn:name="RESERVED NODES",type="string",JSONPath=".spec.NodeRequests.Reserved",description="List of reserved nodes",priority=1
 type AvailableCapacityReservation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1/lvgcrd/logicalvolumegroup_types.go
+++ b/api/v1/lvgcrd/logicalvolumegroup_types.go
@@ -26,10 +26,12 @@ import (
 
 // LogicalVolumeGroup is the Schema for the LVGs API
 // +kubebuilder:resource:scope=Cluster,shortName={lvg,lvgs}
-// +kubebuilder:printcolumn:name="HEALTH",type="string",JSONPath=".spec.Health",description="LVG health status"
 // +kubebuilder:printcolumn:name="SIZE",type="string",JSONPath=".spec.Size",description="Size of Logical volume group"
+// +kubebuilder:printcolumn:name="HEALTH",type="string",JSONPath=".spec.Health",description="LVG health"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".spec.Status",description="LVG status",priority=1
 // +kubebuilder:printcolumn:name="LOCATIONS",type="string",JSONPath=".spec.Locations",description="LVG drives locations list"
 // +kubebuilder:printcolumn:name="NODE",type="string",JSONPath=".spec.Node",description="LVG node location"
+// +kubebuilder:printcolumn:name="VOLUMES",type="string",JSONPath=".spec.VolumeRefs",description="Volume references",priority=1
 type LogicalVolumeGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/csi-baremetal-driver/crds/csi-baremetal.dell.com_availablecapacityreservations.yaml
+++ b/charts/csi-baremetal-driver/crds/csi-baremetal.dell.com_availablecapacityreservations.yaml
@@ -17,6 +17,16 @@ spec:
     description: Status of AvailableCapacityReservation
     name: STATUS
     type: string
+  - JSONPath: .spec.NodeRequests.Requested
+    description: List of requested nodes
+    name: REQUESTED NODES
+    priority: 1
+    type: string
+  - JSONPath: .spec.NodeRequests.Reserved
+    description: List of reserved nodes
+    name: RESERVED NODES
+    priority: 1
+    type: string
   group: csi-baremetal.dell.com
   names:
     kind: AvailableCapacityReservation

--- a/charts/csi-baremetal-driver/crds/csi-baremetal.dell.com_logicalvolumegroups.yaml
+++ b/charts/csi-baremetal-driver/crds/csi-baremetal.dell.com_logicalvolumegroups.yaml
@@ -9,13 +9,18 @@ metadata:
   name: logicalvolumegroups.csi-baremetal.dell.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.Health
-    description: LVG health status
-    name: HEALTH
-    type: string
   - JSONPath: .spec.Size
     description: Size of Logical volume group
     name: SIZE
+    type: string
+  - JSONPath: .spec.Health
+    description: LVG health
+    name: HEALTH
+    type: string
+  - JSONPath: .spec.Status
+    description: LVG status
+    name: Status
+    priority: 1
     type: string
   - JSONPath: .spec.Locations
     description: LVG drives locations list
@@ -24,6 +29,11 @@ spec:
   - JSONPath: .spec.Node
     description: LVG node location
     name: NODE
+    type: string
+  - JSONPath: .spec.VolumeRefs
+    description: Volume references
+    name: VOLUMES
+    priority: 1
     type: string
   group: csi-baremetal.dell.com
   names:


### PR DESCRIPTION
## Purpose
### Issue #509 

Add verbose kubectl output for LVG and ACR

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
**kubectl get acr**
```
NAME             NAMESPACE   STATUS
default-web2-1   default     RESERVED
default-web2-2   default     REQUESTED
default-web2-3   default     REQUESTED
```
**kubectl get acr -o wide**
```
NAME             NAMESPACE   STATUS      REQUESTED NODES                                                               RESERVED NODES
default-web2-2   default     REQUESTED   [9c99aeca-d8af-4c7b-a96c-792f9bdc5dd0 ab96ee69-31f7-4702-98cd-be18d31d4c69]   
default-web2-3   default     RESERVED    [bd241927-ce59-4a7f-a95c-dc6fcc082a21]                                        [bd241927-ce59-4a7f-a95c-dc6fcc082a21]
```
**kubectl get lvg**
```
NAME                                   SIZE        HEALTH   LOCATIONS                                NODE
12fae7d2-1452-483e-9637-e71a2e23ecf1   104857600   GOOD     [37871541-e5be-40ca-8930-36275dbc2904]   ab96ee69-31f7-4702-98cd-be18d31d4c69
839a592a-7730-405c-991b-c674339439c7   104857600   GOOD     [5c65a722-d87a-491e-ae81-337c4b4659f1]   5b4d8c1f-11c8-4e49-b1f8-01d04d2a34d8
852868c7-2b4c-43a7-9544-76f6f07fa88a   104857600   GOOD     [07004c3b-23cc-44a5-ae83-707d52d43835]   9c99aeca-d8af-4c7b-a96c-792f9bdc5dd0
d427bc68-1052-459a-ac96-f90787438a3b   104857600   GOOD     [e6498a22-53b1-4f49-b754-751a6fd04ff5]   bd241927-ce59-4a7f-a95c-dc6fcc082a21
```
**kubectl get lvg -o wide**
```
NAME                                   SIZE        HEALTH   STATUS    LOCATIONS                                NODE                                   VOLUMES
12fae7d2-1452-483e-9637-e71a2e23ecf1   104857600   GOOD     CREATED   [37871541-e5be-40ca-8930-36275dbc2904]   ab96ee69-31f7-4702-98cd-be18d31d4c69   [pvc-1fdb370f-7697-41cf-8a49-1dde5c13e38c pvc-df6ca794-095c-4fb8-8442-b2fab4459c44]
839a592a-7730-405c-991b-c674339439c7   104857600   GOOD     CREATED   [5c65a722-d87a-491e-ae81-337c4b4659f1]   5b4d8c1f-11c8-4e49-b1f8-01d04d2a34d8   [pvc-2a3e3876-4d61-4bf1-8fd1-101d2d5d40e3 pvc-87eb35a7-5b13-4214-ad70-1a83d42b013b]
852868c7-2b4c-43a7-9544-76f6f07fa88a   104857600   GOOD     CREATED   [07004c3b-23cc-44a5-ae83-707d52d43835]   9c99aeca-d8af-4c7b-a96c-792f9bdc5dd0   [pvc-536a8ecd-3fe2-4f5b-9802-1981a4607fae pvc-591d0843-34e3-440a-b727-8b4ea60a323d]
d427bc68-1052-459a-ac96-f90787438a3b   104857600   GOOD     CREATED   [e6498a22-53b1-4f49-b754-751a6fd04ff5]   bd241927-ce59-4a7f-a95c-dc6fcc082a21   [pvc-7af12b80-e029-48d1-be24-5c9deba235ef pvc-fcd057b1-9384-4ea9-b6b0-5ccf25fdf512]
```

