### PR TITLE
[ISSUE-540] Fix node_capacity log message 

### DIFF
--- a/pkg/base/capacityplanner/node_capacity.go
+++ b/pkg/base/capacityplanner/node_capacity.go
@@ -46,8 +46,9 @@ type nodeCapacity struct {
 	acsOrder scToACOrder
 }
 
+// String is pretty print function for nodeCapacity
 func (nc *nodeCapacity) String() string {
-	return fmt.Sprintf("acs: %+v", nc.acsOrder)
+	return fmt.Sprintf("ACs: %+v", nc.acsOrder)
 }
 
 func newNodeCapacity(node string, acs []accrd.AvailableCapacity, acrs []acrcrd.AvailableCapacityReservation) *nodeCapacity {

--- a/pkg/base/capacityplanner/node_capacity.go
+++ b/pkg/base/capacityplanner/node_capacity.go
@@ -17,6 +17,7 @@
 package capacityplanner
 
 import (
+	"fmt"
 	"sort"
 
 	genV1 "github.com/dell/csi-baremetal/api/generated/v1"
@@ -43,6 +44,10 @@ type nodeCapacity struct {
 	reservedACs reservedACs
 	// Storage Class Name: the list of AC names, which can be selected
 	acsOrder scToACOrder
+}
+
+func (nc *nodeCapacity) String() string {
+	return fmt.Sprintf("acs: %+v", nc.acsOrder)
 }
 
 func newNodeCapacity(node string, acs []accrd.AvailableCapacity, acrs []acrcrd.AvailableCapacityReservation) *nodeCapacity {


### PR DESCRIPTION
## Purpose
### Issue #540 

New message:
```
Sep 21 14:00:03.605 [DEBU] [ReservationController] [CapacityManager.PlanVolumesPlacing] [<nil>] [default-web2-0] Node_capacity: map[900ffa05-d107-4394-83c9-44c572800c48:acs: map[ANY:[8743508f-9cbc-4089-8a4b-2fd37f36601d d607eb20-bc30-4d29-80ed-3d4097281351 f754d99a-e61a-4d13-8f18-99b9664999a9] HDD:[8743508f-9cbc-4089-8a4b-2fd37f36601d d607eb20-bc30-4d29-80ed-3d4097281351 f754d99a-e61a-4d13-8f18-99b9664999a9] HDDLVG:[8743508f-9cbc-4089-8a4b-2fd37f36601d d607eb20-bc30-4d29-80ed-3d4097281351 f754d99a-e61a-4d13-8f18-99b9664999a9] NVMELVG:[] SSDLVG:[]] ca26a4c8-24d6-4885-9c84-1a3da2cd74b9:acs: map[ANY:[8bac71f4-dbdb-4d4a-ac66-fec1e485e2e5 8d5a5a92-f654-410c-a9c1-fcb4c4e414b1 ebea929c-677d-4b53-bf78-34162b80808e] HDD:[8bac71f4-dbdb-4d4a-ac66-fec1e485e2e5 8d5a5a92-f654-410c-a9c1-fcb4c4e414b1 ebea929c-677d-4b53-bf78-34162b80808e] HDDLVG:[8bac71f4-dbdb-4d4a-ac66-fec1e485e2e5 8d5a5a92-f654-410c-a9c1-fcb4c4e414b1 ebea929c-677d-4b53-bf78-34162b80808e] NVMELVG:[] SSDLVG:[]] ef78633e-d588-4674-bf1d-fd20deb2d59c:acs: map[ANY:[1d0d9b0f-a30c-451d-8a23-5561cd23e371 38d1dadd-6674-45c7-85d0-07dc25b2687d a7969103-74db-4c5d-aca5-913bfe3d519d] HDD:[1d0d9b0f-a30c-451d-8a23-5561cd23e371 38d1dadd-6674-45c7-85d0-07dc25b2687d a7969103-74db-4c5d-aca5-913bfe3d519d] HDDLVG:[1d0d9b0f-a30c-451d-8a23-5561cd23e371 38d1dadd-6674-45c7-85d0-07dc25b2687d a7969103-74db-4c5d-aca5-913bfe3d519d] NVMELVG:[] SSDLVG:[]]]
``` 

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
