### PR TITLE
[ISSUE-559] block device name change on node reboot causing fake attach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 # tests results
 coverage.out
 coverage.html
+ci.log
+test/e2e/report.xml
+test/kind/kind
 # vscode
 .vscode
 # python 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-# These owners will be the default owners for everything in the repo

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -190,8 +190,9 @@ func main() {
 	for {
 		logger.Info("Waiting for node service to become ready ...")
 		// never returns error
-
 		resp, _ := csiNodeService.Check(ctx, req)
+		// disk info might be outdated (for example, block device names change on node reboot)
+		// need to wait for drive info to be updated before starting accepting CSI calls
 		if resp.Status == grpc_health_v1.HealthCheckResponse_SERVING {
 			logger.Info("Node service is ready to handle requests")
 			break

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -58,7 +58,7 @@ import (
 )
 
 const (
-	componentName      = "csi-baremetal-node"
+	componentName = "csi-baremetal-node"
 	// on loaded system drive manager might response with the delay
 	numberOfRetries  = 20
 	delayBeforeRetry = 5
@@ -202,13 +202,13 @@ func main() {
 			isVolumeMgrReady = true
 			break
 		} else {
-			logger.Info("Not ready yet. Sleeping %s seconds...", delayBeforeRetry)
+			logger.Info("Not ready yet. Sleeping ...")
 			time.Sleep(delayBeforeRetry * time.Second)
 		}
 	}
 	// exit if not ready
 	if !isVolumeMgrReady {
-		logger.Fatalf("Number of retries %s exceeded. Exiting...", numberOfRetries)
+		logger.Fatalf("Number of retries %d exceeded. Exiting...", numberOfRetries)
 	}
 
 	logger.Info("Starting handle CSI calls ...")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -650,6 +650,8 @@ func (s *CSINodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRe
 
 // Check does the health check and changes the status of the server based on drives cache size
 func (s *CSINodeService) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// parameters aren't used
+	_, _ = ctx, req
 	ll := s.log.WithFields(logrus.Fields{
 		"method": "Check",
 	})

--- a/pkg/node/provisioners/drive_provisioner.go
+++ b/pkg/node/provisioners/drive_provisioner.go
@@ -234,6 +234,7 @@ func (d *DriveProvisioner) GetVolumePath(vol api.Volume) (string, error) {
 
 	partNum := d.partOps.SearchPartName(device, volumeUUID)
 	if partNum == "" {
+		// on device disconnect or node reboot device name might change and we need to re-sync drive info
 		return "", fmt.Errorf("unable to find part name for device %s by uuid %s", device, volumeUUID)
 	}
 	return device + partNum, nil


### PR DESCRIPTION
## Purpose
### Issue #559 

- Wait for the first discover loop cycle to update drive info before accepting CSI call like `NodeStageVolume`
- Non issue related: old CODEOWNERS file removed, gitignore updated, comments added

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Node reboot testing:
1. Device mapping before reboot
````
[core@master2 ~]$ lsblk -o NAME,PARTUUID | grep '└─'
└─sda4                       cadbec17-2bf9-402e-91b3-3b825d8ce38d
  └─coreos-luks-root-nocrypt 
└─sdb1                       9ddecb3b-31cf-4b70-b01f-10d28fe4457b
└─sdc1                       c3a8097c-fc6a-4385-be6b-48876a24cb3a
└─sdd1                       2339763b-f0d5-4481-9a61-47f4307823a8
└─sde1                       f2878d82-1532-4fc7-9fbd-b04d1d7f3e52
└─sdf1                       7cc25856-57d9-442e-a145-c17e43401a22
└─sdg1                       25d3431e-03d5-48d1-9bf8-0cfa9a3c980d
└─sdh1                       cbea3eeb-9c6f-403b-9821-a5611a0b3f75
└─sdi1                       38816922-8187-47a6-844c-e5a4a5a5cfac
└─sdj1                       3af41ef3-b003-4fbd-9a43-aa511039812b
└─sdk1                       dcd761bf-4631-453b-addc-501b9673d74d
└─sdl1                       1b3a62a4-9260-47ee-85bb-04b73eab7bdf
└─sdm1                       73f69cad-cdef-4e57-a3f0-d0f3797b99f9
└─sdn1                       7638a113-d6e4-4976-8040-33f7f2d84954
└─sdo1                       3dcc1501-f351-47ea-89f9-2b92c7dba237
└─sdp1                       fc240d7c-0e67-46f6-a8a7-4795a90df79d
└─sdq1                       af6b45dc-b26c-46ff-9908-4e4548329208
└─sdr1                       dfba876f-214b-4381-80af-19389f560725
└─sdt1                       8a1e99a8-fc86-4393-9efe-d14447ea7283
└─sdu1                       f738ab36-f80f-4469-9e22-5cf750bb32ce
└─sdv1                       2f206cb3-4a8e-40d3-8b43-6808b97e8ecc
└─sdw1                       ad64eb32-4539-4364-ab5e-1d107decea2e
└─sdx1                       fd4b9b9f-b1d5-46c3-a1e0-4267f634eb0e
└─sdy1                       c6fd4b21-4537-4100-a2e6-9a691b844b1a
````
2. Device mapping after reboot
```
[core@master2 ~]$ lsblk -o NAME,PARTUUID | grep '└─'
└─sda4                       cadbec17-2bf9-402e-91b3-3b825d8ce38d
  └─coreos-luks-root-nocrypt 
└─sdb1                       7638a113-d6e4-4976-8040-33f7f2d84954
└─sdc1                       9ddecb3b-31cf-4b70-b01f-10d28fe4457b
└─sdd1                       c3a8097c-fc6a-4385-be6b-48876a24cb3a
└─sde1                       2339763b-f0d5-4481-9a61-47f4307823a8
└─sdf1                       f2878d82-1532-4fc7-9fbd-b04d1d7f3e52
└─sdg1                       7cc25856-57d9-442e-a145-c17e43401a22
└─sdh1                       25d3431e-03d5-48d1-9bf8-0cfa9a3c980d
└─sdi1                       cbea3eeb-9c6f-403b-9821-a5611a0b3f75
└─sdj1                       38816922-8187-47a6-844c-e5a4a5a5cfac
└─sdk1                       3af41ef3-b003-4fbd-9a43-aa511039812b
└─sdl1                       dcd761bf-4631-453b-addc-501b9673d74d
└─sdm1                       1b3a62a4-9260-47ee-85bb-04b73eab7bdf
└─sdn1                       73f69cad-cdef-4e57-a3f0-d0f3797b99f9
└─sdo1                       3dcc1501-f351-47ea-89f9-2b92c7dba237
└─sdp1                       fc240d7c-0e67-46f6-a8a7-4795a90df79d
└─sdq1                       af6b45dc-b26c-46ff-9908-4e4548329208
└─sdr1                       dfba876f-214b-4381-80af-19389f560725
└─sdt1                       8a1e99a8-fc86-4393-9efe-d14447ea7283
└─sdu1                       f738ab36-f80f-4469-9e22-5cf750bb32ce
└─sdv1                       2f206cb3-4a8e-40d3-8b43-6808b97e8ecc
└─sdw1                       ad64eb32-4539-4364-ab5e-1d107decea2e
└─sdx1                       fd4b9b9f-b1d5-46c3-a1e0-4267f634eb0e
└─sdy1                       c6fd4b21-4537-4100-a2e6-9a691b844b1a
```
3. No Fake Attach is involved
```
[root@servicenode ~]# oc exec -it web-0 -- df -h
Filesystem                                                                                              Size  Used Avail Use% Mounted on
overlay                                                                                                 447G   27G  421G   6% /
tmpfs                                                                                                    64M     0   64M   0% /dev
tmpfs                                                                                                    32G     0   32G   0% /sys/fs/cgroup
shm                                                                                                      64M     0   64M   0% /dev/shm
tmpfs                                                                                                    32G   49M   32G   1% /etc/hostname
/dev/mapper/coreos-luks-root-nocrypt                                                                    447G   27G  421G   6% /etc/hosts
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-f738ab36-f80f-4469-9e22-5cf750bb32ce/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-4
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-c6fd4b21-4537-4100-a2e6-9a691b844b1a/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-5
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-dcd761bf-4631-453b-addc-501b9673d74d/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-6
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-73f69cad-cdef-4e57-a3f0-d0f3797b99f9/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-7
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-f2878d82-1532-4fc7-9fbd-b04d1d7f3e52/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-8
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ad64eb32-4539-4364-ab5e-1d107decea2e/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-9
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-2339763b-f0d5-4481-9a61-47f4307823a8/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-10
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8a1e99a8-fc86-4393-9efe-d14447ea7283/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-11
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1b3a62a4-9260-47ee-85bb-04b73eab7bdf/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-3
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-7cc25856-57d9-442e-a145-c17e43401a22/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-12
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-2f206cb3-4a8e-40d3-8b43-6808b97e8ecc/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-14
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-cbea3eeb-9c6f-403b-9821-a5611a0b3f75/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-15
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-3af41ef3-b003-4fbd-9a43-aa511039812b/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-16
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-af6b45dc-b26c-46ff-9908-4e4548329208/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-17
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-c3a8097c-fc6a-4385-be6b-48876a24cb3a/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-18
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-7638a113-d6e4-4976-8040-33f7f2d84954/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-19
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-3dcc1501-f351-47ea-89f9-2b92c7dba237/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-20
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-38816922-8187-47a6-844c-e5a4a5a5cfac/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-2
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-dfba876f-214b-4381-80af-19389f560725/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html
/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-fc240d7c-0e67-46f6-a8a7-4795a90df79d/globalmount/dev  7.3T  7.5G  7.3T   1% /usr/share/nginx/html-13
tmpfs                                                                                                    32G   28K   32G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs                                                                                                    32G     0   32G   0% /proc/acpi
tmpfs                                                                                                    32G     0   32G   0% /proc/scsi
tmpfs                                                                                                    32G     0   32G   0% /sys/firmware
```
4. 
