### PR TITLE
[ISSUE-529] Fix csi-controller restart after node removal

### DIFF
--- a/pkg/controller/node/statemonitor.go
+++ b/pkg/controller/node/statemonitor.go
@@ -233,10 +233,12 @@ func (n *ServicesStateMonitor) getPodToNodeList() (map[string]stateComponents, e
 		}
 
 		if podNode == nil {
-			// nolint
-			log.Fatalf("Unable to find node for pod %s", pod.Name)
+			// k8snode is removed, pod should be killed
+			// it's not need to check it state
+			log.Warningf("Unable to find node for pod %s", pod.Name)
+			continue
 		}
-		// nolint - doesn't detect Exit() in Fatalf
+
 		nodeID := string(podNode.GetUID())
 		stateComponentsMap[nodeID] = stateComponents{podNode, pod}
 	}


### PR DESCRIPTION
## Purpose
### Issue #529 

Skip pod status check if node not found

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing

```user@user-vm ~/g/s/g/dell> kg po
NAME                                            READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-5c67f99597-52lvj       4/4     Running   0          82s
csi-baremetal-node-controller-fd9bdd747-bw795   1/1     Running   0          83s
csi-baremetal-node-kernel-5.4-2fdpx             4/4     Running   0          83s
csi-baremetal-node-kernel-5.4-h8t4r             4/4     Running   0          83s
csi-baremetal-node-kernel-5.4-khgp4             4/4     Running   0          55s
csi-baremetal-operator-57497f75ff-nm5mk         1/1     Running   0          104s
csi-baremetal-se-patcher-xjkt9                  1/1     Running   0          82s
csi-baremetal-se-sxpmd                          0/1     Running   0          82s
user@user-vm ~/g/s/g/dell> kdl no kind-worker
node "kind-worker" deleted
user@user-vm ~/g/s/g/dell> kg no
NAME                 STATUS   ROLES    AGE    VERSION
kind-control-plane   Ready    master   5d1h   v1.18.19
kind-worker2         Ready    <none>   5d1h   v1.18.19
kind-worker3         Ready    <none>   5d1h   v1.18.19
user@user-vm ~/g/s/g/dell> kg po
NAME                                            READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-5c67f99597-52lvj       4/4     Running   0          3m22s
csi-baremetal-node-controller-fd9bdd747-bw795   1/1     Running   0          3m23s
csi-baremetal-node-kernel-5.4-2fdpx             4/4     Running   0          3m23s
csi-baremetal-node-kernel-5.4-h8t4r             4/4     Running   0          3m23s
csi-baremetal-operator-57497f75ff-nm5mk         1/1     Running   0          3m44s
csi-baremetal-se-patcher-xjkt9                  1/1     Running   0          3m22s
csi-baremetal-se-sxpmd                          1/1     Running   0          3m22s
user@user-vm ~/g/s/g/dell> kl csi-baremetal-controller-5c67f99597-52lvj -c controller | grep Unable
Sep 14 13:08:12.887 [WARN] [ServicesStateMonitor] [getPodToNodeList] Unable to find node for pod csi-baremetal-node-kernel-5.4-khgp4
Sep 14 13:09:42.968 [WARN] [ServicesStateMonitor] [getPodToNodeList] Unable to find node for pod csi-baremetal-node-kernel-5.4-khgp4
user@user-vm ~/g/s/g/dell> ka ./node.yaml
node/kind-worker created
user@user-vm ~/g/s/g/dell> kg no
NAME                 STATUS   ROLES    AGE    VERSION
kind-control-plane   Ready    master   5d1h   v1.18.19
kind-worker          Ready    <none>   3m2s   v1.18.19
kind-worker2         Ready    <none>   5d1h   v1.18.19
kind-worker3         Ready    <none>   5d1h   v1.18.19
user@user-vm ~/g/s/g/dell> kg po
NAME                                            READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-5c67f99597-52lvj       4/4     Running   0          7m3s
csi-baremetal-node-controller-fd9bdd747-bw795   1/1     Running   0          7m4s
csi-baremetal-node-kernel-5.4-2fdpx             4/4     Running   0          7m4s
csi-baremetal-node-kernel-5.4-h8t4r             4/4     Running   0          7m4s
csi-baremetal-node-kernel-5.4-snwv8             4/4     Running   0          3m5s
csi-baremetal-operator-57497f75ff-nm5mk         1/1     Running   0          7m25s
csi-baremetal-se-patcher-xjkt9                  1/1     Running   0          7m3s
csi-baremetal-se-sxpmd                          1/1     Running   0          7m3s
```
