### PR TITLE
[ISSUE-538] Update node-driver-registrar sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ build-extender \
 build-scheduler \
 build-node-controller
 
-
 build-drivemgr:
 	GOOS=linux go build -o ./build/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/$(DRIVE_MANAGER_TYPE) ./cmd/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ build-extender \
 build-scheduler \
 build-node-controller
 
+
 build-drivemgr:
 	GOOS=linux go build -o ./build/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/$(DRIVE_MANAGER_TYPE) ./cmd/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/main.go
 

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -67,7 +67,6 @@ kind-pull-images: kind-pull-sidecar-images
 kind-pull-sidecar-images:
 	docker pull ${REGISTRY}/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
 	docker pull ${REGISTRY}/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
-	docker pull ${REGISTRY}/${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	docker pull ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	docker pull ${REGISTRY}/${CSI_RESIZER}:${CSI_RESIZER_TAG}
 	docker pull ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG}
@@ -77,7 +76,6 @@ kind-pull-sidecar-images:
 kind-tag-images:
 	docker tag ${REGISTRY}/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG} ${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
 	docker tag ${REGISTRY}/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG} ${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
-	docker tag ${REGISTRY}/${CSI_ATTACHER}:${CSI_ATTACHER_TAG} ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	docker tag ${REGISTRY}/${CSI_RESIZER}:${CSI_RESIZER_TAG} ${CSI_RESIZER}:${CSI_RESIZER_TAG}
 	docker tag ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG} ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	docker tag ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG} ${BUSYBOX}:${BUSYBOX_TAG}
@@ -95,7 +93,6 @@ kind-tag-images:
 kind-load-images:
 	$(KIND) load docker-image ${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
 	$(KIND) load docker-image ${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
-	$(KIND) load docker-image ${CSI_ATTACHER}:${CSI_ATTACHER_TAG}
 	$(KIND) load docker-image ${CSI_RESIZER}:${CSI_RESIZER_TAG}
 	$(KIND) load docker-image ${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	$(KIND) load docker-image ${BUSYBOX}:${BUSYBOX_TAG}

--- a/variables.mk
+++ b/variables.mk
@@ -24,8 +24,7 @@ BRANCH           := $(shell git rev-parse --abbrev-ref HEAD)
 ### third-party components version
 CSI_PROVISIONER_TAG := v1.6.0
 CSI_RESIZER_TAG     := v1.1.0
-CSI_REGISTRAR_TAG   := v1.0.1-gke.0
-CSI_ATTACHER_TAG    := v1.0.1
+CSI_REGISTRAR_TAG   := v1.3.0
 LIVENESS_PROBE_TAG  := v2.1.0
 BUSYBOX_TAG         := 1.29
 
@@ -55,7 +54,6 @@ DRIVE_MANAGER_TYPE := ${BASE_DRIVE_MGR}
 CSI_PROVISIONER := csi-provisioner
 CSI_REGISTRAR   := csi-node-driver-registrar
 CSI_RESIZER     := csi-resizer
-CSI_ATTACHER    := csi-attacher
 LIVENESS_PROBE  := livenessprobe
 BUSYBOX         := busybox
 


### PR DESCRIPTION
## Purpose
### Issue #538 

- node-driver-registrar version is 1.3
- remove csi-attacher

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
