### PR TITLE
[ISSUE-637] Support k8s 1.22 version for csi

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -22,7 +22,7 @@ TAG              := ${FULL_VERSION}
 BRANCH           := $(shell git rev-parse --abbrev-ref HEAD)
 
 ### third-party components version
-CSI_PROVISIONER_TAG := v1.6.0
+CSI_PROVISIONER_TAG := v3.0.0
 CSI_RESIZER_TAG     := v1.1.0
 CSI_REGISTRAR_TAG   := v1.3.0
 LIVENESS_PROBE_TAG  := v2.1.0


### PR DESCRIPTION
Signed-off-by: Nikita Mikhnenko <nikita_mikhnenko@dell.com>

## Purpose
### Resolves #637 

Updating csi-provisioner version to v3.0.0 to support k8s v1.22.0

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
