### PR TITLE
[ISSUE-515] Fix CSI Operator pull target

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -45,7 +45,7 @@ EXTENDER         := extender
 EXTENDER_PATCHER := scheduler-patcher
 NODE_CONTROLLER  := ${NODE_CONTROLLER_PKG}-${CONTROLLER}
 PLUGIN           := plugin
-OPERATOR		 := operator
+OPERATOR         := operator
 
 BASE_DRIVE_MGR     := basemgr
 LOOPBACK_DRIVE_MGR := loopbackmgr

--- a/variables.mk
+++ b/variables.mk
@@ -45,6 +45,7 @@ EXTENDER         := extender
 EXTENDER_PATCHER := scheduler-patcher
 NODE_CONTROLLER  := ${NODE_CONTROLLER_PKG}-${CONTROLLER}
 PLUGIN           := plugin
+OPERATOR		 := operator
 
 BASE_DRIVE_MGR     := basemgr
 LOOPBACK_DRIVE_MGR := loopbackmgr


### PR DESCRIPTION
## Purpose
### Issue #515 

Fix CSI Operator pull target:
```
$ make load-operator-image OPERATOR_VERSION=0.4.0-52.1ebc772 REGISTRY=asdrepo.isus.emc.com:9042
docker pull asdrepo.isus.emc.com:9042/csi-baremetal-:0.4.0-52.1ebc772
invalid reference format
Makefile.validation:53: recipe for target 'load-operator-image' failed
make: *** [load-operator-image] Error 1
```

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Tested locally:
```
$ make load-operator-image OPERATOR_VERSION=0.4.0-52.1ebc772 REGISTRY=asdrepo.isus.emc.com:9042
docker pull asdrepo.isus.emc.com:9042/csi-baremetal-operator:0.4.0-52.1ebc772
0.4.0-52.1ebc772: Pulling from csi-baremetal-operator
b49b96595fd4: Already exists 
f747f7b81d76: Pull complete 
Digest: sha256:6fe32b72dabba40b4f4aa78ace9f582bd4369281488c38b0612cbf53fa6246b0
Status: Downloaded newer image for asdrepo.isus.emc.com:9042/csi-baremetal-operator:0.4.0-52.1ebc772
docker tag asdrepo.isus.emc.com:9042/csi-baremetal-operator:0.4.0-52.1ebc772 csi-baremetal-operator:0.4.0-52.1ebc772
test/kind/kind load docker-image csi-baremetal-operator:0.4.0-52.1ebc772
Image: "csi-baremetal-operator:0.4.0-52.1ebc772" with ID "sha256:b5941f075ab907122650a44c53f8e4e075c7b5b4364a981edecb2d017421ee6b" not present on node "kind-worker2"
Image: "csi-baremetal-operator:0.4.0-52.1ebc772" with ID "sha256:b5941f075ab907122650a44c53f8e4e075c7b5b4364a981edecb2d017421ee6b" not present on node "kind-worker"
Image: "csi-baremetal-operator:0.4.0-52.1ebc772" with ID "sha256:b5941f075ab907122650a44c53f8e4e075c7b5b4364a981edecb2d017421ee6b" not present on node "kind-control-plane"
Image: "csi-baremetal-operator:0.4.0-52.1ebc772" with ID "sha256:b5941f075ab907122650a44c53f8e4e075c7b5b4364a981edecb2d017421ee6b" not present on node "kind-worker3"
```
Node reboot test from e2e test failed, but issue is not related with image name change.