### PR TITLE
[ISSUE-548] Idempotent PrepareVolume procedure

### DIFF
--- a/pkg/base/linuxutils/datadiscover/datadiscover.go
+++ b/pkg/base/linuxutils/datadiscover/datadiscover.go
@@ -51,7 +51,7 @@ func (w *WrapDataDiscoverImpl) DiscoverData(device, serialNumber string) (*types
 		err        error
 	)
 
-	if fileSystem, err = w.fsHelper.DeviceFs(device); err != nil {
+	if fileSystem, err = w.fsHelper.GetFSType(device); err != nil {
 		return nil, err
 	}
 	if fileSystem != "" {

--- a/pkg/base/linuxutils/datadiscover/datadiscover_test.go
+++ b/pkg/base/linuxutils/datadiscover/datadiscover_test.go
@@ -22,7 +22,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return("xfs", nil).Times(1)
+		fs.On("GetFSType", device).Return("xfs", nil).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)
 		assert.Nil(t, err)
 		assert.True(t, discoverResult.HasData)
@@ -34,7 +34,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return(" ", nil).Times(1)
+		fs.On("GetFSType", device).Return(" ", nil).Times(1)
 		part.On("DeviceHasPartitionTable", device).Return(true, nil).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)
 		assert.Nil(t, err)
@@ -47,7 +47,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return("", nil).Times(1)
+		fs.On("GetFSType", device).Return("", nil).Times(1)
 		part.On("DeviceHasPartitionTable", device).Return(false, nil).Times(1)
 		part.On("DeviceHasPartitions", device).Return(true, nil).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)
@@ -62,7 +62,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return("", nil).Times(1)
+		fs.On("GetFSType", device).Return("", nil).Times(1)
 		part.On("DeviceHasPartitionTable", device).Return(false, nil).Times(1)
 		part.On("DeviceHasPartitions", device).Return(false, nil).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)
@@ -77,7 +77,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return("", errors.New("error")).Times(1)
+		fs.On("GetFSType", device).Return("", errors.New("error")).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)
 		assert.NotNil(t, err)
 		assert.Nil(t, discoverResult)
@@ -89,7 +89,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return("", nil).Times(1)
+		fs.On("GetFSType", device).Return("", nil).Times(1)
 		part.On("DeviceHasPartitionTable", device).Return(false, errors.New("error")).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)
 		assert.NotNil(t, err)
@@ -102,7 +102,7 @@ func Test_DiscoverData(t *testing.T) {
 			lvm          = mocklu.MockWrapLVM{}
 			discoverData = NewDataDiscover(&fs, &part, &lvm)
 		)
-		fs.On("DeviceFs", device).Return("", nil).Times(1)
+		fs.On("GetFSType", device).Return("", nil).Times(1)
 		part.On("DeviceHasPartitionTable", device).Return(false, nil).Times(1)
 		part.On("DeviceHasPartitions", device).Return(false, errors.New("error")).Times(1)
 		discoverResult, err := discoverData.DiscoverData(device, serialNumber)

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -139,7 +139,7 @@ func (h *WrapFSImpl) MkDir(src string) error {
 	if _, _, err := h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(strings.TrimSpace(fmt.Sprintf(MkDirCmdTmpl, "")))); err != nil {
-		return fmt.Errorf("failed to create dir %s: %v", src, err)
+		return fmt.Errorf("failed to create dir %s: %w", src, err)
 	}
 	return nil
 }
@@ -179,7 +179,7 @@ func (h *WrapFSImpl) RmDir(src string) error {
 	if _, _, err := h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(strings.TrimSpace(fmt.Sprintf(RmDirCmdTmpl, "")))); err != nil {
-		return fmt.Errorf("failed to delete path %s: %v", src, err)
+		return fmt.Errorf("failed to delete path %s: %w", src, err)
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func (h *WrapFSImpl) CreateFS(fsType FileSystem, device string) error {
 	if _, _, err := h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(strings.TrimSpace(fmt.Sprintf(MkFSCmdTmpl, "", "")))); err != nil {
-		return fmt.Errorf("failed to create file system on %s: %v", device, err)
+		return fmt.Errorf("failed to create file system on %s: %w", device, err)
 	}
 	return nil
 }
@@ -215,7 +215,7 @@ func (h *WrapFSImpl) WipeFS(device string) error {
 	if _, _, err := h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(strings.TrimSpace(fmt.Sprintf(WipeFSCmdTmpl, "")))); err != nil {
-		return fmt.Errorf("failed to wipe file system on %s: %v", device, err)
+		return fmt.Errorf("failed to wipe file system on %s: %w", device, err)
 	}
 	return nil
 }
