### PR TITLE
[ISSUE-581] Add App label to Volume CR from PVC

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,7 @@ github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -525,6 +526,7 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.0 h1:Gwkk+PTu/nfOwNMtUB/mRUv0X7ewW5dO4AERT1ThVKo=
 github.com/onsi/gomega v1.10.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/pkg/base/k8s/kubeclient.go
+++ b/pkg/base/k8s/kubeclient.go
@@ -184,7 +184,7 @@ func (k *KubeClient) ConstructACCR(name string, apiAC api.AvailableCapacity) *ac
 		},
 		ObjectMeta: apisV1.ObjectMeta{
 			Name:   name,
-			Labels: constructAppMap(),
+			Labels: constructDefaultAppMap(),
 		},
 		Spec: apiAC,
 	}
@@ -201,7 +201,7 @@ func (k *KubeClient) ConstructACRCR(name string, apiACR api.AvailableCapacityRes
 		},
 		ObjectMeta: apisV1.ObjectMeta{
 			Name:   name,
-			Labels: constructAppMap(),
+			Labels: constructDefaultAppMap(),
 		},
 		Spec: apiACR,
 	}
@@ -218,7 +218,7 @@ func (k *KubeClient) ConstructLVGCR(name string, apiLVG api.LogicalVolumeGroup) 
 		},
 		ObjectMeta: apisV1.ObjectMeta{
 			Name:   name,
-			Labels: constructAppMap(),
+			Labels: constructDefaultAppMap(),
 		},
 		Spec: apiLVG,
 	}
@@ -227,7 +227,7 @@ func (k *KubeClient) ConstructLVGCR(name string, apiLVG api.LogicalVolumeGroup) 
 // ConstructVolumeCR constructs Volume custom resource from api.Volume struct
 // Receives a name for k8s ObjectMeta and an instance of api.Volume struct
 // Returns an instance of Volume CR struct
-func (k *KubeClient) ConstructVolumeCR(name string, namespace string, apiVolume api.Volume) *volumecrd.Volume {
+func (k *KubeClient) ConstructVolumeCR(name, namespace, appName string, apiVolume api.Volume) *volumecrd.Volume {
 	return &volumecrd.Volume{
 		TypeMeta: apisV1.TypeMeta{
 			Kind:       crdV1.VolumeKind,
@@ -236,7 +236,7 @@ func (k *KubeClient) ConstructVolumeCR(name string, namespace string, apiVolume 
 		ObjectMeta: apisV1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    constructAppMap(),
+			Labels:    constructCustomAppMap(appName),
 		},
 		Spec: apiVolume,
 	}
@@ -253,7 +253,7 @@ func (k *KubeClient) ConstructDriveCR(name string, apiDrive api.Drive) *drivecrd
 		},
 		ObjectMeta: apisV1.ObjectMeta{
 			Name:   name,
-			Labels: constructAppMap(),
+			Labels: constructDefaultAppMap(),
 		},
 		Spec: apiDrive,
 	}
@@ -270,7 +270,7 @@ func (k *KubeClient) ConstructCSIBMNodeCR(name string, csiNode api.Node) *nodecr
 		},
 		ObjectMeta: apisV1.ObjectMeta{
 			Name:   name,
-			Labels: constructAppMap(),
+			Labels: constructDefaultAppMap(),
 		},
 		Spec: csiNode,
 	}
@@ -452,9 +452,13 @@ func PrepareScheme() (*runtime.Scheme, error) {
 }
 
 // constructAppMap creates the map contains app labels
