### PR TITLE
[ISSUE-596] Extend Locate statuses with N/A

### DIFF
--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -128,8 +128,9 @@ const (
 	LocateStop   = int32(1)
 	LocateStatus = int32(2)
 
-	LocateStatusOn  = int32(1)
 	LocateStatusOff = int32(0)
+	LocateStatusOn  = int32(1)
+	LocateStatusNa  = int32(2)
 
 	DockerImageKernelVersion = "5.4"
 )

--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -128,9 +128,9 @@ const (
 	LocateStop   = int32(1)
 	LocateStatus = int32(2)
 
-	LocateStatusOff = int32(0)
-	LocateStatusOn  = int32(1)
-	LocateStatusNa  = int32(2)
+	LocateStatusOff          = int32(0)
+	LocateStatusOn           = int32(1)
+	LocateStatusNotAvailable = int32(2)
 
 	DockerImageKernelVersion = "5.4"
 )

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -346,7 +346,7 @@ func (c *Controller) handleDriveUsageRemoved(ctx context.Context, log *logrus.En
 func (c *Controller) locateDriveLED(ctx context.Context, log *logrus.Entry, drive *drivecrd.Drive) {
 	// try to enable LED
 	status, err := c.driveMgrClient.Locate(ctx, &api.DriveLocateRequest{Action: apiV1.LocateStart, DriveSerialNumber: drive.Spec.SerialNumber})
-	if err != nil || status.Status != apiV1.LocateStatusOn {
+	if err != nil || (status.Status != apiV1.LocateStatusOn && status.Status != apiV1.LocateStatusNa) {
 		log.Errorf("Failed to locate LED of drive %s, LED status - %+v, err %v", drive.Spec.SerialNumber, status, err)
 		drive.Spec.Usage = apiV1.DriveUsageFailed
 		// send error level alert

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -346,7 +346,7 @@ func (c *Controller) handleDriveUsageRemoved(ctx context.Context, log *logrus.En
 func (c *Controller) locateDriveLED(ctx context.Context, log *logrus.Entry, drive *drivecrd.Drive) {
 	// try to enable LED
 	status, err := c.driveMgrClient.Locate(ctx, &api.DriveLocateRequest{Action: apiV1.LocateStart, DriveSerialNumber: drive.Spec.SerialNumber})
-	if err != nil || (status.Status != apiV1.LocateStatusOn && status.Status != apiV1.LocateStatusNa) {
+	if err != nil || (status.Status != apiV1.LocateStatusOn && status.Status != apiV1.LocateStatusNotAvailable) {
 		log.Errorf("Failed to locate LED of drive %s, LED status - %+v, err %v", drive.Spec.SerialNumber, status, err)
 		drive.Spec.Usage = apiV1.DriveUsageFailed
 		// send error level alert


### PR DESCRIPTION
### Resolves #596

Add Locate NA status - Locate status can't be detected,
locateDriveLED must to expected NA as correct status.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing

Desk replacement with internal disks.
Drivemgr:

```
Nov  1 10:15:40.483 [INFO] [HALManager] [Locate] [0] [Y99GK5GJF7EE] Locate finished successfully, current led status - 2
```
Events:
```
4m49s Warning DriveReadyForPhysicalRemoval drive/4bee1fb4-2424-4709-9866-cdd6b1fd7de8 Drive successfully removed from CSI, and ready for physical removal, Drive Details: SN='Y99GK5GJF7EE', Model='ATA TOSHIBA MG04ACA2', Type='HDD', Size='2000000000000', Firmware='FK5D', Slot='0'
```