### PR TITLE
[ISSUE-123] Pre-provisioned volumes documentation

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -140,7 +140,7 @@ kind-install: kind-build
 	rm -f /usr/bin/kind
 
 	# Copy executive file
-	mv $(KIND) /usr/bin
+	cp $(KIND) /usr/bin
 
 	# Check
 	kind version

--- a/docs/pre-provisioned-volumes.md
+++ b/docs/pre-provisioned-volumes.md
@@ -1,0 +1,121 @@
+# Title: Pre-provisioned Volumes support
+
+Last updated: 9-Dec-2021 
+
+
+## Abstract
+
+CSI must be able to work with pre-provisioned volumes.
+
+## Background
+
+Pre-provisioned volumes are volumes whuch we created manually by administrator. 
+
+## Proposal
+
+1. Choose the drive which you plan to use
+2. Make sure that it has available capacity fits to your volume
+3. Generate volume UUID
+```
+uuidgen
+```
+4. Create Volume custom resource
+```
+apiVersion: csi-baremetal.dell.com/v1
+kind: Volume
+metadata:
+  finalizers:
+  - dell.emc.csi/volume-cleanup
+  name: pvc-<UUID>
+  namespace: default
+spec:
+  CSIStatus: CREATING
+  Health: GOOD
+  Id: pvc-<UUID>
+  Location: <CSI drive UUID>
+  LocationType: DRIVE
+  Mode: <FS/RAW/RAW_PART>
+  NodeId: <CSI node UUID>
+  OperationalStatus: OPERATIVE
+  Size: <CSI drive size>
+  StorageClass: <Storage Class>
+  # For FS Mode only  
+  Type: <FS TYPE>
+  Usage: IN_USE
+```
+5. Wait for CSIStatus to be CREATED
+6. Create Persistent Volume
+```
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pvc-<UUID>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: <SIZE> 
+  csi:
+    driver: csi-baremetal
+    fsType: <FS TYPE> 
+    volumeAttributes:
+      csi.storage.k8s.io/pv/name: pvc-<UUID>
+      csi.storage.k8s.io/pvc/namespace: <NAMESPACE>
+      fsType: <FS TYPE> 
+      storageType: <Storage Class> 
+    volumeHandle: pvc-<UUID>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: nodes.csi-baremetal.dell.com/uuid
+          operator: In
+          values:
+          - <CSI Node UUID>
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: <csi-baremetal sc name>
+  volumeMode: <Filesystem/Raw>
+```
+7. Create Kubernetes Persistent Volume Claim
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <claim name>
+  namespace: <NAMESPACE>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: <size>
+  storageClassName: <csi-baremetal sc name>
+  volumeMode: <Filesystem/Raw>
+  volumeName: pvc-<UUID>
+```
+8. Use PVC for your application
+
+## Rationale
+
+[A discussion of alternate approaches and the trade offs, advantages, and disadvantages of the specified approach.]
+
+## Compatibility
+
+[A discussion of the change with regard to the compatibility with previous product and Kubernetes versions.]
+
+## Implementation
+
+[A description of the steps in the implementation, who will do them, and when.]
+
+## Assumptions (if applicable)
+
+ID | Name | Descriptions | Comments
+---| -----| -------------| --------
+ASSUM-1 |   |   |
+
+
+## Open issues (if applicable)
+
+ID | Name | Descriptions | Status | Comments
+---| -----| -------------| ------ | --------
+ISSUE-1 |   |   |   |   

--- a/docs/pre-provisioned-volumes.md
+++ b/docs/pre-provisioned-volumes.md
@@ -2,19 +2,24 @@
 
 Last updated: 9-Dec-2021 
 
-
 ## Abstract
 
-CSI must be able to work with pre-provisioned volumes.
+Bare-metal CSI supports pre-provisioned volumes.
 
 ## Background
 
-Pre-provisioned volumes are volumes whuch we created manually by administrator. 
+Pre-provisioned volumes are volumes which were created manually by administrator. 
 
-## Proposal
+## Workflow
 
 1. Choose the drive which you plan to use
-2. Make sure that it has available capacity fits to your volume
+```
+kubectl get drives
+```
+2. Make sure that it has available capacity of required size
+```
+kubectl get ac
+```
 3. Generate volume UUID
 ```
 uuidgen
