### PR TITLE
[ISSUE-702] Bump sidecars versions

### DIFF
--- a/Makefile.validation
+++ b/Makefile.validation
@@ -156,7 +156,7 @@ kind-delete-cluster:
 
 deps-docker-pull:
 	docker pull k8s.gcr.io/sig-storage/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
-	docker pull quay.io/k8scsi/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
+	docker pull k8s.gcr.io/sig-storage/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
 	docker pull k8s.gcr.io/sig-storage/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	docker pull k8s.gcr.io/sig-storage/${CSI_RESIZER}:${CSI_RESIZER_TAG}
 	docker pull ${BUSYBOX}:${BUSYBOX_TAG}
@@ -165,7 +165,7 @@ deps-docker-pull:
 
 deps-docker-tag:
 	docker tag k8s.gcr.io/sig-storage/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG} ${REGISTRY}/${CSI_PROVISIONER}:${CSI_PROVISIONER_TAG}
-	docker tag quay.io/k8scsi/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG} ${REGISTRY}/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
+	docker tag k8s.gcr.io/sig-storage/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG} ${REGISTRY}/${CSI_REGISTRAR}:${CSI_REGISTRAR_TAG}
 	docker tag k8s.gcr.io/sig-storage/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG} ${REGISTRY}/${LIVENESS_PROBE}:${LIVENESS_PROBE_TAG}
 	docker tag k8s.gcr.io/sig-storage/${CSI_RESIZER}:${CSI_RESIZER_TAG} ${REGISTRY}/${CSI_RESIZER}:${CSI_RESIZER_TAG}
 	docker tag ${BUSYBOX}:${BUSYBOX_TAG} ${REGISTRY}/${BUSYBOX}:${BUSYBOX_TAG}

--- a/variables.mk
+++ b/variables.mk
@@ -22,10 +22,10 @@ TAG              := ${FULL_VERSION}
 BRANCH           := $(shell git rev-parse --abbrev-ref HEAD)
 
 ### third-party components version
-CSI_PROVISIONER_TAG := v3.0.0
-CSI_RESIZER_TAG     := v1.1.0
-CSI_REGISTRAR_TAG   := v1.3.0
-LIVENESS_PROBE_TAG  := v2.1.0
+CSI_PROVISIONER_TAG := v3.1.0
+CSI_RESIZER_TAG     := v1.4.0
+CSI_REGISTRAR_TAG   := v2.5.0
+LIVENESS_PROBE_TAG  := v2.6.0
 BUSYBOX_TAG         := 1.29
 
 ### PATH


### PR DESCRIPTION
## Purpose
### Resolves #702 

- csi-provisioner 3.0.0 -> 3.1.0
- csi-node-driver-registrar 1.3.0 -> 2.5.0
- csi-resizer 1.1.0 -> 1.4.0
- livenessprobe 2.1.0 -> 2.6.0

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
[_Provide test details_](https://github.com/dell/csi-baremetal/actions/runs/1817092499)