-func constructAppMap() map[string]string {
+func constructDefaultAppMap() map[string]string {
+	return constructCustomAppMap(AppLabelValue)
+}
+
+func constructCustomAppMap(appName string) map[string]string {
 	return map[string]string{
-		AppLabelKey:      AppLabelValue,
-		AppLabelShortKey: AppLabelValue,
+		AppLabelKey:      appName,
+		AppLabelShortKey: appName,
 	}
 }

--- a/pkg/base/k8s/kubeclient_test.go
+++ b/pkg/base/k8s/kubeclient_test.go
@@ -44,6 +44,7 @@ const (
 	testID             = "someID"
 	testNode1Name      = "node1"
 	testDriveLocation1 = "drive"
+	testApp            = "app"
 )
 
 var (
@@ -441,6 +442,7 @@ var _ = Describe("Constructor methods", func() {
 			Expect(constructedCR.ObjectMeta.Name).To(Equal(testACCR.ObjectMeta.Name))
 			Expect(constructedCR.ObjectMeta.Namespace).To(Equal(testACCR.ObjectMeta.Namespace))
 			Expect(constructedCR.Spec).To(Equal(testACCR.Spec))
+			Expect(constructedCR.Labels).To(Equal(constructDefaultAppMap()))
 		})
 	})
 	Context("ConstructDriveCR", func() {
@@ -451,16 +453,18 @@ var _ = Describe("Constructor methods", func() {
 			Expect(constructedCR.ObjectMeta.Name).To(Equal(testDriveCR.ObjectMeta.Name))
 			Expect(constructedCR.ObjectMeta.Namespace).To(Equal(testDriveCR.ObjectMeta.Namespace))
 			Expect(constructedCR.Spec).To(Equal(testDriveCR.Spec))
+			Expect(constructedCR.Labels).To(Equal(constructDefaultAppMap()))
 		})
 	})
 	Context("ConstructVolumeCR", func() {
 		It("Should return right Volume CR", func() {
-			constructedCR := k8sclient.ConstructVolumeCR(testApiVolume.Id, testNs, testApiVolume)
+			constructedCR := k8sclient.ConstructVolumeCR(testApiVolume.Id, testNs, testApp, testApiVolume)
 			Expect(constructedCR.TypeMeta.Kind).To(Equal(testVolumeCR.TypeMeta.Kind))
 			Expect(constructedCR.TypeMeta.APIVersion).To(Equal(testVolumeCR.TypeMeta.APIVersion))
 			Expect(constructedCR.ObjectMeta.Name).To(Equal(testVolumeCR.ObjectMeta.Name))
 			Expect(constructedCR.ObjectMeta.Namespace).To(Equal(testVolumeCR.ObjectMeta.Namespace))
 			Expect(constructedCR.Spec).To(Equal(testVolumeCR.Spec))
+			Expect(constructedCR.Labels).To(Equal(constructCustomAppMap(testApp)))
 		})
 	})
 	Context("ConstructLVGCR", func() {
@@ -471,6 +475,7 @@ var _ = Describe("Constructor methods", func() {
 			Expect(constructedCR.ObjectMeta.Name).To(Equal(testLVGCR.ObjectMeta.Name))
 			Expect(constructedCR.ObjectMeta.Namespace).To(Equal(testLVGCR.ObjectMeta.Namespace))
 			Expect(constructedCR.Spec).To(Equal(testLVGCR.Spec))
+			Expect(constructedCR.Labels).To(Equal(constructDefaultAppMap()))
 		})
 	})
 })

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -146,7 +146,7 @@ func (c *CSIControllerService) CreateVolume(ctx context.Context, req *csi.Create
 		"method":   "CreateVolume",
 		"volumeID": req.GetName(),
 	})
-	ll.Infof("Processing request: %v", req)
+	ll.Infof("Processing request: %+v", req)
 
 	if req.GetName() == "" {
 		return nil, status.Error(codes.InvalidArgument, "Volume name missing in request")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -56,6 +56,7 @@ var (
 	testLogger = logrus.New()
 	testID     = "someID"
 	testNs     = "default"
+	testApp    = "app"
 
 	testCtx       = context.Background()
 	testNode1Name = "node1"
@@ -221,6 +222,7 @@ var _ = Describe("CSIControllerService CreateVolume", func() {
 			err = controller.k8sclient.ReadCR(context.Background(), "req1", testNs, vol)
 			Expect(err).To(BeNil())
 			Expect(vol.Spec.CSIStatus).To(Equal(apiV1.Created))
+			Expect(vol.Labels[k8s.AppLabelKey], testApp)
 		})
 		It("Volume CR has already exists", func() {
 			uuid := "uuid-1234"
@@ -297,7 +299,7 @@ var _ = Describe("CSIControllerService DeleteVolume", func() {
 				err       error
 			)
 			// create volume crd to delete
-			volumeCrd = controller.k8sclient.ConstructVolumeCR(volumeID, testNs, api.Volume{Id: volumeID, CSIStatus: apiV1.Created})
+			volumeCrd = controller.k8sclient.ConstructVolumeCR(volumeID, testNs, testApp, api.Volume{Id: volumeID, CSIStatus: apiV1.Created})
 			err = controller.k8sclient.CreateCR(testCtx, volumeID, volumeCrd)
 			Expect(err).To(BeNil())
 			fillCache(controller, volumeID, testNs)

--- a/test/app/nginx.yaml
+++ b/test/app/nginx.yaml
@@ -9,10 +9,12 @@ spec:
   selector:
     matchLabels:
       app: nginx
+      app.kubernetes.io/name: nginx
   template:
     metadata:
       labels:
         app: nginx
+        app.kubernetes.io/name: nginx
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
## Purpose
### Issue #581 

- Check PVC labels on CreateVolume request
- If it contains `app.kubernetes.io/name`, add it to Volume CR
- If empty, `app.kubernetes.io/name=""`

## PR checklist
- [ ] Add link to the issue
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing

PVC
```
Name:          www-web-2
Namespace:     default
StorageClass:  csi-baremetal-sc
Status:        Pending
Volume:        
Labels:        app=nginx
               app.kubernetes.io/name=nginx
```

Volume CR
```
user@user-vm ~/g/s/g/dell> kd volume
Name:         pvc-e4da7535-ae7f-44f5-aac6-1143af5af8b1
Namespace:    default
Labels:       app=nginx
              app.kubernetes.io/name=nginx
```
