### PR TITLE
[ISSUE-518] DriveRemovalFailed event isn't generated after volume release=failed

### DIFF
--- a/api/v1/drivecrd/drive_types.go
+++ b/api/v1/drivecrd/drive_types.go
@@ -83,9 +83,12 @@ func (in *Drive) Equals(drive *api.Drive) bool {
 }
 
 func (in *Drive) GetDriveDescription() string {
-	return fmt.Sprintf("Drive Details: SN='%s', Node='%s',"+
-		" Type='%s', Model='%s %s',"+
-		" Size='%d', Firmware='%s'",
-		in.Spec.SerialNumber, in.Spec.NodeId, in.Spec.Type,
-		in.Spec.VID, in.Spec.PID, in.Spec.Size, in.Spec.Firmware)
+	spec := in.Spec
+	description := fmt.Sprintf("Drive Details: SN='%s', Model='%s %s', Type='%s', Size='%d', Node='%s'",
+		spec.SerialNumber, spec.VID, spec.PID, spec.Type, spec.Size, spec.NodeId)
+	// add firmware info only if detected
+	if spec.Firmware != "" {
+		description += fmt.Sprintf(", Firmware='%s'", spec.Firmware)
+	}
+	return description
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -369,6 +369,10 @@ func (m *VolumeManager) updateVolumeAndDriveUsageStatus(ctx context.Context, vol
 		m.addVolumeStatusAnnotation(drive, volume.Name, apiV1.VolumeUsageReleased)
 	}
 	if drive != nil {
+		if driveStatus == apiV1.DriveUsageFailed {
+			eventMsg := fmt.Sprintf("Failed to release volume(s), %s", drive.GetDriveDescription())
+			m.recorder.Eventf(drive, eventing.DriveRemovalFailed, eventMsg)
+		}
 		drive.Spec.Usage = driveStatus
 		if err := m.k8sClient.UpdateCR(ctx, drive); err != nil {
 			ll.Errorf("Unable to change drive %s usage status to %s, error: %v.",


### PR DESCRIPTION
## Purpose
### Issue #518 

Add missing event

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
$ kubectl annotate volume pvc-3328fbb8-c817-464e-a82a-b2747835dafa release=failed
volume.csi-baremetal.dell.com/pvc-3328fbb8-c817-464e-a82a-b2747835dafa annotated
$ kubectl get volumes -o wide
NAME                                       SIZE        STORAGE CLASS   HEALTH   CSI_STATUS   OP_STATUS   USAGE    TYPE   LOCATION                               NODE
pvc-3328fbb8-c817-464e-a82a-b2747835dafa   105906176   HDD             BAD      PUBLISHED    OPERATIVE   FAILED   xfs    078c473a-e30a-4c5d-b822-5df70e5f3b96   96b107b2-77f3-4372-a0d7-65b31950c633
pvc-3eb64a62-286b-4ac8-8f88-190774c9bc39   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    73cd765e-b8b1-423d-9701-3cad4274a91e   369c1464-d0b1-4e13-9392-3fe5e524da10
pvc-4e660b60-0efe-48aa-b2f3-9a92cacb5695   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    8f899ae7-be51-4b79-aa00-1f2f803b5128   b609ccac-7d8f-443b-82d7-6e3696e8b8a8
pvc-6255c204-c1d0-4bf1-b8b0-795a05afbe84   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    bbced511-3f3d-419e-b33e-45d3ad6eca69   369c1464-d0b1-4e13-9392-3fe5e524da10
pvc-92dc65b7-4e54-46a2-8f64-ed2209017dc3   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    2a8ea31c-e555-4349-9d8d-a91981bd91cf   b609ccac-7d8f-443b-82d7-6e3696e8b8a8
pvc-95089864-a53c-4974-b6bd-1434dd1f01ae   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    a5ed4ba3-86af-4459-80a1-c14da879b7c7   96b107b2-77f3-4372-a0d7-65b31950c633
pvc-cf63822b-f1c2-4271-b14f-8328368e8158   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    bf7c66f3-bbdb-4a4d-be4a-8a638fc16346   369c1464-d0b1-4e13-9392-3fe5e524da10
pvc-d90b40ce-e743-4209-a500-38637b99b7df   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    b3d35e34-e8ec-4f33-a559-35f2c947ddbf   b609ccac-7d8f-443b-82d7-6e3696e8b8a8
pvc-ff830be7-b90f-4384-93d8-89b8716baf5e   105906176   HDD             GOOD     PUBLISHED    OPERATIVE   IN_USE   xfs    e1e972ee-4356-412e-bdff-e23e455ff80d   96b107b2-77f3-4372-a0d7-65b31950c633
$ kubectl get drives -o wide
NAME                                   SIZE        TYPE   HEALTH   STATUS   USAGE    SYSTEM   PATH          SERIAL NUMBER        SLOT   NODE
078c473a-e30a-4c5d-b822-5df70e5f3b96   105906176   HDD    BAD      ONLINE   FAILED            /dev/loop35   LOOPBACK2423462983          96b107b2-77f3-4372-a0d7-65b31950c633
2a8ea31c-e555-4349-9d8d-a91981bd91cf   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop40   LOOPBACK1969894280          b609ccac-7d8f-443b-82d7-6e3696e8b8a8
73cd765e-b8b1-423d-9701-3cad4274a91e   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop36   LOOPBACK1515078814          369c1464-d0b1-4e13-9392-3fe5e524da10
8f899ae7-be51-4b79-aa00-1f2f803b5128   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop37   LOOPBACK819186540           b609ccac-7d8f-443b-82d7-6e3696e8b8a8
a5ed4ba3-86af-4459-80a1-c14da879b7c7   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop33   LOOPBACK1155969490          96b107b2-77f3-4372-a0d7-65b31950c633
b3d35e34-e8ec-4f33-a559-35f2c947ddbf   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop38   LOOPBACK2831698245          b609ccac-7d8f-443b-82d7-6e3696e8b8a8
bbced511-3f3d-419e-b33e-45d3ad6eca69   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop39   LOOPBACK3929393032          369c1464-d0b1-4e13-9392-3fe5e524da10
bf7c66f3-bbdb-4a4d-be4a-8a638fc16346   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop41   LOOPBACK1135661690          369c1464-d0b1-4e13-9392-3fe5e524da10
e1e972ee-4356-412e-bdff-e23e455ff80d   105906176   HDD    GOOD     ONLINE   IN_USE            /dev/loop34   LOOPBACK4188124280          96b107b2-77f3-4372-a0d7-65b31950c633

$ kubectl describe drive 078c473a-e30a-4c5d-b822-5df70e5f3b96
Name:         078c473a-e30a-4c5d-b822-5df70e5f3b96
Events:
  Type     Reason                 Age   From                                                      Message
  ----     ------                 ----  ----                                                      -------
  Normal   DriveDiscovered        6m7s  csi-baremetal-node, 96b107b2-77f3-4372-a0d7-65b31950c633  New drive discovered SN: LOOPBACK2423462983, Node: 96b107b2-77f3-4372-a0d7-65b31950c633. Drive Details: SN='LOOPBACK2423462983', Model='Test Loopback', Type='HDD', Size='105906176', Node='96b107b2-77f3-4372-a0d7-65b31950c633'
  Normal   DriveHealthGood        6m7s  csi-baremetal-node, 96b107b2-77f3-4372-a0d7-65b31950c633  Drive health is: GOOD, previous state: UNKNOWN. Drive Details: SN='LOOPBACK2423462983', Model='Test Loopback', Type='HDD', Size='105906176', Node='96b107b2-77f3-4372-a0d7-65b31950c633'
  Warning  DriveHealthOverridden  67s   csi-baremetal-node, 96b107b2-77f3-4372-a0d7-65b31950c633  Drive health is overridden with: BAD, real state: GOOD. Drive Details: SN='LOOPBACK2423462983', Model='Test Loopback', Type='HDD', Size='105906176', Node='96b107b2-77f3-4372-a0d7-65b31950c633'
  Error    DriveHealthFailure     67s   csi-baremetal-node, 96b107b2-77f3-4372-a0d7-65b31950c633  Drive health is: BAD, previous state: GOOD. Drive Details: SN='LOOPBACK2423462983', Model='Test Loopback', Type='HDD', Size='105906176', Node='96b107b2-77f3-4372-a0d7-65b31950c633'
  Error    DriveRemovalFailed     42s   csi-baremetal-node, 96b107b2-77f3-4372-a0d7-65b31950c633  Failed to release volume(s), Drive Details: SN='LOOPBACK2423462983', Model='Test Loopback', Type='HDD', Size='105906176', Node='96b107b2-77f3-4372-a0d7-65b31950c633'
```
