### PR TITLE
[ISSUE-679]: Don't skip drives with UNKNOWN health

### DIFF
--- a/pkg/controller/capacitycontroller/capacitycontroller.go
+++ b/pkg/controller/capacitycontroller/capacitycontroller.go
@@ -127,7 +127,9 @@ func (d *Controller) reconcileDrive(ctx context.Context, drive *drivecrd.Drive) 
 		usage  = drive.Spec.GetUsage()
 	)
 	switch {
-	case health != apiV1.HealthGood || status != apiV1.DriveStatusOnline || usage != apiV1.DriveUsageInUse:
+	case (health != apiV1.HealthGood && health != apiV1.HealthUnknown) ||
+		status != apiV1.DriveStatusOnline ||
+		usage != apiV1.DriveUsageInUse:
 		return d.handleInaccessibleDrive(ctx, drive.Spec)
 	default:
 		return d.createOrUpdateCapacity(ctx, drive.Spec)

--- a/pkg/controller/capacitycontroller/capacitycontroller_test.go
+++ b/pkg/controller/capacitycontroller/capacitycontroller_test.go
@@ -127,123 +127,181 @@ var (
 	}
 )
 
+/* Complementary structures for table tests */
+// inputData represents input parameters for drive reconciliation
+type inputData struct {
+	driveHealth      string
+	driveACIsPresent bool
+	driveIsClean     bool
+}
+
+// expectedResult represents expected results for drive reconciliation
+type expectedResult struct {
+	reconcileError error
+	acList         accrd.AvailableCapacityList
+}
+
 func Test_NewLVGController(t *testing.T) {
 	c := NewCapacityController(nil, nil, testLogger)
 	assert.NotNil(t, c)
 }
 
 func TestController_ReconcileDrive(t *testing.T) {
-	t.Run("Drive is good, AC is not present", func(t *testing.T) {
-		kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
-		assert.Nil(t, err)
-		controller := NewCapacityController(kubeClient, kubeClient, testLogger)
-		assert.NotNil(t, controller)
-		testDrive := drive1CR.DeepCopy()
-		err = kubeClient.Create(tCtx, testDrive)
-		assert.Nil(t, err)
-		_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
-		assert.Nil(t, err)
-		acList := &accrd.AvailableCapacityList{}
-		err = kubeClient.ReadList(tCtx, acList)
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(acList.Items))
-		assert.Equal(t, acSpec, acList.Items[0].Spec)
-	})
+	for _, testData := range []struct {
+		testCaseName   string
+		inputData      inputData
+		expectedResult expectedResult
+	}{
+		{
+			testCaseName: "Drive is good, AC is not present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthGood,
+				driveACIsPresent: false,
+				driveIsClean:     true,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList: accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: acSpec,
+						},
+					},
+				},
+			},
+		},
+		{
+			testCaseName: "Drive is good, AC is present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthGood,
+				driveACIsPresent: true,
+				driveIsClean:     true,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList:         accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: acSpec,
+						},
+					},
+				},
+			},
+		},
+		{
+			testCaseName: "Drive is bad, AC is not present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthBad,
+				driveACIsPresent: false,
+				driveIsClean:     true,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList:         accrd.AvailableCapacityList{},
+			},
+		},
+		{
+			testCaseName: "Drive is bad, AC is present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthBad,
+				driveACIsPresent: true,
+				driveIsClean:     true,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList: accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: api.AvailableCapacity{
+								Location:     drive1UUID,
+								NodeId:       apiDrive1.NodeId,
+								StorageClass: apiDrive1.Type,
+								Size:         0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testCaseName: "Drive is good and not clean, AC is present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthGood,
+				driveACIsPresent: true,
+				driveIsClean:     false,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList: accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: api.AvailableCapacity{
+								Location:     drive1UUID,
+								NodeId:       apiDrive1.NodeId,
+								StorageClass: apiDrive1.Type,
+								Size:         0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testCaseName: "Drive is good and not clean, AC is not present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthGood,
+				driveACIsPresent: false,
+				driveIsClean:     false,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList: accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: api.AvailableCapacity{
+								Location:     drive1UUID,
+								NodeId:       apiDrive1.NodeId,
+								StorageClass: apiDrive1.Type,
+								Size:         0,
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(testData.testCaseName, func(t *testing.T) {
+			// preparing fake kubeClient and capacity controller
+			kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
+			assert.Nil(t, err)
+			controller := NewCapacityController(kubeClient, kubeClient, testLogger)
+			assert.NotNil(t, controller)
 
-	t.Run("Drive is good, AC is present", func(t *testing.T) {
-		kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
-		assert.Nil(t, err)
-		controller := NewCapacityController(kubeClient, kubeClient, testLogger)
-		assert.NotNil(t, controller)
-		testDrive := drive1CR
-		err = kubeClient.Create(tCtx, &testDrive)
-		assert.Nil(t, err)
-		testAC := acCR
-		err = kubeClient.Create(tCtx, &testAC)
-		assert.Nil(t, err)
-		_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
-		assert.Nil(t, err)
-		acList := &accrd.AvailableCapacityList{}
-		err = kubeClient.ReadList(tCtx, acList)
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(acList.Items))
-		assert.Equal(t, acSpec, acList.Items[0].Spec)
-	})
+			// creating test objects
+			testDrive := drive1CR.DeepCopy()
+			testDrive.Spec.IsClean = testData.inputData.driveIsClean
+			err = kubeClient.Create(tCtx, testDrive)
+			assert.Nil(t, err)
+			if testData.inputData.driveACIsPresent {
+				testAC := acCR
+				err = kubeClient.Create(tCtx, &testAC)
+				assert.Nil(t, err)
+			}
 
-	t.Run("Drive is bad, AC is not present", func(t *testing.T) {
-		kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
-		assert.Nil(t, err)
-		controller := NewCapacityController(kubeClient, kubeClient, testLogger)
-		assert.NotNil(t, controller)
-		testDrive := drive1CR
-		testDrive.Spec.Health = apiV1.HealthBad
-		err = kubeClient.Create(tCtx, &testDrive)
-		assert.Nil(t, err)
-		_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
-		assert.Nil(t, err)
-		acList := &accrd.AvailableCapacityList{}
-		err = kubeClient.ReadList(tCtx, acList)
-		assert.Nil(t, err)
-		assert.Equal(t, 0, len(acList.Items))
-	})
+			// reconciling controller
+			_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
+			assert.ErrorIs(t, testData.expectedResult.reconcileError, err)
 
-	t.Run("Drive is bad, AC is present", func(t *testing.T) {
-		kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
-		assert.Nil(t, err)
-		controller := NewCapacityController(kubeClient, kubeClient, testLogger)
-		assert.NotNil(t, controller)
-		testDrive := drive1CR
-		testDrive.Spec.Health = apiV1.HealthBad
-		err = kubeClient.Create(tCtx, &testDrive)
-		assert.Nil(t, err)
-		testAC := acCR
-		err = kubeClient.Create(tCtx, &testAC)
-		assert.Nil(t, err)
-		_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
-		assert.Nil(t, err)
-		acList := &accrd.AvailableCapacityList{}
-		err = kubeClient.ReadList(tCtx, acList)
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(acList.Items))
-		assert.Equal(t, int64(0), acList.Items[0].Spec.Size)
-	})
-	t.Run("Drive is good and not clean, AC is present", func(t *testing.T) {
-		kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
-		assert.Nil(t, err)
-		controller := NewCapacityController(kubeClient, kubeClient, testLogger)
-		assert.NotNil(t, controller)
-		testDrive := drive1CR
-		testDrive.Spec.IsClean = false
-		err = kubeClient.Create(tCtx, &testDrive)
-		assert.Nil(t, err)
-		testAC := acCR
-		err = kubeClient.Create(tCtx, &testAC)
-		assert.Nil(t, err)
-		_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
-		assert.Nil(t, err)
-		acList := &accrd.AvailableCapacityList{}
-		err = kubeClient.ReadList(tCtx, acList)
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(acList.Items))
-		assert.Equal(t, int64(0), acList.Items[0].Spec.Size)
-	})
-	t.Run("Drive is good and not clean, AC is not present", func(t *testing.T) {
-		kubeClient, err := k8s.GetFakeKubeClient(ns, testLogger)
-		assert.Nil(t, err)
-		controller := NewCapacityController(kubeClient, kubeClient, testLogger)
-		assert.NotNil(t, controller)
-		testDrive := drive1CR
-		testDrive.Spec.IsClean = false
-		err = kubeClient.Create(tCtx, &testDrive)
-		assert.Nil(t, err)
-		_, err = controller.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: testDrive.Name}})
-		assert.Nil(t, err)
-		acList := &accrd.AvailableCapacityList{}
-		err = kubeClient.ReadList(tCtx, acList)
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(acList.Items))
-		assert.Equal(t, int64(0), acList.Items[0].Spec.Size)
-	})
+			// checking capacity results
+			acList := &accrd.AvailableCapacityList{}
+			err = kubeClient.ReadList(tCtx, acList)
+			assert.Nil(t, err)
+			assert.Equal(t, len(testData.expectedResult.acList.Items), len(acList.Items))
+			for i := 0; i < len(acList.Items); i++ {
+				assert.Equal(t, testData.expectedResult.acList.Items[i].Spec, acList.Items[i].Spec)
+			}
+		})
+	}
 }
 
 func TestController_ReconcileLVG(t *testing.T) {

--- a/pkg/controller/capacitycontroller/capacitycontroller_test.go
+++ b/pkg/controller/capacitycontroller/capacitycontroller_test.go
@@ -279,6 +279,7 @@ func TestController_ReconcileDrive(t *testing.T) {
 
 			// creating test objects
 			testDrive := drive1CR.DeepCopy()
+			testDrive.Spec.Health = testData.inputData.driveHealth
 			testDrive.Spec.IsClean = testData.inputData.driveIsClean
 			err = kubeClient.Create(tCtx, testDrive)
 			assert.Nil(t, err)

--- a/pkg/controller/capacitycontroller/capacitycontroller_test.go
+++ b/pkg/controller/capacitycontroller/capacitycontroller_test.go
@@ -189,6 +189,42 @@ func TestController_ReconcileDrive(t *testing.T) {
 			},
 		},
 		{
+			testCaseName: "Drive is unknown, AC is not present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthUnknown,
+				driveACIsPresent: false,
+				driveIsClean:     true,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList: accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: acSpec,
+						},
+					},
+				},
+			},
+		},
+		{
+			testCaseName: "Drive is unknown, AC is present",
+			inputData: inputData{
+				driveHealth:      apiV1.HealthGood,
+				driveACIsPresent: true,
+				driveIsClean:     true,
+			},
+			expectedResult: expectedResult{
+				reconcileError: nil,
+				acList:         accrd.AvailableCapacityList{
+					Items: []accrd.AvailableCapacity{
+						{
+							Spec: acSpec,
+						},
+					},
+				},
+			},
+		},
+		{
 			testCaseName: "Drive is bad, AC is not present",
 			inputData: inputData{
 				driveHealth:      apiV1.HealthBad,


### PR DESCRIPTION
## Purpose
### Resolves #679 

CSI creates non zero AC for disks with unknown health. Logic is covered by UTs

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
