### PR TITLE
[ISSUE-756] Fix the unrelated SCs check in scheduler-extender

### DIFF
--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -226,7 +226,7 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 		"pod":         pod.Name,
 	})
 
-	scChecker, err := e.buildSCChecker(ctx, ll)
+	scs, err := e.buildSCChecker(ctx, ll)
 	if err != nil {
 		ll.Errorf("Unable to collect storage classes: %v", err)
 		return nil, err
@@ -255,7 +255,7 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 				continue
 			}
 
-			storageType, scType := scChecker.check(*claimSpec.StorageClassName)
+			storageType, scType := scs.check(*claimSpec.StorageClassName)
 			switch scType {
 			case unknown:
 				ll.Warningf("SC %s is not found in cache, wait until update", *claimSpec.StorageClassName)
@@ -309,7 +309,7 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 			// Workaround is realized in CSI Operator ACRValidator. It checks all ACR and removed ones for
 			// Running pods.
 
-			storageType, scType := scChecker.check(*pvc.Spec.StorageClassName)
+			storageType, scType := scs.check(*pvc.Spec.StorageClassName)
 			switch scType {
 			case unknown:
 				ll.Warningf("SC %s is not found in cache, wait until update", *pvc.Spec.StorageClassName)

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -324,7 +324,7 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 					storageReq = resource.Quantity{}
 				}
 				requests = append(requests, &genV1.CapacityRequest{
-					Name:         generateEphemeralVolumeName(pod.GetName(), v.Name),
+					Name:         pvc.Name,
 					StorageClass: util.ConvertStorageClass(storageType),
 					Size:         storageReq.Value(),
 				})

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -655,9 +655,9 @@ func (e *Extender) buildSCChecker(ctx context.Context, log *logrus.Entry) (*scCh
 
 // scChecker.check return codes
 const (
-	relatedSC   = 0
-	unrelatedSC = 1
-	unknown     = 2
+	relatedSC = iota
+	unrelatedSC
+	unknown
 )
 
 // check returns storageType and scType, return codes:

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -233,6 +233,7 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 	}
 
 	requests := make([]*genV1.CapacityRequest, 0)
+	// TODO - refactor repeatable code - https://github.com/dell/csi-baremetal/issues/760
 	for _, v := range pod.Spec.Volumes {
 		ll.Debugf("Volume %s details: %+v", v.Name, v)
 		// check whether volume Ephemeral or not

--- a/pkg/scheduler/extender/extender.go
+++ b/pkg/scheduler/extender/extender.go
@@ -315,12 +315,12 @@ func (e *Extender) gatherCapacityRequestsByProvisioner(ctx context.Context, pod 
 				ll.Warningf("SC %s is not found in cache, wait until update", *pvc.Spec.StorageClassName)
 				return nil, baseerr.ErrorNotFound
 			case unrelatedSC:
-				ll.Infof("SC %s is not provisioned by CSI Baremetal driver, skip this volume", *pvc.Spec.StorageClassName)
+				ll.Infof("SC %s is not provisioned by CSI Baremetal driver, skip PVC %s", *pvc.Spec.StorageClassName, pvc.Name)
 				continue
 			case relatedSC:
 				storageReq, ok := pvc.Spec.Resources.Requests[coreV1.ResourceStorage]
 				if !ok {
-					ll.Errorf("There is no key for storage resource for PVC %s", v.Name)
+					ll.Errorf("There is no key for storage resource for PVC %s", pvc.Name)
 					storageReq = resource.Quantity{}
 				}
 				requests = append(requests, &genV1.CapacityRequest{

--- a/pkg/scheduler/extender/extender_test.go
+++ b/pkg/scheduler/extender/extender_test.go
@@ -517,9 +517,9 @@ func TestExtender_buildSCChecker_Success(t *testing.T) {
 
 	m, err := e.buildSCChecker(testCtx, testLogger.WithField("test", "buildSCChecker"))
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(m.relatedSCs))
-	assert.Equal(t, 1, len(m.unrelatedSCs))
-	assert.Equal(t, m.relatedSCs[testSCName1], testStorageType)
+	assert.Equal(t, 1, len(m.managedSCs))
+	assert.Equal(t, 1, len(m.unmanagedSCs))
+	assert.Equal(t, m.managedSCs[testSCName1], testStorageType)
 }
 
 func TestExtender_buildSCChecker_Fail(t *testing.T) {
@@ -532,16 +532,16 @@ func TestExtender_buildSCChecker_Fail(t *testing.T) {
 
 func TestExtender_scChecker_check(t *testing.T) {
 	ch := &scChecker{
-		relatedSCs:   map[string]string{testSCName1: testStorageType},
-		unrelatedSCs: map[string]bool{testSCName2: true},
+		managedSCs:   map[string]string{testSCName1: testStorageType},
+		unmanagedSCs: map[string]bool{testSCName2: true},
 	}
 
 	storageType, scType := ch.check(testSCName1)
-	assert.Equal(t, scType, relatedSC)
+	assert.Equal(t, scType, managedSC)
 	assert.Equal(t, storageType, testStorageType)
 
 	_, scType = ch.check(testSCName2)
-	assert.Equal(t, scType, unrelatedSC)
+	assert.Equal(t, scType, unmanagedSC)
 
 	_, scType = ch.check("non-cached-sc")
 	assert.Equal(t, scType, unknown)

--- a/pkg/scheduler/extender/extender_test.go
+++ b/pkg/scheduler/extender/extender_test.go
@@ -56,17 +56,38 @@ var (
 	testSCName1     = "baremetal-sc-qwe"
 	testSCName2     = "another-one-sc"
 
-	testSizeGb       int64 = 10
-	testSizeStr            = fmt.Sprintf("%dG", testSizeGb)
-	testStorageType        = v1.StorageClassHDD
-	testCSIVolumeSrc       = coreV1.CSIVolumeSource{
+	testSizeGb      int64 = 10
+	testSizeStr           = fmt.Sprintf("%dG", testSizeGb)
+	testStorageType       = v1.StorageClassHDD
+
+	testCSIVolumeSrc = coreV1.CSIVolumeSource{
 		Driver:           testProvisioner,
 		VolumeAttributes: map[string]string{base.SizeKey: testSizeStr, base.StorageTypeKey: testStorageType},
 	}
+
 	testEphemeralVolumeSrc = coreV1.EphemeralVolumeSource{
 		VolumeClaimTemplate: &coreV1.PersistentVolumeClaimTemplate{
 			Spec: coreV1.PersistentVolumeClaimSpec{
 				StorageClassName: &testSCName1,
+				Resources: coreV1.ResourceRequirements{
+					Requests: coreV1.ResourceList{
+						coreV1.ResourceStorage: *resource.NewQuantity(testSizeGb*1024, resource.DecimalSI),
+					},
+				},
+			},
+		},
+	}
+
+	testEphemeralVolumeSrcNilSC = coreV1.EphemeralVolumeSource{
+		VolumeClaimTemplate: &coreV1.PersistentVolumeClaimTemplate{
+			Spec: coreV1.PersistentVolumeClaimSpec{},
+		},
+	}
+
+	testEphemeralVolumeSrcAnotherDriver = coreV1.EphemeralVolumeSource{
+		VolumeClaimTemplate: &coreV1.PersistentVolumeClaimTemplate{
+			Spec: coreV1.PersistentVolumeClaimSpec{
+				StorageClassName: &testSCName2,
 				Resources: coreV1.ResourceRequirements{
 					Requests: coreV1.ResourceList{
 						coreV1.ResourceStorage: *resource.NewQuantity(testSizeGb*1024, resource.DecimalSI),
@@ -123,6 +144,23 @@ var (
 			Name:      testPVC2Name,
 			Namespace: testNs,
 		},
+		Spec: coreV1.PersistentVolumeClaimSpec{
+			StorageClassName: &testSCName2,
+			Resources: coreV1.ResourceRequirements{
+				Requests: coreV1.ResourceList{
+					coreV1.ResourceStorage: *resource.NewQuantity(testSizeGb*1024, resource.DecimalSI),
+				},
+			},
+		},
+	}
+
+	testPVC3Name = "corrupted-pvc"
+	testPVC3     = coreV1.PersistentVolumeClaim{
+		TypeMeta: testPVCTypeMeta,
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      testPVC3Name,
+			Namespace: testNs,
+		},
 		Spec: coreV1.PersistentVolumeClaimSpec{},
 	}
 
@@ -136,14 +174,22 @@ var (
 
 func TestExtender_gatherVolumesByProvisioner_Success(t *testing.T) {
 	e := setup(t)
-	pod := testPod
-	// append inlineVolume
+	pod := testPod.DeepCopy()
+	// append ephemeralVolume
 	pod.Spec.Volumes = append(pod.Spec.Volumes, coreV1.Volume{
 		VolumeSource: coreV1.VolumeSource{CSI: &testCSIVolumeSrc},
 	})
-	// append ephemeralVolume
+	// append generic ephemeralVolume with CSI Baremetal SC
 	pod.Spec.Volumes = append(pod.Spec.Volumes, coreV1.Volume{
 		VolumeSource: coreV1.VolumeSource{Ephemeral: &testEphemeralVolumeSrc},
+	})
+	// append generic ephemeralVolume with Nil SC
+	pod.Spec.Volumes = append(pod.Spec.Volumes, coreV1.Volume{
+		VolumeSource: coreV1.VolumeSource{Ephemeral: &testEphemeralVolumeSrcNilSC},
+	})
+	// append generic ephemeralVolume with another CSI SC
+	pod.Spec.Volumes = append(pod.Spec.Volumes, coreV1.Volume{
+		VolumeSource: coreV1.VolumeSource{Ephemeral: &testEphemeralVolumeSrcAnotherDriver},
 	})
 	// append testPVC1
 	pod.Spec.Volumes = append(pod.Spec.Volumes, coreV1.Volume{
@@ -161,10 +207,18 @@ func TestExtender_gatherVolumesByProvisioner_Success(t *testing.T) {
 			},
 		},
 	})
+	// append testPVC3
+	pod.Spec.Volumes = append(pod.Spec.Volumes, coreV1.Volume{
+		VolumeSource: coreV1.VolumeSource{
+			PersistentVolumeClaim: &coreV1.PersistentVolumeClaimVolumeSource{
+				ClaimName: testPVC3Name,
+			},
+		},
+	})
 	// create PVCs and SC
-	applyObjs(t, e.k8sClient, testPVC1.DeepCopy(), testPVC2.DeepCopy(), testSC1.DeepCopy())
+	applyObjs(t, e.k8sClient, testPVC1.DeepCopy(), testPVC2.DeepCopy(), testPVC3.DeepCopy(), testSC1.DeepCopy(), testSC2.DeepCopy())
 
-	volumes, err := e.gatherCapacityRequestsByProvisioner(testCtx, &pod)
+	volumes, err := e.gatherCapacityRequestsByProvisioner(testCtx, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(volumes))
 }
@@ -173,13 +227,13 @@ func TestExtender_gatherVolumesByProvisioner_Fail(t *testing.T) {
 	e := setup(t)
 
 	// sc mapping empty
-	pod := testPod
-	volumes, err := e.gatherCapacityRequestsByProvisioner(testCtx, &pod)
+	pod := testPod.DeepCopy()
+	volumes, err := e.gatherCapacityRequestsByProvisioner(testCtx, pod)
 	assert.Nil(t, volumes)
 	assert.NotNil(t, err)
 
 	// createCapacityRequest failed
-	pod = testPod
+	pod = testPod.DeepCopy()
 	badCSIVolumeSrc := testCSIVolumeSrc
 	badCSIVolumeSrc.VolumeAttributes = map[string]string{}
 	// append inlineVolume
@@ -189,7 +243,7 @@ func TestExtender_gatherVolumesByProvisioner_Fail(t *testing.T) {
 	// create SC
 	applyObjs(t, e.k8sClient, testSC1.DeepCopy())
 
-	volumes, err = e.gatherCapacityRequestsByProvisioner(testCtx, &pod)
+	volumes, err = e.gatherCapacityRequestsByProvisioner(testCtx, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(volumes))
 	//assert.True(t, volumes[0].Ephemeral)
@@ -206,7 +260,7 @@ func TestExtender_gatherVolumesByProvisioner_Fail(t *testing.T) {
 			},
 		},
 	})
-	volumes, err = e.gatherCapacityRequestsByProvisioner(testCtx, &pod)
+	volumes, err = e.gatherCapacityRequestsByProvisioner(testCtx, pod)
 	assert.Nil(t, volumes)
 	assert.Equal(t, err, baseerr.ErrorNotFound) // PVC can be created later
 
@@ -224,7 +278,7 @@ func TestExtender_gatherVolumesByProvisioner_Fail(t *testing.T) {
 		},
 	}}
 
-	volumes, err = e.gatherCapacityRequestsByProvisioner(testCtx, &pod)
+	volumes, err = e.gatherCapacityRequestsByProvisioner(testCtx, pod)
 	assert.Nil(t, err)
 	assert.NotNil(t, volumes)
 	assert.Equal(t, 1, len(volumes))
@@ -549,22 +603,6 @@ func Test_getNodeId(t *testing.T) {
 func applyObjs(t *testing.T, k8sClient *k8s.KubeClient, objs ...k8sCl.Object) {
 	for _, obj := range objs {
 		assert.Nil(t, k8sClient.Create(testCtx, obj))
-	}
-}
-
-func getNodeNames(nodes []coreV1.Node) []string {
-	nodeNames := make([]string, 0)
-	for _, n := range nodes {
-		nodeNames = append(nodeNames, n.Name)
-	}
-	return nodeNames
-}
-
-func removeAllACRs(k *k8s.KubeClient, t *testing.T) {
-	acrList := acrcrd.AvailableCapacityReservationList{}
-	assert.Nil(t, k.ReadList(testCtx, &acrList))
-	for _, acr := range acrList.Items {
-		assert.Nil(t, k.DeleteCR(testCtx, &acr))
 	}
 }
 


### PR DESCRIPTION
## Purpose
### Resolves #756

Refactor SC checking in extender:
- SC is found and provisioned by CSI Baremetal -> add volume in requests
- SC is found and provisioned by another driver -> skip volume
- SC is not found -> skip filter request (return empty list) and wait cache update

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
**CSI Baremetal PVC**
```
user@user-vm ~/g/s/g/dell> ka csi-baremetal/test/app/nginx.yaml

user@user-vm ~/g/s/g/dell> kg volume
NAME                                       SIZE        STORAGE CLASS   HEALTH   CSI_STATUS   LOCATION                               NODE
pvc-00ecbf97-c256-461a-aed4-ceec70787ffc   105906176   HDD             GOOD     PUBLISHED    91b8be6c-5f0b-4b8a-bef3-9f8fc2ecb2c2   56e4455e-2ed9-42bf-a8b9-8fcd1063008e
pvc-034a9c9e-c49f-4d4c-9353-4b8e01a7b6cd   105906176   HDD             GOOD     PUBLISHED    3a595a44-5054-45d6-883b-076d8f9c7d5f   dda09db1-0414-4525-a1f7-83c4f472e8b6
pvc-33bc57c3-84d7-4688-8cb1-3d40ddf1fddb   105906176   HDD             GOOD     PUBLISHED    7378aceb-a651-4cd4-970a-84ffde391f7a   56e4455e-2ed9-42bf-a8b9-8fcd1063008e
pvc-3efea709-7a79-438c-9c2c-cde3ccf4ee92   105906176   HDD             GOOD     PUBLISHED    4c88bfb7-c4e7-4476-a671-0b68d24cded4   dda09db1-0414-4525-a1f7-83c4f472e8b6
pvc-85c8bccc-12d3-4c7c-a7cb-df1c7ff0afc0   105906176   HDD             GOOD     PUBLISHED    948d5066-baa4-4097-8805-3a8abd243ca6   dda09db1-0414-4525-a1f7-83c4f472e8b6
pvc-b43240e7-7257-4de5-9523-bddac4cc069d   105906176   HDD             GOOD     PUBLISHED    9910d205-3957-4612-9fe1-9df05d14d0c6   56e4455e-2ed9-42bf-a8b9-8fcd1063008e
```

**CSI Baremetal generic ephemeral volumes**
```
user@user-vm ~/g/s/g/dell> ka csi-baremetal/test/app/nginx-generic-ephemeral.yaml
statefulset.apps/web created

user@user-vm ~/g/s/g/dell> kg volume
NAME                                       SIZE        STORAGE CLASS   HEALTH   CSI_STATUS   LOCATION                               NODE
pvc-4647b96b-f57b-4e58-acc8-1768552bd94e   105906176   HDD             GOOD     PUBLISHED    4c88bfb7-c4e7-4476-a671-0b68d24cded4   dda09db1-0414-4525-a1f7-83c4f472e8b6
pvc-4da08b26-c95e-4db1-88d9-19aef1c51b74   105906176   HDD             GOOD     PUBLISHED    3a595a44-5054-45d6-883b-076d8f9c7d5f   dda09db1-0414-4525-a1f7-83c4f472e8b6
pvc-9599ea6a-61b6-445f-9fb8-ac413f9bba9c   105906176   HDD             GOOD     PUBLISHED    91b8be6c-5f0b-4b8a-bef3-9f8fc2ecb2c2   56e4455e-2ed9-42bf-a8b9-8fcd1063008e
pvc-b1570d1e-5773-4855-8c1e-461d49e1de82   105906176   HDD             GOOD     PUBLISHED    948d5066-baa4-4097-8805-3a8abd243ca6   dda09db1-0414-4525-a1f7-83c4f472e8b6
pvc-b438e816-7fde-4414-b066-ce88fa0c1cd7   105906176   HDD             GOOD     PUBLISHED    7378aceb-a651-4cd4-970a-84ffde391f7a   56e4455e-2ed9-42bf-a8b9-8fcd1063008e
pvc-f797102b-a704-4ddc-9df7-e6a226d9ac80   105906176   HDD             GOOD     PUBLISHED    9910d205-3957-4612-9fe1-9df05d14d0c6   56e4455e-2ed9-42bf-a8b9-8fcd1063008e
```

**Other CSI PVC**
```
user@user-vm ~/g/s/g/dell> ka csi-baremetal/test/app/nginx.yaml 
statefulset.apps/web created

user@user-vm ~/g/s/g/dell> kg pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-web-0   Bound    pvc-955cba4c-6d03-4b5f-b00a-562958f57722   60Mi       RWO            standard       25s
data-web-1   Bound    pvc-0e22117e-4da5-4456-a1ef-954bed8172cb   60Mi       RWO            standard       25s
logs-web-0   Bound    pvc-709d1404-d3b9-430a-ad69-a8f5960e891c   60Mi       RWO            standard       25s
logs-web-1   Bound    pvc-66d2c9ba-efee-406e-839b-1bfcc24689fd   60Mi       RWO            standard       25s
www-web-0    Bound    pvc-db0449bb-2e29-423c-9c79-3202cd7a3f2f   60Mi       RWO            standard       25s
www-web-1    Bound    pvc-033470e1-e140-40b2-a103-7414a0841809   60Mi       RWO            standard       25s
```

**Wrong SC**
```
user@user-vm ~/g/s/g/dell> kd pvc data-web-0
Name:          data-web-0
Namespace:     default
StorageClass:  standard23
Status:        Pending
Volume:        
Labels:        app=nginx
               app.kubernetes.io/name=nginx
Annotations:   <none>
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       web-0
Events:
  Type     Reason              Age               From                         Message
  ----     ------              ----              ----                         -------
  Warning  ProvisioningFailed  4s (x2 over 14s)  persistentvolume-controller  storageclass.storage.k8s.io "standard23" not found
```