@@ -94,28 +99,3 @@ spec:
   volumeName: pvc-<UUID>
 ```
 8. Use PVC for your application
-
-## Rationale
-
-[A discussion of alternate approaches and the trade offs, advantages, and disadvantages of the specified approach.]
-
-## Compatibility
-
-[A discussion of the change with regard to the compatibility with previous product and Kubernetes versions.]
-
-## Implementation
-
-[A description of the steps in the implementation, who will do them, and when.]
-
-## Assumptions (if applicable)
-
-ID | Name | Descriptions | Comments
----| -----| -------------| --------
-ASSUM-1 |   |   |
-
-
-## Open issues (if applicable)
-
-ID | Name | Descriptions | Status | Comments
----| -----| -------------| ------ | --------
-ISSUE-1 |   |   |   |   

--- a/test/e2e/scenarios/bare-metal-testdriver.go
+++ b/test/e2e/scenarios/bare-metal-testdriver.go
@@ -75,6 +75,7 @@ func InitBaremetalDriver(needAllTests bool) *baremetalDriver {
 var _ testsuites.TestDriver = &baremetalDriver{}
 var _ testsuites.DynamicPVTestDriver = &baremetalDriver{}
 var _ testsuites.EphemeralTestDriver = &baremetalDriver{}
+var _ testsuites.PreprovisionedPVTestDriver = &baremetalDriver{}
 
 // GetDriverInfo is implementation of TestDriver interface method
 func (d *baremetalDriver) GetDriverInfo() *testsuites.DriverInfo {
@@ -96,9 +97,9 @@ func (d *baremetalDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) 
 		}
 	}
 
-	if pattern.VolType == testpatterns.PreprovisionedPV {
+	/*if pattern.VolType == testpatterns.PreprovisionedPV {
 		e2eskipper.Skipf("Baremetal Driver does not support PreprovisionedPV -- skipping")
-	}
+	}*/
 }
 
 // PrepareCSI deploys CSI and enables logging for containers
@@ -184,6 +185,16 @@ func (d *baremetalDriver) GetVolume(config *testsuites.PerTestConfig,
 // GetCSIDriverName is implementation of EphemeralTestDriver interface method
 func (d *baremetalDriver) GetCSIDriverName(config *testsuites.PerTestConfig) string {
 	return d.GetDriverInfo().Name
+}
+
+// CreateVolume is implementation of PreprovisionedPVTestDriver interface method
+func (d *baremetalDriver) CreateVolume(config *testsuites.PerTestConfig, volumeType testpatterns.TestVolType) testsuites.TestVolume {
+	panic("implement me")
+}
+
+// CreateVolume is implementation of GetPersistentVolumeSource interface method
+func (d *baremetalDriver) GetPersistentVolumeSource(readOnly bool, fsType string, testVolume testsuites.TestVolume) (*corev1.PersistentVolumeSource, *corev1.VolumeNodeAffinity) {
+	panic("implement me")
 }
 
 // constructDefaultLoopbackConfig constructs default ConfigMap for LoopBackManager

--- a/test/e2e/scenarios/bare-metal-testdriver.go
+++ b/test/e2e/scenarios/bare-metal-testdriver.go
@@ -97,9 +97,10 @@ func (d *baremetalDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) 
 		}
 	}
 
-	/*if pattern.VolType == testpatterns.PreprovisionedPV {
-		e2eskipper.Skipf("Baremetal Driver does not support PreprovisionedPV -- skipping")
-	}*/
+	// TODO https://github.com/dell/csi-baremetal/issues/666 - add test coverage
+	if pattern.VolType == testpatterns.PreprovisionedPV {
+		e2eskipper.Skipf("Baremetal Driver does not have PreprovisionedPV test suite implemented yet -- skipping")
+	}
 }
 
 // PrepareCSI deploys CSI and enables logging for containers
@@ -192,7 +193,7 @@ func (d *baremetalDriver) CreateVolume(config *testsuites.PerTestConfig, volumeT
 	panic("implement me")
 }
 
-// CreateVolume is implementation of GetPersistentVolumeSource interface method
+// GetPersistentVolumeSource is implementation of PreprovisionedPVTestDriver interface method
 func (d *baremetalDriver) GetPersistentVolumeSource(readOnly bool, fsType string, testVolume testsuites.TestVolume) (*corev1.PersistentVolumeSource, *corev1.VolumeNodeAffinity) {
 	panic("implement me")
 }


### PR DESCRIPTION
## Purpose
### Resolves #123 

Documentation how to create and use pre-provisioned volumes

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
/workspace/csi-baremetal> kubectl get drives
NAME                                   SIZE        TYPE   HEALTH   SERIAL NUMBER        NODE                                   SLOT
3c14ddc4-9255-4bea-b402-9cde77e2b649   105906176   HDD    GOOD     LOOPBACK205648707    48b0fdda-0e44-4e2e-b4e6-5f8bb12bafd7   
6f6c3642-a61c-4510-9ea1-43a7ddd095f0   105906176   HDD    GOOD     LOOPBACK3015598031   48b0fdda-0e44-4e2e-b4e6-5f8bb12bafd7   
b84bf04a-7c00-40ac-82c7-9a100b96fbe6   105906176   HDD    GOOD     LOOPBACK3733093195   0fc94161-5fe4-4b45-be0d-fc072820d28e   
cc914056-9859-41ba-8538-c9aee0da8d95   105906176   HDD    GOOD     LOOPBACK1649946218   0fc94161-5fe4-4b45-be0d-fc072820d28e   
e265d664-e357-4d88-b0ca-62202b5814cc   105906176   HDD    GOOD     LOOPBACK2402721003   48b0fdda-0e44-4e2e-b4e6-5f8bb12bafd7   
fbff9932-bc54-440a-ae12-0ddd68b34da4   105906176   HDD    GOOD     LOOPBACK2656276755   0fc94161-5fe4-4b45-be0d-fc072820d28e   

apiVersion: csi-baremetal.dell.com/v1
kind: Volume
metadata:
  finalizers:
  - dell.emc.csi/volume-cleanup
  name: pvc-df79f6eb-ae53-435e-a700-e1c35c030de0
  namespace: default
spec:
  CSIStatus: CREATING
  Health: GOOD
  Id: pvc-df79f6eb-ae53-435e-a700-e1c35c030de0
  Location: 6f6c3642-a61c-4510-9ea1-43a7ddd095f0
  LocationType: DRIVE
  Mode: FS
  NodeId: 48b0fdda-0e44-4e2e-b4e6-5f8bb12bafd7
  OperationalStatus: OPERATIVE
  Size: 105906172
  StorageClass: HDD
  # For FS Mode only  
  Type: xfs
  Usage: IN_USE
  
  
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pvc-df79f6eb-ae53-435e-a700-e1c35c030de0
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 105906172
  csi:
    driver: csi-baremetal
    fsType: xfs
    volumeAttributes:
      csi.storage.k8s.io/pv/name: pvc-df79f6eb-ae53-435e-a700-e1c35c030de0
      csi.storage.k8s.io/pvc/namespace: default
      fsType: xfs 
      storageType: csi-baremetal-sc-hdd
    volumeHandle: pvc-df79f6eb-ae53-435e-a700-e1c35c030de0
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: nodes.csi-baremetal.dell.com/uuid
          operator: In
          values:
          - 48b0fdda-0e44-4e2e-b4e6-5f8bb12bafd7
  persistentVolumeReclaimPolicy: Delete
  storageClassName: csi-baremetal-sc-hdd
  volumeMode: Filesystem
  
  
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: www-web-0
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 105906172
  storageClassName: csi-baremetal-sc-hdd 
  volumeMode: Filesystem
  volumeName: pvc-df79f6eb-ae53-435e-a700-e1c35c030de0
```
