### PR TITLE
[ISSUE-600] Update CSI version to 1.0.0

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -29,7 +29,7 @@ const (
 	PluginName = "csi-baremetal"
 	// PluginVersion is a version of current CSI plugin
 	// TODO: get rid of hardcoded value https://github.com/dell/csi-baremetal/issues/79
-	PluginVersion = "0.5.0"
+	PluginVersion = "1.0.0"
 	// DefaultDriveMgrEndpoint is the default gRPC endpoint for drivemgr
 	DefaultDriveMgrEndpoint = "tcp://:8888"
 	// DefaultHealthIP is the default gRPC IP for Health server

--- a/variables.mk
+++ b/variables.mk
@@ -8,8 +8,8 @@ CONTROLLER_GEN_BIN=./bin/controller-gen
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 ### version
-MAJOR            := 0
-MINOR            := 5
+MAJOR            := 1
+MINOR            := 0
 PATCH            := 0
 PRODUCT_VERSION  ?= ${MAJOR}.${MINOR}.${PATCH}
 BUILD_REL_A      := $(shell git rev-list HEAD |wc -l)


### PR DESCRIPTION
## Purpose
### Resolves #600 

Switch CSI version to 1.0.0

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
$ docker images | grep 1.0.0
asdrepo.isus.emc.com:9042/csi-baremetal-node-controller      1.0.0-480.bd80c9c   dff2e07733b5        47 seconds ago       49.7MB
asdrepo.isus.emc.com:9042/csi-baremetal-scheduler            1.0.0-480.bd80c9c   4b57aee9c704        51 seconds ago       62.9MB
asdrepo.isus.emc.com:9042/csi-baremetal-scheduler-extender   1.0.0-480.bd80c9c   4070493f3b47        53 seconds ago       58.7MB
asdrepo.isus.emc.com:9042/csi-baremetal-controller           1.0.0-480.bd80c9c   2a05d1959873        58 seconds ago       62.1MB
asdrepo.isus.emc.com:9042/csi-baremetal-node-kernel-5.4      1.0.0-480.bd80c9c   064b93991622        About a minute ago   272MB
asdrepo.isus.emc.com:9042/csi-baremetal-node                 1.0.0-480.bd80c9c   e411b5b4aab3        About a minute ago   190MB
asdrepo.isus.emc.com:9042/csi-baremetal-basemgr              1.0.0-480.bd80c9c   a8b86653ba0b        About a minute ago   131MB
asdrepo.isus.emc.com:9042/csi-baremetal-scheduler-patcher    1.0.0-480.bd80c9c   eb3b771a909a        7 weeks ago          87MB
```