@@ -229,7 +229,7 @@ func (h *WrapFSImpl) IsMounted(path string) (bool, error) {
 
 	procMounts, err := util.ConsistentRead(MountInfoFile, 5, time.Millisecond)
 	if err != nil || len(procMounts) == 0 {
-		return false, fmt.Errorf("unable to check whether %s mounted or no, error: %v", path, err)
+		return false, fmt.Errorf("unable to check whether %s mounted or no, error: %w", path, err)
 	}
 
 	// parse /proc/mounts content and search path entry
@@ -306,7 +306,7 @@ func (h *WrapFSImpl) GetFSType(device string) (string, error) {
 	if stdout, _, err = h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(fmt.Sprintf(GetFSTypeCmdTmpl, ""))); err != nil {
-		return "", fmt.Errorf("failed to detect file system on %s: %v", device, err)
+		return "", fmt.Errorf("failed to detect file system on %s: %w", device, err)
 	}
 	return strings.TrimSpace(stdout), err
 }

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -54,8 +54,8 @@ const (
 	RmDirCmdTmpl = "rm -rf %s"
 	// WipeFSCmdTmpl cmd for wiping FS on device
 	WipeFSCmdTmpl = wipefs + "-af %s" //
-	// DetectFSCmdTmpl cmd for detecting FS on device GetFSTypeCmdTmpl
-	DetectFSCmdTmpl = "lsblk %s --output FSTYPE --noheadings"
+	// GetFSTypeCmdTmpl cmd for detecting FS on device
+	GetFSTypeCmdTmpl = "lsblk %s --output FSTYPE --noheadings"
 	// MountInfoFile "/proc/mounts" path
 	MountInfoFile = "/proc/self/mountinfo"
 	// FindMntCmdTmpl find source device for target mount path cmd
@@ -76,7 +76,7 @@ type WrapFS interface {
 	RmDir(src string) error
 	CreateFS(fsType FileSystem, device string) error
 	WipeFS(device string) error
-	DeviceFs(device string) (string, error)
+	GetFSType(device string) (string, error)
 	// Mount operations
 	IsMounted(src string) (bool, error)
 	FindMountPoint(target string) (string, error)
@@ -294,18 +294,18 @@ func (h *WrapFSImpl) Unmount(path string) error {
 	return err
 }
 
-// DeviceFs detect FS from the provided device using lsblk --output FSTYPE
+// GetFSType detect FS from the provided device using lsblk --output FSTYPE
 // Receives file path of the device as a string
 // Returns error if something went wrong
-func (h *WrapFSImpl) DeviceFs(device string) (string, error) {
+func (h *WrapFSImpl) GetFSType(device string) (string, error) {
 	var (
-		cmd    = fmt.Sprintf(DetectFSCmdTmpl, device)
+		cmd    = fmt.Sprintf(GetFSTypeCmdTmpl, device)
 		stdout string
 		err    error
 	)
 	if stdout, _, err = h.e.RunCmd(cmd,
 		command.UseMetrics(true),
-		command.CmdName(fmt.Sprintf(DetectFSCmdTmpl, ""))); err != nil {
+		command.CmdName(fmt.Sprintf(GetFSTypeCmdTmpl, ""))); err != nil {
 		return "", fmt.Errorf("failed to detect file system on %s: %v", device, err)
 	}
 	return strings.TrimSpace(stdout), err

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -78,7 +78,8 @@ type WrapFS interface {
 	RmDir(src string) error
 	CreateFS(fsType FileSystem, device string) error
 	WipeFS(device string) error
-	GetFSType(device string) (FileSystem, error)
+	// GetFSType(device string) (FileSystem, error)
+
 	// Mount operations
 	IsMounted(src string) (bool, error)
 	FindMountPoint(target string) (string, error)

--- a/pkg/base/linuxutils/fs/fs_helper_test.go
+++ b/pkg/base/linuxutils/fs/fs_helper_test.go
@@ -188,28 +188,6 @@ func TestWipeFS(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestGetFSType(t *testing.T) {
-	var (
-		e          = &mocks.GoMockExecutor{}
-		fh         = NewFSImpl(e)
-		device     = "/dev/sda"
-		cmd        = fmt.Sprintf(GetFSTypeCmdTmpl, device)
-		expectedFS = "xfs"
-		currentFS  FileSystem
-		err        error
-	)
-
-	e.OnCommand(cmd).Return(expectedFS, "", nil).Times(1)
-	currentFS, err = fh.GetFSType(device)
-	assert.Nil(t, err)
-	assert.Equal(t, FileSystem(expectedFS), currentFS)
-
-	// cmd failed
-	e.OnCommand(cmd).Return("", "", testError).Times(1)
-	_, err = fh.GetFSType(device)
-	assert.NotNil(t, err)
-}
-
 func TestMount(t *testing.T) {
 	var (
 		e   = &mocks.GoMockExecutor{}

--- a/pkg/base/linuxutils/fs/fs_helper_test.go
+++ b/pkg/base/linuxutils/fs/fs_helper_test.go
@@ -227,26 +227,26 @@ func TestUnmount(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func Test_DeviceHasFs(t *testing.T) {
+func Test_GetFSType(t *testing.T) {
 	var (
 		e    = &mocks.GoMockExecutor{}
 		fh   = NewFSImpl(e)
 		path = "/dev/sda"
-		cmd  = fmt.Sprintf(DetectFSCmdTmpl, path)
+		cmd  = fmt.Sprintf(GetFSTypeCmdTmpl, path)
 	)
 
 	e.OnCommand(cmd).Return("", "", nil).Times(1)
-	hasData, err := fh.DeviceFs(path)
+	hasData, err := fh.GetFSType(path)
 	assert.Nil(t, err)
 	assert.Equal(t, "", hasData)
 
 	e.OnCommand(cmd).Return("xfs", "", testError).Times(1)
-	hasData, err = fh.DeviceFs(path)
+	hasData, err = fh.GetFSType(path)
 	assert.NotNil(t, err)
 	assert.Equal(t, "", hasData)
 
 	e.OnCommand(cmd).Return("xfs", "", nil).Times(1)
-	hasData, err = fh.DeviceFs(path)
+	hasData, err = fh.GetFSType(path)
 	assert.Nil(t, err)
 	assert.Equal(t, "xfs", hasData)
 }

--- a/pkg/mocks/linuxutils/fs_helper.go
+++ b/pkg/mocks/linuxutils/fs_helper.go
@@ -27,8 +27,8 @@ type MockWrapFS struct {
 	mock.Mock
 }
 
-// DeviceFs is a mock implementations
-func (m *MockWrapFS) DeviceFs(device string) (string, error) {
+// GetFSType is a mock implementations
+func (m *MockWrapFS) GetFSType(device string) (string, error) {
 	args := m.Mock.Called(device)
 
 	return args.String(0), args.Error(1)
@@ -74,13 +74,6 @@ func (m *MockWrapFS) WipeFS(device string) error {
 	args := m.Mock.Called(device)
 
 	return args.Error(0)
-}
-
-// GetFSType is a mock implementations
-func (m *MockWrapFS) GetFSType(device string) (fs.FileSystem, error) {
-	args := m.Mock.Called(device)
-
-	return args.Get(0).(fs.FileSystem), args.Error(1)
 }
 
 // IsMounted is a mock implementations

--- a/pkg/mocks/provisioners/fs_operations.go
+++ b/pkg/mocks/provisioners/fs_operations.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package provisioners
 
-import mocklu "github.com/dell/csi-baremetal/pkg/mocks/linuxutils"
+import (
+	"github.com/dell/csi-baremetal/pkg/base/linuxutils/fs"
+	mocklu "github.com/dell/csi-baremetal/pkg/mocks/linuxutils"
+)
 
 // MockFsOpts is a mock implementation of FSOperation interface from volumeprovisioner package
 type MockFsOpts struct {
@@ -40,6 +43,13 @@ func (m *MockFsOpts) MountFakeTmpfs(volumeID, path string) error {
 // UnmountWithCheck is a mock implementation
 func (m *MockFsOpts) UnmountWithCheck(path string) error {
 	args := m.Mock.Called(path)
+
+	return args.Error(0)
+}
+
+// CreateFSIfNotExist is a mock implementation
+func (m *MockFsOpts) CreateFSIfNotExist(fsType fs.FileSystem, device string) error {
+	args := m.Mock.Called(fsType, device)
 
 	return args.Error(0)
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -238,10 +238,10 @@ func (s *CSINodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	if currStatus != apiV1.VolumeReady {
 		volumeCR.Spec.CSIStatus = newStatus
-		//if err := s.k8sClient.UpdateCR(ctx, volumeCR); err == nil {
-		ll.Errorf("Unable to set volume status to %s: %v", newStatus, err)
-		resp, errToReturn = nil, fmt.Errorf("failed to stage volume: update volume CR error")
-		//}
+		if err := s.k8sClient.UpdateCR(ctx, volumeCR); err == nil {
+			ll.Errorf("Unable to set volume status to %s: %v", newStatus, err)
+			resp, errToReturn = nil, fmt.Errorf("failed to stage volume: update volume CR error")
+		}
 	}
 
 	return resp, errToReturn

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -238,7 +238,7 @@ func (s *CSINodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	if currStatus != apiV1.VolumeReady {
 		volumeCR.Spec.CSIStatus = newStatus
-		if err := s.k8sClient.UpdateCR(ctx, volumeCR); err == nil {
+		if err := s.k8sClient.UpdateCR(ctx, volumeCR); err != nil {
 			ll.Errorf("Unable to set volume status to %s: %v", newStatus, err)
 			resp, errToReturn = nil, fmt.Errorf("failed to stage volume: update volume CR error")
 		}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -238,10 +238,10 @@ func (s *CSINodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	if currStatus != apiV1.VolumeReady {
 		volumeCR.Spec.CSIStatus = newStatus
-		if err := s.k8sClient.UpdateCR(ctx, volumeCR); err != nil {
-			ll.Errorf("Unable to set volume status to %s: %v", newStatus, err)
-			resp, errToReturn = nil, fmt.Errorf("failed to stage volume: update volume CR error")
-		}
+		//if err := s.k8sClient.UpdateCR(ctx, volumeCR); err == nil {
+		ll.Errorf("Unable to set volume status to %s: %v", newStatus, err)
+		resp, errToReturn = nil, fmt.Errorf("failed to stage volume: update volume CR error")
+		//}
 	}
 
 	return resp, errToReturn

--- a/pkg/node/provisioners/drive_provisioner.go
+++ b/pkg/node/provisioners/drive_provisioner.go
@@ -48,7 +48,7 @@ const (
 type DriveProvisioner struct {
 	listBlk lsblk.WrapLsblk
 	// fsOps uses for operations with file systems
-	fsOps fs.WrapFS
+	fsOps uw.FSOperations
 	// partOps uses for operations with partitions
 	partOps uw.PartitionOperations
 
@@ -65,7 +65,7 @@ func NewDriveProvisioner(
 	log *logrus.Logger) *DriveProvisioner {
 	return &DriveProvisioner{
 		listBlk:   lsblk.NewLSBLK(log),
-		fsOps:     fs.NewFSImpl(e),
+		fsOps:     uw.NewFSOperationsImpl(e, log),
 		partOps:   uw.NewPartitionOperationsImpl(e, log),
 		k8sClient: k,
 		crHelper:  k8s.NewCRHelper(k, log),
@@ -119,10 +119,9 @@ func (d *DriveProvisioner) PrepareVolume(vol api.Volume) error {
 		ll.Errorf("Unable to prepare partition: %v", err)
 		return fmt.Errorf("unable to prepare partition for volume %v", vol)
 	}
-	ll.Infof("Partition was created successfully %v", partPtr)
+	ll.Infof("Partition was created successfully %+v", partPtr)
 
-	// create FS
-	return d.fsOps.CreateFS(fs.FileSystem(vol.Type), partPtr.GetFullPath())
+	return d.fsOps.CreateFSIfNotExist(fs.FileSystem(vol.Type), partPtr.GetFullPath())
 }
 
 // ReleaseVolume remove FS and partition based on vol attributes.

--- a/pkg/node/provisioners/lvm_provisioner_test.go
+++ b/pkg/node/provisioners/lvm_provisioner_test.go
@@ -91,7 +91,7 @@ func TestLVMProvisioner_PrepareVolume_Fail(t *testing.T) {
 		Return(nil).Times(1)
 
 	devFile := fmt.Sprintf("/dev/%s/%s", testVolume1.Location, testVolume1.Id)
-	fsOps.On("CreateFS", fs.FileSystem(testVolume1.Type), devFile).
+	fsOps.On("CreateFSIfNotExist", fs.FileSystem(testVolume1.Type), devFile).
 		Return(errTest).Times(1)
 
 	err = lp.PrepareVolume(testVolume1)

--- a/pkg/node/provisioners/lvm_provisioner_test.go
+++ b/pkg/node/provisioners/lvm_provisioner_test.go
@@ -58,7 +58,7 @@ func TestLVMProvisioner_PrepareVolume_Success(t *testing.T) {
 		Return(nil).Times(1)
 
 	devFile := fmt.Sprintf("/dev/%s/%s", testVolume1.Location, testVolume1.Id)
-	fsOps.On("CreateFS", fs.FileSystem(testVolume1.Type), devFile).
+	fsOps.On("CreateFSIfNotExist", fs.FileSystem(testVolume1.Type), devFile).
 		Return(nil).Times(1)
 
 	err := lp.PrepareVolume(testVolume1)

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -191,7 +191,7 @@ func (fsOp *FSOperationsImpl) CreateFSIfNotExist(fsType fs.FileSystem, device st
 	})
 
 	// check FS
-	existingFS, err := fsOp.DeviceFs(device)
+	existingFS, err := fsOp.GetFSType(device)
 	if err != nil {
 		ll.Errorf("Unable to check FS type on %s: %s", device, err)
 		return err

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -35,6 +35,8 @@ type FSOperations interface {
 	MountFakeTmpfs(volumeID, dst string) error
 	// UnmountWithCheck unmount operation
 	UnmountWithCheck(path string) error
+	// CreateFSIfNotExist checks FS and creates one if not exist
+	CreateFSIfNotExist(fsType fs.FileSystem, device string) error
 	fs.WrapFS
 }
 
@@ -156,7 +158,9 @@ func (fsOp *FSOperationsImpl) MountFakeTmpfs(volumeID, dst string) error {
 		CMD example:
 			mount -t tmpfs -o size=1M,ro <volumeID> <dst>
 	*/
-	ll := fsOp.log.WithFields(logrus.Fields{"method": "FakeAttach"})
+	ll := fsOp.log.WithFields(logrus.Fields{
+		"method": "MountFakeTmpfs",
+	})
 
 	ll.Warningf("Simulate attachment")
 	_, err := os.Stat(dst)
@@ -171,4 +175,42 @@ func (fsOp *FSOperationsImpl) MountFakeTmpfs(volumeID, dst string) error {
 	}
 
 	return fsOp.Mount(volumeID, dst, "-t tmpfs -o size=1M,ro")
+}
+
+// CreateFSIfNotExist checks FS and creates one if not exist
+/*
+	CMD example:
+		lsblk <device> --output FSTYPE --noheadings
+		# Check output
+
+		mkfs.<fsType> <device>
+*/
+func (fsOp *FSOperationsImpl) CreateFSIfNotExist(fsType fs.FileSystem, device string) error {
+	ll := fsOp.log.WithFields(logrus.Fields{
+		"method": "CreateFSIfNotExist",
+	})
+
+	// check FS
+	existingFS, err := fsOp.DeviceFs(device)
+	if err != nil {
+		ll.Errorf("Unable to check FS type on %s: %s", device, err)
+		return err
+	}
+	if fs.FileSystem(existingFS) == fsType {
+		ll.Warnf("FS on %s with type %s is already exist, skip creating", device, fs.FileSystem(existingFS))
+		return nil
+	}
+	if existingFS != "" {
+		ll.Errorf("device %s is not empty. Existing FS - %s", device, fsType)
+		return fmt.Errorf("device %s is not empty. Existing FS - %s", device, fsType)
+	}
+
+	// create FS
+	err = fsOp.CreateFS(fsType, device)
+	if err != nil {
+		ll.Errorf("Unable to create FS type %s on %s: %s", fsType, device, err)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -193,7 +193,7 @@ func (fsOp *FSOperationsImpl) CreateFSIfNotExist(fsType fs.FileSystem, device st
 	// check FS
 	existingFS, err := fsOp.GetFSType(device)
 	if err != nil {
-		ll.Errorf("Unable to check FS type on %s: %s", device, err)
+		ll.Errorf("Unable to check FS type on %s: %v", device, err)
 		return err
 	}
 	if fs.FileSystem(existingFS) == fsType {
@@ -208,7 +208,7 @@ func (fsOp *FSOperationsImpl) CreateFSIfNotExist(fsType fs.FileSystem, device st
 	// create FS
 	err = fsOp.CreateFS(fsType, device)
 	if err != nil {
-		ll.Errorf("Unable to create FS type %s on %s: %s", fsType, device, err)
+		ll.Errorf("Unable to create FS type %s on %s: %v", fsType, device, err)
 		return err
 	}
 

--- a/pkg/node/provisioners/utilwrappers/fs_operations_test.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations_test.go
@@ -235,6 +235,7 @@ func TestFSOperationsImpl_CreateFSIfNotExist_CheckError(t *testing.T) {
 	err = fsOps.CreateFSIfNotExist(fs.FileSystem(fsType), path)
 	assert.NotNil(t, err)
 }
+
 func TestFSOperationsImpl_CreateFSIfNotExist_CreateError(t *testing.T) {
 	var (
 		fsOps  = NewFSOperationsImpl(&command.Executor{}, logrus.New())

--- a/pkg/node/provisioners/utilwrappers/fs_operations_test.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations_test.go
@@ -170,3 +170,84 @@ func TestFSOperationsImpl_MountWithCheck_Fail(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, unmountErr, err)
 }
+
+func TestFSOperationsImpl_CreateFSIfNotExist_NoFS(t *testing.T) {
+	var (
+		fsOps  = NewFSOperationsImpl(&command.Executor{}, logrus.New())
+		wrapFS = &mocklu.MockWrapFS{}
+		path   = "/some/path"
+		fsType = "xfs"
+		err    error
+	)
+	fsOps.WrapFS = wrapFS
+
+	wrapFS.On("GetFSType", path).Return("", nil).Once()
+	wrapFS.On("CreateFS", fs.FileSystem(fsType), path).Return(nil).Once()
+
+	err = fsOps.CreateFSIfNotExist(fs.FileSystem(fsType), path)
+	assert.Nil(t, err)
+}
+
+func TestFSOperationsImpl_CreateFSIfNotExist_FSExists(t *testing.T) {
+	var (
+		fsOps  = NewFSOperationsImpl(&command.Executor{}, logrus.New())
+		wrapFS = &mocklu.MockWrapFS{}
+		path   = "/some/path"
+		fsType = "xfs"
+		err    error
+	)
+	fsOps.WrapFS = wrapFS
+
+	wrapFS.On("GetFSType", path).Return(fsType, nil).Once()
+
+	err = fsOps.CreateFSIfNotExist(fs.FileSystem(fsType), path)
+	assert.Nil(t, err)
+}
+
+func TestFSOperationsImpl_CreateFSIfNotExist_OtherFS(t *testing.T) {
+	var (
+		fsOps  = NewFSOperationsImpl(&command.Executor{}, logrus.New())
+		wrapFS = &mocklu.MockWrapFS{}
+		path   = "/some/path"
+		fsType = "xfs"
+		err    error
+	)
+	fsOps.WrapFS = wrapFS
+
+	wrapFS.On("GetFSType", path).Return("other_FS", nil).Once()
+
+	err = fsOps.CreateFSIfNotExist(fs.FileSystem(fsType), path)
+	assert.NotNil(t, err)
+}
+
+func TestFSOperationsImpl_CreateFSIfNotExist_CheckError(t *testing.T) {
+	var (
+		fsOps  = NewFSOperationsImpl(&command.Executor{}, logrus.New())
+		wrapFS = &mocklu.MockWrapFS{}
+		path   = "/some/path"
+		fsType = "xfs"
+		err    error
+	)
+	fsOps.WrapFS = wrapFS
+
+	wrapFS.On("GetFSType", path).Return("", errors.New("some_error")).Once()
+
+	err = fsOps.CreateFSIfNotExist(fs.FileSystem(fsType), path)
+	assert.NotNil(t, err)
+}
+func TestFSOperationsImpl_CreateFSIfNotExist_CreateError(t *testing.T) {
+	var (
+		fsOps  = NewFSOperationsImpl(&command.Executor{}, logrus.New())
+		wrapFS = &mocklu.MockWrapFS{}
+		path   = "/some/path"
+		fsType = "xfs"
+		err    error
+	)
+	fsOps.WrapFS = wrapFS
+
+	wrapFS.On("GetFSType", path).Return("", nil).Once()
+	wrapFS.On("CreateFS", fs.FileSystem(fsType), path).Return(errors.New("some_error")).Once()
+
+	err = fsOps.CreateFSIfNotExist(fs.FileSystem(fsType), path)
+	assert.NotNil(t, err)
+}

--- a/pkg/node/provisioners/utilwrappers/partition_operations.go
+++ b/pkg/node/provisioners/utilwrappers/partition_operations.go
@@ -112,7 +112,7 @@ func (d *PartitionOperationsImpl) PreparePartition(p Partition) (*Partition, err
 			ll.Infof("Partition has already prepared.")
 			p.Name = d.SearchPartName(p.Device, p.PartUUID)
 			if p.Name == "" {
-				return nil, fmt.Errorf("unable to determine partition name after it being created: %v", err)
+				return nil, fmt.Errorf("unable to determine partition name after it being created: %w", err)
 			}
 			return &p, nil
 		}

--- a/pkg/node/provisioners/utilwrappers/partition_operations.go
+++ b/pkg/node/provisioners/utilwrappers/partition_operations.go
@@ -110,6 +110,10 @@ func (d *PartitionOperationsImpl) PreparePartition(p Partition) (*Partition, err
 		}
 		if currUUID == p.PartUUID {
 			ll.Infof("Partition has already prepared.")
+			p.Name = d.SearchPartName(p.Device, p.PartUUID)
+			if p.Name == "" {
+				return nil, fmt.Errorf("unable to determine partition name after it being created: %v", err)
+			}
 			return &p, nil
 		}
 		return nil, fmt.Errorf("partition %v has already exist but have another UUID - %s", p, currUUID)

--- a/pkg/node/provisioners/utilwrappers/parttiion_operations_test.go
+++ b/pkg/node/provisioners/utilwrappers/parttiion_operations_test.go
@@ -39,7 +39,7 @@ var (
 
 	testPart1 = Partition{
 		Device:    testDevice1,
-		Name:      "",
+		Name:      "some_name",
 		Num:       DefaultPartitionNumber,
 		TableType: partitionhelper.PartitionGPT,
 		Label:     DefaultPartitionLabel,
@@ -71,6 +71,10 @@ func TestDriveProvisioner_PreparePartition_Success(t *testing.T) {
 		Return(true, nil).Once()
 	mockPH.On("GetPartitionUUID", testPart1.Device, testPart1.Num).
 		Return(testPart1.PartUUID, nil).Once()
+	mockPH.On("SyncPartitionTable", testPart1.Device).
+		Return(nil).Once()
+	mockPH.On("GetPartitionNameByUUID", testPart1.Device, testPart1.PartUUID).
+		Return(testPart1.Name, nil).Once()
 
 	currentPPtr, err = partOps.PreparePartition(testPart1)
 	assert.Nil(t, err)

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -914,6 +914,7 @@ func (m *VolumeManager) getProvisionerForVolume(vol *api.Volume) p.Provisioner {
 // handleDriveStatusChange removes AC that is based on unhealthy drive, returns AC if drive returned to healthy state,
 // mark volumes of the unhealthy drive as unhealthy.
 // Receives golang context and api.Drive that should be handled
+// TODO the method is called every rime after drive go to OFFLINE - https://github.com/dell/csi-baremetal/issues/550
 func (m *VolumeManager) handleDriveStatusChange(ctx context.Context, drive updatedDrive) {
 	cur := drive.CurrentState.Spec
 	prev := drive.PreviousState.Spec

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -457,13 +457,6 @@ func (m *VolumeManager) prepareVolume(ctx context.Context, volume *volumecrd.Vol
 	}
 
 	volume.Spec.CSIStatus = newStatus
-
-	if volume.Spec.CSIStatus == apiV1.Created {
-		var updateErr error
-		ll.Errorf("Unable to update volume status to %s: %v", newStatus, updateErr)
-		return ctrl.Result{Requeue: true}, updateErr
-	}
-
 	if updateErr := m.k8sClient.UpdateCRWithAttempts(ctx, volume, 5); updateErr != nil {
 		ll.Errorf("Unable to update volume status to %s: %v", newStatus, updateErr)
 		return ctrl.Result{Requeue: true}, updateErr


### PR DESCRIPTION
## Purpose
### Issue #548 

- check existing FS before creating
- rename DetectFS to GetFSType
- fix updating volume health after drive goes to OFFLINE

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Tested manually
Non-LVG volume:
```
Sep 23 12:17:35.849 [INFO] [VolumeManager] [Reconcile] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Processing for status CREATING
Sep 23 12:17:35.849 [INFO] [DriveProvisioner] [PrepareVolume] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Processing for volume {pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e 5c2fb995-d7ff-45e4-8b5b-7b42ff1b5731 DRIVE HDD 8eb38e9e-3a74-4086-a600-2044d51f82d3 [] 105906176 FS xfs GOOD OPERATIVE CREATING IN_USE false {} [] 0}
Sep 23 12:17:35.857 [INFO] [DriveProvisioner] [PrepareVolume] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Search device file for drive with S/N LOOPBACK2205308016
Sep 23 12:17:35.857 [INFO] [DriveProvisioner] [PrepareVolume] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Create partition {/dev/loop41  1 gpt CSI 9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e false} on device /dev/loop41 and set UUID
Sep 23 12:17:35.857 [DEBU] [PartitionOperations] [PreparePartition] [9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Processing for partition utilwrappers.Partition{Device:"/dev/loop41", Name:"", Num:"1", TableType:"gpt", Label:"CSI", PartUUID:"9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e", Ephemeral:false}
Sep 23 12:17:35.906 [DEBU] [Executor] [partprobe -d -s /dev/loop41] [49.286616ms] [49286616] stdout: /dev/loop41: gpt partitions 1

Sep 23 12:17:35.953 [DEBU] [Executor] [sgdisk /dev/loop41 --info=1] [46.577147ms] [46577147] stdout: Partition GUID code: 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem)
Partition unique GUID: 9EA8810C-5745-4FE7-8C3F-E34E25BF8B7E
First sector: 34 (at 17.0 KiB)
Last sector: 206814 (at 101.0 MiB)
Partition size: 206781 sectors (101.0 MiB)
Attribute flags: 0000000000000000
Partition name: 'CSI'

Sep 23 12:17:35.953 [INFO] [PartitionOperations] [PreparePartition] [9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Partition has already prepared.
Sep 23 12:17:35.953 [DEBU] [PartitionOperations] [SearchPartName] [9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Search partition number for device /dev/loop41 and uuid 9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e
Sep 23 12:17:36.103 [DEBU] [Executor] [partprobe /dev/loop41] [149.301095ms] [149301095] stdout: 
Sep 23 12:17:39.114 [DEBU] [PartitionOperations] [SearchPartName] [9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Got partition number p1
Sep 23 12:17:39.114 [INFO] [DriveProvisioner] [PrepareVolume] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Partition was created successfully &{/dev/loop41 p1 1 gpt CSI 9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e false}
Sep 23 12:17:39.118 [DEBU] [Executor] [lsblk /dev/loop41p1 --output FSTYPE --noheadings] [3.944053ms] [3944053] stdout: xfs

Sep 23 12:17:39.118 [WARN] [DriveProvisioner] [PrepareVolume] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] FS on /dev/loop41p1 with type xfs is already exist, skip creating
Sep 23 12:17:39.118 [ERRO] [VolumeManager] [prepareVolume] [pvc-9ea8810c-5745-4fe7-8c3f-e34e25bf8b7e] Unable to update volume status to CREATED: <nil>
```

LVG volume:
```
Sep 23 12:49:32.490 [INFO] [VolumeManager] [Reconcile] [pvc-81b77bda-7616-431a-b39d-6c806a469971] Processing for status CREATING
Sep 23 12:49:32.496 [INFO] [LVMProvisioner] [PrepareVolume] [pvc-81b77bda-7616-431a-b39d-6c806a469971] Processing for volume v1api.Volume{Id:"pvc-81b77bda-7616-431a-b39d-6c806a469971", Location:"5386f10f-29ea-49fe-bc33-ff862a4889dd", LocationType:"LVM", StorageClass:"HDDLVG", NodeId:"ecc5b853-5f78-496d-86c3-58214879415f", Owners:[]string(nil), Size:41943040, Mode:"FS", Type:"xfs", Health:"GOOD", OperationalStatus:"OPERATIVE", CSIStatus:"CREATING", Usage:"IN_USE", Ephemeral:false, XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}
Sep 23 12:49:32.496 [INFO] [LVMProvisioner] [PrepareVolume] [pvc-81b77bda-7616-431a-b39d-6c806a469971] Creating LV pvc-81b77bda-7616-431a-b39d-6c806a469971 sizeof 40m in VG 5386f10f-29ea-49fe-bc33-ff862a4889dd
Sep 23 12:49:33.571 [ERRO] [Executor] [/sbin/lvm lvcreate --yes --name pvc-81b77bda-7616-431a-b39d-6c806a469971 --size 40m 5386f10f-29ea-49fe-bc33-ff862a4889dd] [1.074619665s] [1074619665] stdout: , stderr:   Logical Volume "pvc-81b77bda-7616-431a-b39d-6c806a469971" already exists in volume group "5386f10f-29ea-49fe-bc33-ff862a4889dd"
, Error: exit status 5
Sep 23 12:49:33.571 [DEBU] [LVMProvisioner] [PrepareVolume] [pvc-81b77bda-7616-431a-b39d-6c806a469971] Creating FS on /dev/5386f10f-29ea-49fe-bc33-ff862a4889dd/pvc-81b77bda-7616-431a-b39d-6c806a469971
Sep 23 12:49:33.577 [DEBU] [Executor] [lsblk /dev/5386f10f-29ea-49fe-bc33-ff862a4889dd/pvc-81b77bda-7616-431a-b39d-6c806a469971 --output FSTYPE --noheadings] [6.494411ms] [6494411] stdout: xfs

Sep 23 12:49:33.578 [WARN] [FSOperations] [CreateFSIfNotExist] FS on /dev/5386f10f-29ea-49fe-bc33-ff862a4889dd/pvc-81b77bda-7616-431a-b39d-6c806a469971 with type xfs is already exist, skip creating
Sep 23 12:49:33.578 [ERRO] [VolumeManager] [prepareVolume] [pvc-81b77bda-7616-431a-b39d-6c806a469971] Unable to update volume status to CREATED: <nil>
```
