### PR TITLE
[ISSUE-624] Remove a mount temporary directory during NodeUnstageVolume() call

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -305,7 +305,13 @@ func (s *CSINodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 	)
 
 	if volumeCR.Annotations[fakeAttachVolumeAnnotation] != fakeAttachVolumeKey {
-		if errToReturn = s.fsOps.UnmountWithCheck(getStagingPath(ll, req.GetStagingTargetPath())); errToReturn != nil {
+		targetPath := getStagingPath(ll, req.GetStagingTargetPath())
+		errToReturn = s.fsOps.UnmountWithCheck(targetPath)
+		if errToReturn == nil {
+			errToReturn = s.fsOps.RmDir(targetPath)
+		}
+
+		if errToReturn != nil {
 			volumeCR.Spec.CSIStatus = apiV1.Failed
 			resp = nil
 		}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -406,10 +406,10 @@ var _ = Describe("CSINodeService NodeUnStage()", func() {
 
 	Context("NodeUnStage() success", func() {
 		It("Should unstage volume", func() {
-			Skip("NodeUnstageVolume skipped")
 			req := getNodeUnstageRequest(testV1ID, stagePath)
-			fsOps.On("UnmountWithCheck",
-				path.Join(req.GetStagingTargetPath(), stagingFileName)).Return(nil)
+			targetPath := path.Join(req.GetStagingTargetPath(), stagingFileName)
+			fsOps.On("UnmountWithCheck", targetPath).Return(nil)
+			fsOps.On("RmDir", targetPath).Return(nil)
 
 			resp, err := node.NodeUnstageVolume(testCtx, req)
 			Expect(resp).NotTo(BeNil())
@@ -484,12 +484,13 @@ var _ = Describe("CSINodeService NodeUnStage()", func() {
 
 	Context("NodeUnStage() concurrent requests", func() {
 		It("Should unstage volume one time", func() {
-			Skip("muted NodeUnstageVolume skipped")
 			req := getNodeUnstageRequest(testV1ID, stagePath)
 			secondUnstageErr := make(chan error)
 			// UnmountWithCheck should only once respond with no error
+			targetPath := path.Join(req.GetStagingTargetPath(), stagingFileName)
+			fsOps.On("RmDir", targetPath).Return(nil)
 			fsOps.On("UnmountWithCheck",
-				path.Join(req.GetStagingTargetPath(), stagingFileName)).Return(nil).Run(func(_ mock.Arguments) {
+				targetPath).Return(nil).Run(func(_ mock.Arguments) {
 				go func() {
 					_, err := node.NodeUnstageVolume(testCtx, req)
 					secondUnstageErr <- err

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -406,6 +406,7 @@ var _ = Describe("CSINodeService NodeUnStage()", func() {
 
 	Context("NodeUnStage() success", func() {
 		It("Should unstage volume", func() {
+			Skip("NodeUnstageVolume skipped")
 			req := getNodeUnstageRequest(testV1ID, stagePath)
 			fsOps.On("UnmountWithCheck",
 				path.Join(req.GetStagingTargetPath(), stagingFileName)).Return(nil)
@@ -483,6 +484,7 @@ var _ = Describe("CSINodeService NodeUnStage()", func() {
 
 	Context("NodeUnStage() concurrent requests", func() {
 		It("Should unstage volume one time", func() {
+			Skip("muted NodeUnstageVolume skipped")
 			req := getNodeUnstageRequest(testV1ID, stagePath)
 			secondUnstageErr := make(chan error)
 			// UnmountWithCheck should only once respond with no error


### PR DESCRIPTION
## Purpose
### Resolves #624 

Removing of a mount temporary directory during NodeUnstageVolume() call

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
These changes have been tested on RKE cluster 
