### PR TITLE
[ISSUE-692] Bugfix issue volume expand test failed by timeout

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -31,7 +31,7 @@ pr-validation-junit:
 # Run e2e tests for CI. All of these tests use ginkgo so we can use native ginkgo methods to print junit output.
 # Also go test doesn't provide functionnality to save test's log into the file. Use > to archieve artifatcs.
 test-ci:
-	${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v test/e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
+	${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v test/e2e/baremetal_e2e_test.go -ginkgo.focus="volume-expand should not allow expansion of pvcs without AllowVolumeExpansion property" -ginkgo.v -ginkgo.progress -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
 
 # Run e2e tests and run community tests only.
 test-short-ci:

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -31,7 +31,7 @@ pr-validation-junit:
 # Run e2e tests for CI. All of these tests use ginkgo so we can use native ginkgo methods to print junit output.
 # Also go test doesn't provide functionnality to save test's log into the file. Use > to archieve artifatcs.
 test-ci:
-	${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v test/e2e/baremetal_e2e_test.go -ginkgo.focus="volume-expand should not allow expansion of pvcs without AllowVolumeExpansion property" -ginkgo.v -ginkgo.progress -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
+	${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v test/e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
 
 # Run e2e tests and run community tests only.
 test-short-ci:

--- a/test/e2e/scenarios/bare-metal-testdriver.go
+++ b/test/e2e/scenarios/bare-metal-testdriver.go
@@ -47,7 +47,8 @@ var (
 	ext4Fs                    = "ext4"
 	ext3Fs                    = "ext3"
 	hddStorageType            = "HDD"
-	maxDriveSize              = "3Gi"
+	// default value for expansion is hardcoded to 1Gi in e2e test framework
+	maxDriveSize              = "1.2Gi"
 )
 
 func initBaremetalDriverInfo(name string) testsuites.DriverInfo {


### PR DESCRIPTION
## Purpose
### Resolves #692

3Gi size of disk in e2e test causing test failure by timeout. On some system file creation takes 
about 80 seconds:
```
VirtualBox:/workspace/volume-expand> grep copied *
csi-baremetal-node-5tbvk-drivemgr.log:3221225472 bytes (3.2 GB, 3.0 GiB) copied, 83.3278 s, 38.7 MB/s
csi-baremetal-node-jrmrf-drivemgr.log:3221225472 bytes (3.2 GB, 3.0 GiB) copied, 84.6204 s, 38.1 MB/s
csi-baremetal-node-rjf84-drivemgr.log:3221225472 bytes (3.2 GB, 3.0 GiB) copied, 83.9625 s, 38.4 MB/s
csi-baremetal-node-sjbb7-drivemgr.log:3221225472 bytes (3.2 GB, 3.0 GiB) copied, 78.4537 s, 41.1 MB/s
csi-baremetal-node-x5tdt-drivemgr.log:3221225472 bytes (3.2 GB, 3.0 GiB) copied, 14.422 s, 223 MB/s
csi-baremetal-node-z29ft-drivemgr.log:3221225472 bytes (3.2 GB, 3.0 GiB) copied, 8.32874 s, 387 MB/s
```
Since minimal expansion size is 1Gi suggest to use 1.2Gi value to speed up test execution.

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
Tested locally:
```
[sig-storage] CSI Volumes
/usr/share/go/pkg/mod/k8s.io/kubernetes@v1.18.19/test/e2e/storage/utils/framework.go:23
  [Driver: csi-baremetal]
  /workspace/csi-baremetal/test/e2e/scenarios/setup.go:53
    [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand
    /usr/share/go/pkg/mod/k8s.io/kubernetes@v1.18.19/test/e2e/storage/testsuites/base.go:94
      should resize volume when PVC is edited while pod is using it
      /usr/share/go/pkg/mod/k8s.io/kubernetes@v1.18.19/test/e2e/storage/testsuites/volume_expand.go:221
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
JUnit report was created: /workspace/csi-baremetal/test/e2e/reports/report.xml

Ran 1 of 108 Specs in 140.349 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 107 Skipped
--- PASS: Test (140.35s)
PASS
ok      command-line-arguments  140.396s
```
PVC resizing:
```
borism1@borism1-VirtualBox:/workspace> kubectl get pods -n volume-expand-8081
NAME                                                    READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-f9495d6c5-dr5sb                4/4     Running   0          88s
csi-baremetal-node-controller-79d46c6d8f-gvg7n          1/1     Running   0          89s
csi-baremetal-node-kernel-5.4-59cvr                     4/4     Running   1          88s
csi-baremetal-node-kernel-5.4-lrd5g                     4/4     Running   0          88s
csi-baremetal-node-kernel-5.4-nw6hn                     4/4     Running   1          88s
csi-baremetal-node-kernel-5.4-qdkvm                     4/4     Running   2          88s
csi-baremetal-node-kernel-5.4-x67gw                     4/4     Running   1          88s
csi-baremetal-node-kernel-5.4-zzc5f                     4/4     Running   0          88s
csi-baremetal-operator-597774cbfc-vzs2q                 1/1     Running   0          92s
csi-baremetal-se-patcher-ltkkn                          1/1     Running   0          87s
csi-baremetal-se-wfkt4                                  1/1     Running   0          88s
security-context-66000fea-68b4-46af-96ea-d689928ba807   0/1     Pending   0          7s
borism1@borism1-VirtualBox:/workspace> kubectl get pvc
No resources found.
borism1@borism1-VirtualBox:/workspace> kubectl get pvc -A
NAMESPACE            NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                               AGE
volume-expand-8081   csi-baremetalmc2fn   Bound    pvc-0b40578c-8f7a-4987-b1dc-d84e95cb87da   100Mi      RWO            volume-expand-8081-csi-baremetal-sczk99w   11s
borism1@borism1-VirtualBox:/workspace> kubectl get pvc -A
NAMESPACE            NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                               AGE
volume-expand-8081   csi-baremetalmc2fn   Bound    pvc-0b40578c-8f7a-4987-b1dc-d84e95cb87da   1124Mi     RWO            volume-expand-8081-csi-baremetal-sczk99w   15s
```

