### PR TITLE
[ISSUE-656]: fix partition alignment

### DIFF
--- a/pkg/base/linuxutils/partitionhelper/partition_helper.go
+++ b/pkg/base/linuxutils/partitionhelper/partition_helper.go
@@ -65,9 +65,9 @@ const (
 	// fill device and partition table type
 	CreatePartitionTableCmdTmpl = sgdisk + "%s -o"
 	// CreatePartitionCmdTmpl create partition on provided device cmd template, fill device and partition label
-	CreatePartitionCmdTmpl = sgdisk + "-a1 -n 1:0:0 -c 1:%s %s"
+	CreatePartitionCmdTmpl = sgdisk + "-n 1:0:0 -c 1:%s %s"
 	// CreatePartitionCmdWithUUIDTmpl create partition on provided device with uuid cmd template, fill device and partition label
-	CreatePartitionCmdWithUUIDTmpl = sgdisk + "-a1 -n 1:0:0 -c 1:%s -u 1:%s %s"
+	CreatePartitionCmdWithUUIDTmpl = sgdisk + "-n 1:0:0 -c 1:%s -u 1:%s %s"
 	// DeletePartitionCmdTmpl delete partition from provided device cmd template, fill device and partition number
 	DeletePartitionCmdTmpl = sgdisk + "-d %s %s"
 

--- a/pkg/mocks/commands.go
+++ b/pkg/mocks/commands.go
@@ -71,7 +71,7 @@ var DiskCommands = map[string]CmdOut{
 		Stderr: "",
 		Err:    nil,
 	},
-	"sgdisk -a1 -n 1:0:0 -c 1:CSI -u 1:64be631b-62a5-11e9-a756-00505680d67f /dev/sde": {
+	"sgdisk -n 1:0:0 -c 1:CSI -u 1:64be631b-62a5-11e9-a756-00505680d67f /dev/sde": {
 		Stdout: `Creating new GPT entries.
 Setting name!
 partNum is 0
@@ -79,7 +79,7 @@ The operation has completed successfully`,
 		Stderr: "",
 		Err:    nil,
 	},
-	"sgdisk -a1 -n 1:0:0 -c 1:CSI /dev/sde": {
+	"sgdisk -n 1:0:0 -c 1:CSI /dev/sde": {
 		Stdout: `Creating new GPT entries.
 Setting name!
 partNum is 0


### PR DESCRIPTION
## Purpose
### Resolves #656 

Fixing alignment bug while creating partition.
It should correspond to alignment multiple. With our current value we have LBA address of partition starts at 34 sector, which is ok for 512e disks with 512 Minimum I/O size (which is used by mkfs for optimizations). It uses 512 sector size:
```bash
[root@master0 ~]# mkfs.xfs /dev/sdc1
meta-data=/dev/sdc1              isize=512    agcount=4, agsize=122094660 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1
data     =                       bsize=4096   blocks=488378637, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=238466, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```
But with 4096 minimum I/O size it's not optimal and that's why we have warning with mkfs, because it uses 4096 sector size:
```bash
warning: device is not properly aligned /dev/sdc1
Use -f to force usage of a misaligned device
```
Success output for fs creation:
```bash
# mkfs.xfs /dev/sdg1
meta-data=/dev/sdg1              isize=512    agcount=8, agsize=268435455 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=0, rmapbt=0, reflink=0
data     =                       bsize=4096   blocks=1953506636, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal log           bsize=4096   blocks=521728, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
