### PR TITLE
[ISSUE-616] block pr merge when UTs code coverage decreased

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v1.0.2
-      continue-on-error: true  # added here as workaround for codecov-action on validation of PR from forked repo
+      continue-on-error: false # comment this line as workaround for codecov-action on validation of PR from forked repo
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.out


### PR DESCRIPTION
## Purpose
### Resolves #616 

Make `codecov` check pass mandatory

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
n/a
