### PR TITLE
[ISSUE-764] Keep volume in CREATED after driveCR reading error on NodeStage

### DIFF
--- a/pkg/base/error/k8s.go
+++ b/pkg/base/error/k8s.go
@@ -1,0 +1,10 @@
+package error
+
+import k8sError "k8s.io/apimachinery/pkg/api/errors"
+
+// IsSafeReturnError returns if error is safe to retry
+func IsSafeReturnError(err error) bool {
+	return k8sError.IsServiceUnavailable(err) ||
+		k8sError.IsTimeout(err) ||
+		k8sError.IsTooManyRequests(err)
+}

--- a/pkg/base/error/k8s.go
+++ b/pkg/base/error/k8s.go
@@ -4,7 +4,7 @@ import k8sError "k8s.io/apimachinery/pkg/api/errors"
 
 // IsSafeReturnError returns if error is safe to retry
 func IsSafeReturnError(err error) bool {
-	return k8sError.IsServiceUnavailable(err) ||
+	return k8sError.IsServerTimeout(err) ||
 		k8sError.IsTimeout(err) ||
 		k8sError.IsTooManyRequests(err)
 }

--- a/pkg/base/error/types.go
+++ b/pkg/base/error/types.go
@@ -4,9 +4,9 @@ import "errors"
 
 // ErrorNotFound indicates that requested object wasn't found
 var (
-	ErrorNotFound       = errors.New("not found")
-	ErrorEmptyParameter = errors.New("empty parameter")
-	ErrorFailedParsing  = errors.New("failed to parse")
-
+	ErrorNotFound                 = errors.New("not found")
+	ErrorEmptyParameter           = errors.New("empty parameter")
+	ErrorFailedParsing            = errors.New("failed to parse")
+	ErrorGetDriveFailed           = errors.New("failed to get/update/delete k8s object")
 	ErrorRejectReservationRequest = errors.New("reject reservation request")
 )

--- a/pkg/base/error/types.go
+++ b/pkg/base/error/types.go
@@ -7,6 +7,6 @@ var (
 	ErrorNotFound                 = errors.New("not found")
 	ErrorEmptyParameter           = errors.New("empty parameter")
 	ErrorFailedParsing            = errors.New("failed to parse")
-	ErrorGetDriveFailed           = errors.New("failed to get/update/delete k8s object")
+	ErrorGetDriveFailed           = errors.New("failed to get drive cr")
 	ErrorRejectReservationRequest = errors.New("reject reservation request")
 )

--- a/pkg/base/k8s/cr_helper_test.go
+++ b/pkg/base/k8s/cr_helper_test.go
@@ -118,14 +118,14 @@ func TestCRHelper_GetDriveCRByVolume(t *testing.T) {
 
 func TestCRHelper_GetVolumeCRs(t *testing.T) {
 	ch := setup()
-	vol1 := testVolumeCR
-	vol2 := testVolumeCR
+	vol1 := testVolumeCR.DeepCopy()
+	vol2 := testVolumeCR.DeepCopy()
 	vol2.Name = "anotherName"
 	vol2.Spec.NodeId = "anotherNode"
 
-	err := ch.k8sClient.CreateCR(testCtx, vol1.Name, &vol1)
+	err := ch.k8sClient.CreateCR(testCtx, vol1.Name, vol1)
 	assert.Nil(t, err)
-	err = ch.k8sClient.CreateCR(testCtx, vol2.Name, &vol2)
+	err = ch.k8sClient.CreateCR(testCtx, vol2.Name, vol2)
 	assert.Nil(t, err)
 
 	// node as empty string - expected all volumes

--- a/pkg/base/linuxutils/lsblk/lsblk.go
+++ b/pkg/base/linuxutils/lsblk/lsblk.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/dell/csi-baremetal/api/v1/drivecrd"
+	api "github.com/dell/csi-baremetal/api/generated/v1"
 	"github.com/dell/csi-baremetal/pkg/base/command"
 )
 
@@ -42,7 +42,7 @@ const (
 // WrapLsblk is an interface that encapsulates operation with system lsblk util
 type WrapLsblk interface {
 	GetBlockDevices(device string) ([]BlockDevice, error)
-	SearchDrivePath(drive *drivecrd.Drive) (string, error)
+	SearchDrivePath(drive *api.Drive) (string, error)
 }
 
 // LSBLK is a wrap for system lsblk util
@@ -160,9 +160,9 @@ func (l *LSBLK) GetBlockDevices(device string) ([]BlockDevice, error) {
 // SearchDrivePath if not defined returns drive path based on drive S/N, VID and PID.
 // Receives an instance of drivecrd.Drive struct
 // Returns drive's path based on provided drivecrd.Drive or error if something went wrong
-func (l *LSBLK) SearchDrivePath(drive *drivecrd.Drive) (string, error) {
+func (l *LSBLK) SearchDrivePath(drive *api.Drive) (string, error) {
 	// device path might be already set by hwmgr
-	device := drive.Spec.Path
+	device := drive.Path
 	if device != "" {
 		return device, nil
 	}
@@ -174,9 +174,9 @@ func (l *LSBLK) SearchDrivePath(drive *drivecrd.Drive) (string, error) {
 	}
 
 	// get drive serial number
-	sn := drive.Spec.SerialNumber
-	vid := drive.Spec.VID
-	pid := drive.Spec.PID
+	sn := drive.SerialNumber
+	vid := drive.VID
+	pid := drive.PID
 	for _, l := range lsblkOut {
 		if strings.EqualFold(l.Serial, sn) && strings.EqualFold(l.Vendor, vid) &&
 			strings.EqualFold(l.Model, pid) {

--- a/pkg/base/linuxutils/lsblk/lsblk_test.go
+++ b/pkg/base/linuxutils/lsblk/lsblk_test.go
@@ -89,7 +89,7 @@ func TestLSBLK_SearchDrivePath_Success(t *testing.T) {
 	path := "/dev/sda"
 	dCR.Spec.Path = path
 
-	res, err := l.SearchDrivePath(&dCR)
+	res, err := l.SearchDrivePath(&dCR.Spec)
 	assert.Nil(t, err)
 	assert.Equal(t, path, res)
 
@@ -100,7 +100,7 @@ func TestLSBLK_SearchDrivePath_Success(t *testing.T) {
 	d2CR := testDriveCR
 	d2CR.Spec.SerialNumber = sn
 
-	res, err = l.SearchDrivePath(&d2CR)
+	res, err = l.SearchDrivePath(&d2CR.Spec)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedDevice, res)
 }
@@ -112,7 +112,7 @@ func TestLSBLK_SearchDrivePath(t *testing.T) {
 	// lsblk fail
 	expectedErr := errors.New("lsblk error")
 	e.On("RunCmd", allDevicesCmd).Return("", "", expectedErr)
-	res, err := l.SearchDrivePath(&testDriveCR)
+	res, err := l.SearchDrivePath(&testDriveCR.Spec)
 	assert.Equal(t, "", res)
 	assert.Equal(t, expectedErr, err)
 
@@ -122,7 +122,7 @@ func TestLSBLK_SearchDrivePath(t *testing.T) {
 	dCR := testDriveCR
 	dCR.Spec.SerialNumber = sn
 
-	res, err = l.SearchDrivePath(&dCR)
+	res, err = l.SearchDrivePath(&dCR.Spec)
 	assert.Equal(t, "", res)
 	assert.NotNil(t, err)
 
@@ -133,7 +133,7 @@ func TestLSBLK_SearchDrivePath(t *testing.T) {
 	dCR.Spec.VID = "vendor"
 	dCR.Spec.PID = "pid"
 
-	res, err = l.SearchDrivePath(&dCR)
+	res, err = l.SearchDrivePath(&dCR.Spec)
 	assert.NotNil(t, err)
 }
 

--- a/pkg/crcontrollers/lvg/lvgcontroller.go
+++ b/pkg/crcontrollers/lvg/lvgcontroller.go
@@ -259,7 +259,7 @@ func (c *Controller) createSystemLVG(lvg *lvgcrd.LogicalVolumeGroup) (locations 
 		// get serial number
 		sn := drive.Spec.SerialNumber
 		// get device path
-		dev, err := c.listBlk.SearchDrivePath(drive)
+		dev, err := c.listBlk.SearchDrivePath(&drive.Spec)
 		if err != nil {
 			ll.Error(err)
 			continue

--- a/pkg/mocks/linuxutils/lsblk.go
+++ b/pkg/mocks/linuxutils/lsblk.go
@@ -19,7 +19,7 @@ package linuxutils
 import (
 	"github.com/stretchr/testify/mock"
 
-	"github.com/dell/csi-baremetal/api/v1/drivecrd"
+	api "github.com/dell/csi-baremetal/api/generated/v1"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/lsblk"
 )
 
@@ -49,7 +49,7 @@ func (m *MockWrapLsblk) GetBlockDevices(device string) ([]lsblk.BlockDevice, err
 }
 
 // SearchDrivePath is a mock implementations
-func (m *MockWrapLsblk) SearchDrivePath(drive *drivecrd.Drive) (string, error) {
+func (m *MockWrapLsblk) SearchDrivePath(drive *api.Drive) (string, error) {
 	args := m.Mock.Called(drive)
 
 	return args.String(0), args.Error(1)

--- a/pkg/mocks/provisioners/provisioner.go
+++ b/pkg/mocks/provisioners/provisioner.go
@@ -32,28 +32,28 @@ type MockProvisioner struct {
 func GetMockProvisionerSuccess(everytimePath string) *MockProvisioner {
 	mp := MockProvisioner{}
 	mp.On("PrepareVolume", mock.Anything).Return(nil)
-	mp.On("ReleaseVolume", mock.Anything).Return(nil)
+	mp.On("ReleaseVolume", mock.Anything, mock.Anything).Return(nil)
 	mp.On("GetVolumePath", mock.Anything).Return(everytimePath, nil)
 
 	return &mp
 }
 
 // PrepareVolume is the mock implementation of PrepareVolume method from Provisioner interface
-func (m *MockProvisioner) PrepareVolume(volume api.Volume) error {
+func (m *MockProvisioner) PrepareVolume(volume *api.Volume) error {
 	args := m.Mock.Called(volume)
 
 	return args.Error(0)
 }
 
 // ReleaseVolume is the mock implementation of ReleaseVolume method from Provisioner interface
-func (m *MockProvisioner) ReleaseVolume(volume api.Volume) error {
-	args := m.Mock.Called(volume)
+func (m *MockProvisioner) ReleaseVolume(volume *api.Volume, drive *api.Drive) error {
+	args := m.Mock.Called(volume, drive)
 
 	return args.Error(0)
 }
 
 // GetVolumePath is the mock implementation of GetVolumePath method from Provisioner interface
-func (m *MockProvisioner) GetVolumePath(volume api.Volume) (string, error) {
+func (m *MockProvisioner) GetVolumePath(volume *api.Volume) (string, error) {
 	args := m.Mock.Called(volume)
 
 	return args.String(0), args.Error(1)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -206,7 +206,7 @@ var _ = Describe("CSINodeService NodeStage()", func() {
 			// testVolume2 has Create status
 			req := getNodeStageRequest(testVolume2.Id, *testVolumeCap)
 			partitionPath := "/partition/path/for/volume1"
-			prov.On("GetVolumePath", testVolume2).Return(partitionPath, nil)
+			prov.On("GetVolumePath", &testVolume2).Return(partitionPath, nil)
 			fsOps.On("PrepareAndPerformMount",
 				partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 				Return(nil)
@@ -227,7 +227,7 @@ var _ = Describe("CSINodeService NodeStage()", func() {
 			err := node.k8sClient.UpdateCR(testCtx, vol1)
 
 			partitionPath := "/partition/path/for/volume1"
-			prov.On("GetVolumePath", vol1.Spec).Return(partitionPath, nil)
+			prov.On("GetVolumePath", &vol1.Spec).Return(partitionPath, nil)
 			fsOps.On("PrepareAndPerformMount",
 				partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 				Return(nil)
@@ -281,7 +281,7 @@ var _ = Describe("CSINodeService NodeStage()", func() {
 		})
 		It("Should fail because partition path wasn't found", func() {
 			req := getNodeStageRequest(testVolume1.Id, *testVolumeCap)
-			prov.On("GetVolumePath", testVolume1).
+			prov.On("GetVolumePath", &testVolume1).
 				Return("", errors.New("GetVolumePath error"))
 
 			resp, err := node.NodeStageVolume(testCtx, req)
@@ -293,7 +293,7 @@ var _ = Describe("CSINodeService NodeStage()", func() {
 		It("Failed because PrepareAndPerformMount had failed", func() {
 			req := getNodeStageRequest(testVolume2.Id, *testVolumeCap)
 			partitionPath := "/partition/path/for/volume1"
-			prov.On("GetVolumePath", testVolume2).Return(partitionPath, nil)
+			prov.On("GetVolumePath", &testVolume2).Return(partitionPath, nil)
 			fsOps.On("PrepareAndPerformMount",
 				partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 				Return(errors.New("PrepareAndPerformMount error"))
@@ -310,7 +310,7 @@ var _ = Describe("CSINodeService NodeStage()", func() {
 			err := node.k8sClient.UpdateCR(testCtx, vol1)
 
 			partitionPath := "/partition/path/for/volume1"
-			prov.On("GetVolumePath", vol1.Spec).Return(partitionPath, nil)
+			prov.On("GetVolumePath", &vol1.Spec).Return(partitionPath, nil)
 			fsOps.On("PrepareAndPerformMount",
 				partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 				Return(errors.New("mount error"))
@@ -664,7 +664,7 @@ var _ = Describe("CSINodeService InlineVolumes", func() {
 			Expect(err).To(BeNil())
 
 			volOps.On("CreateVolume", mock.Anything, mock.Anything).Return(&createdVolCR.Spec, nil)
-			prov.On("GetVolumePath", createdVolCR.Spec).Return(srcPath, errors.New("error"))
+			prov.On("GetVolumePath", &createdVolCR.Spec).Return(srcPath, errors.New("error"))
 
 			resp, err := node.NodePublishVolume(testCtx, req)
 			Expect(resp).To(BeNil())
@@ -734,7 +734,7 @@ var _ = Describe("CSINodeService Fake-Attach", func() {
 		Expect(err).To(BeNil())
 
 		partitionPath := "/partition/path/for/volume1"
-		prov.On("GetVolumePath", vol1.Spec).Return(partitionPath, nil)
+		prov.On("GetVolumePath", &vol1.Spec).Return(partitionPath, nil)
 		fsOps.On("PrepareAndPerformMount",
 			partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 			Return(errors.New("mount error"))
@@ -801,7 +801,7 @@ var _ = Describe("CSINodeService Fake-Attach", func() {
 		Expect(err).To(BeNil())
 
 		partitionPath := "/partition/path/for/volume1"
-		prov.On("GetVolumePath", vol1.Spec).Return(partitionPath, nil)
+		prov.On("GetVolumePath", &vol1.Spec).Return(partitionPath, nil)
 		fsOps.On("PrepareAndPerformMount",
 			partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 			Return(nil)
@@ -848,7 +848,7 @@ var _ = Describe("CSINodeService Wbt Configuration", func() {
 			// testVolume2 has Create status
 			req := getNodeStageRequest(testVolume2.Id, *testVolumeCap)
 			partitionPath := "/partition/path/for/volume1"
-			prov.On("GetVolumePath", testVolume2).Return(partitionPath, nil)
+			prov.On("GetVolumePath", &testVolume2).Return(partitionPath, nil)
 			fsOps.On("PrepareAndPerformMount",
 				partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 				Return(nil)
@@ -889,7 +889,7 @@ var _ = Describe("CSINodeService Wbt Configuration", func() {
 			// testVolume2 has Create status
 			req := getNodeStageRequest(testVolume2.Id, *testVolumeCap)
 			partitionPath := "/partition/path/for/volume1"
-			prov.On("GetVolumePath", testVolume2).Return(partitionPath, nil)
+			prov.On("GetVolumePath", &testVolume2).Return(partitionPath, nil)
 			fsOps.On("PrepareAndPerformMount",
 				partitionPath, path.Join(req.GetStagingTargetPath(), stagingFileName), true, false).
 				Return(nil)

--- a/pkg/node/provisioners/drive_provisioner.go
+++ b/pkg/node/provisioners/drive_provisioner.go
@@ -210,7 +210,10 @@ func (d *DriveProvisioner) GetVolumePath(vol *api.Volume) (string, error) {
 	// read Drive CR based on Volume.Location (vol.Location == Drive.UUID == Drive.Name)
 	if err := d.k8sClient.ReadCR(ctxWithID, vol.Location, "", drive); err != nil {
 		ll.Errorf("failed to get drive CR %s: %v", vol.Location, err)
-		return "", baseerr.ErrorGetDriveFailed
+		if baseerr.IsSafeReturnError(err) {
+			return "", baseerr.ErrorGetDriveFailed
+		}
+		return "", err
 	}
 	ll.Debugf("Got drive %+v", drive)
 

--- a/pkg/node/provisioners/drive_provisioner_test.go
+++ b/pkg/node/provisioners/drive_provisioner_test.go
@@ -26,6 +26,7 @@ import (
 	api "github.com/dell/csi-baremetal/api/generated/v1"
 	"github.com/dell/csi-baremetal/api/v1/drivecrd"
 	"github.com/dell/csi-baremetal/pkg/base/command"
+	baseerr "github.com/dell/csi-baremetal/pkg/base/error"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/fs"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/partitionhelper"
@@ -85,14 +86,12 @@ func TestDriveProvisioner_PrepareVolume_Success(t *testing.T) {
 		}
 	)
 
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return(device, nil)
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return(device, nil)
 	mockPH.On("PreparePartition", part).Return(&expectedPart, nil)
 	mockFS.On("CreateFSIfNotExist", fs.FileSystem(testVolume2.Type), expectedPart.GetFullPath()).
 		Return(nil)
 
-	err = dp.PrepareVolume(testVolume2)
+	err = dp.PrepareVolume(&testVolume2)
 	assert.Nil(t, err)
 }
 
@@ -109,11 +108,9 @@ func TestDriveProvisioner_PrepareVolume_Block_Success(t *testing.T) {
 		device = "/some/device"
 	)
 
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return(device, nil)
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return(device, nil)
 
-	err = dp.PrepareVolume(testVolume2Raw)
+	err = dp.PrepareVolume(&testVolume2Raw)
 	assert.Nil(t, err)
 }
 
@@ -145,12 +142,10 @@ func TestDriveProvisioner_PrepareVolume_Blockrawpart_Success(t *testing.T) {
 		}
 	)
 
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return(device, nil)
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return(device, nil)
 	mockPH.On("PreparePartition", part).Return(&expectedPart, nil)
 
-	err = dp.PrepareVolume(testVolume2RawPart)
+	err = dp.PrepareVolume(&testVolume2RawPart)
 	assert.Nil(t, err)
 }
 
@@ -161,7 +156,7 @@ func TestDriveProvisioner_PrepareVolume_Fail(t *testing.T) {
 	)
 
 	// drive CR isn't exist
-	err = dp.PrepareVolume(testVolume2)
+	err = dp.PrepareVolume(&testVolume2)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "failed to read drive CR with name")
 
@@ -173,7 +168,7 @@ func TestDriveProvisioner_PrepareVolume_Fail(t *testing.T) {
 	mockLsblk.On("SearchDrivePath", mock.Anything).
 		Return("", errTest).Once()
 
-	err = dp.PrepareVolume(testVolume2)
+	err = dp.PrepareVolume(&testVolume2)
 	assert.Error(t, err)
 	assert.Equal(t, errTest, err)
 
@@ -185,7 +180,7 @@ func TestDriveProvisioner_PrepareVolume_Fail(t *testing.T) {
 	mockPH.On("PreparePartition", mock.Anything).
 		Return(&uw.Partition{}, errTest).Once()
 
-	err = dp.PrepareVolume(testVolume2)
+	err = dp.PrepareVolume(&testVolume2)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to prepare partition for volume")
 
@@ -194,7 +189,7 @@ func TestDriveProvisioner_PrepareVolume_Fail(t *testing.T) {
 		Return(&uw.Partition{}, nil).Once()
 	mockFS.On("CreateFSIfNotExist", fs.FileSystem(testVolume2.Type), mock.Anything).Return(errTest)
 
-	err = dp.PrepareVolume(testVolume2)
+	err = dp.PrepareVolume(&testVolume2)
 	assert.Error(t, err)
 	assert.Equal(t, errTest, err)
 }
@@ -222,15 +217,13 @@ func TestDriveProvisioner_ReleaseVolume_Success(t *testing.T) {
 		}
 	)
 
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return(deviceFile, nil).Once()
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return(deviceFile, nil)
 	mockPH.On("SearchPartName", deviceFile, testVolume2.Id).Return(partName, nil).Once()
 	mockFS.On("WipeFS", deviceFile+partName).Return(nil).Once()
 	mockPH.On("ReleasePartition", part).Return(nil)
 	mockFS.On("WipeFS", deviceFile).Return(nil).Once()
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Nil(t, err)
 
 	// SearchPartName failed but partition isn't exist (was removed before)
@@ -241,7 +234,7 @@ func TestDriveProvisioner_ReleaseVolume_Success(t *testing.T) {
 	mockLsblk.On("GetBlockDevices", deviceFile).Return(nil, nil).Once()
 	mockFS.On("WipeFS", deviceFile).Return(nil).Once()
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Nil(t, err)
 }
 
@@ -251,20 +244,13 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 		err                           error
 	)
 
-	// failed to find DriveCR
-	err = dp.ReleaseVolume(api.Volume{})
-	assert.Error(t, err)
-	assert.EqualError(t, err, "unable to find drive by vol location")
-
 	err = dp.k8sClient.CreateCR(testCtx, testDriveCR.Name, testDriveCR.DeepCopy())
 	assert.Nil(t, err)
 
 	// SearchDrivePath failed
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return("", errTest).Once()
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return("", errTest).Once()
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to find device for drive with S/N")
 
@@ -279,7 +265,7 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	mockLsblk.On("GetBlockDevices", deviceFile).
 		Return(nil, errTest)
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to find partition name")
 
@@ -291,7 +277,7 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	// WipeFS failed
 	mockFS.On("WipeFS", deviceFile+partName).Return(errTest).Once()
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Error(t, err)
 	assert.Equal(t, errTest, err)
 
@@ -299,7 +285,7 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	mockFS.On("WipeFS", mock.Anything).Return(nil).Once()
 	mockPH.On("ReleasePartition", mock.Anything).Return(errTest).Once()
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to release partition")
 
@@ -308,7 +294,7 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	mockPH.On("ReleasePartition", mock.Anything).Return(nil)
 	mockFS.On("WipeFS", deviceFile).Return(errTest)
 
-	err = dp.ReleaseVolume(testVolume2)
+	err = dp.ReleaseVolume(&testVolume2, &testDriveCR.Spec)
 	assert.Error(t, err)
 	assert.Equal(t, errTest, err)
 }
@@ -328,13 +314,11 @@ func TestDriveProvisioner_GetVolumePath_Success(t *testing.T) {
 		partName   = "p1"
 	)
 
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return(deviceFile, nil).Once()
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return(deviceFile, nil).Once()
 	mockPH.On("SearchPartName", deviceFile, testVolume2.Id).
 		Return(partName, nil).Once()
 
-	fullPath, err = dp.GetVolumePath(testVolume2)
+	fullPath, err = dp.GetVolumePath(&testVolume2)
 	assert.Nil(t, err)
 	assert.Equal(t, deviceFile+partName, fullPath)
 }
@@ -347,20 +331,18 @@ func TestDriveProvisioner_GetVolumePath_Fail(t *testing.T) {
 	)
 
 	// failed to find DriveCR
-	fullPath, err = dp.GetVolumePath(api.Volume{})
+	fullPath, err = dp.GetVolumePath(&api.Volume{})
 	assert.Error(t, err)
 	assert.Equal(t, "", fullPath)
-	assert.Contains(t, err.Error(), "unable to find drive by location")
+	assert.Equal(t, err, baseerr.ErrorGetDriveFailed)
 
 	err = dp.k8sClient.CreateCR(testCtx, testDriveCR.Name, testDriveCR.DeepCopy())
 	assert.Nil(t, err)
 
 	// SearchDrivePath
-	mockLsblk.On("SearchDrivePath",
-		mock.MatchedBy(func(d *drivecrd.Drive) bool { return d.Name == testDriveCR.Name })).
-		Return("", errTest).Once()
+	mockLsblk.On("SearchDrivePath", &testDriveCR.Spec).Return("", errTest).Once()
 
-	fullPath, err = dp.GetVolumePath(testVolume2)
+	fullPath, err = dp.GetVolumePath(&testVolume2)
 	assert.Error(t, err)
 	assert.Equal(t, "", fullPath)
 	assert.Contains(t, err.Error(), "unable to find device for drive with S/N")
@@ -372,7 +354,7 @@ func TestDriveProvisioner_GetVolumePath_Fail(t *testing.T) {
 	mockPH.On("SearchPartName", deviceFile, testVolume2.Id).
 		Return("").Once()
 
-	fullPath, err = dp.GetVolumePath(testVolume2)
+	fullPath, err = dp.GetVolumePath(&testVolume2)
 	assert.Error(t, err)
 	assert.Equal(t, "", fullPath)
 	assert.Contains(t, err.Error(), "unable to find part name for device")

--- a/pkg/node/provisioners/drive_provisioner_test.go
+++ b/pkg/node/provisioners/drive_provisioner_test.go
@@ -26,7 +26,6 @@ import (
 	api "github.com/dell/csi-baremetal/api/generated/v1"
 	"github.com/dell/csi-baremetal/api/v1/drivecrd"
 	"github.com/dell/csi-baremetal/pkg/base/command"
-	baseerr "github.com/dell/csi-baremetal/pkg/base/error"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/fs"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/partitionhelper"
@@ -334,7 +333,6 @@ func TestDriveProvisioner_GetVolumePath_Fail(t *testing.T) {
 	fullPath, err = dp.GetVolumePath(&api.Volume{})
 	assert.Error(t, err)
 	assert.Equal(t, "", fullPath)
-	assert.Equal(t, err, baseerr.ErrorGetDriveFailed)
 
 	err = dp.k8sClient.CreateCR(testCtx, testDriveCR.Name, testDriveCR.DeepCopy())
 	assert.Nil(t, err)

--- a/pkg/node/provisioners/lvm_provisioner_test.go
+++ b/pkg/node/provisioners/lvm_provisioner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	api "github.com/dell/csi-baremetal/api/generated/v1"
 	apiV1 "github.com/dell/csi-baremetal/api/v1"
 	"github.com/dell/csi-baremetal/pkg/base/command"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
@@ -61,7 +62,7 @@ func TestLVMProvisioner_PrepareVolume_Success(t *testing.T) {
 	fsOps.On("CreateFSIfNotExist", fs.FileSystem(testVolume1.Type), devFile).
 		Return(nil).Times(1)
 
-	err := lp.PrepareVolume(testVolume1)
+	err := lp.PrepareVolume(&testVolume1)
 	assert.Nil(t, err)
 }
 
@@ -71,7 +72,7 @@ func TestLVMProvisioner_PrepareVolume_Block_Success(t *testing.T) {
 	lvmOps.On("LVCreate", testVolume1.Id, mock.Anything, testVolume1.Location).
 		Return(nil).Times(1)
 
-	err := lp.PrepareVolume(testVolume1Raw)
+	err := lp.PrepareVolume(&testVolume1Raw)
 	assert.Nil(t, err)
 }
 
@@ -81,7 +82,7 @@ func TestLVMProvisioner_PrepareVolume_Block_RawPart_Success(t *testing.T) {
 	lvmOps.On("LVCreate", testVolume1.Id, mock.Anything, testVolume1.Location).
 		Return(nil).Times(1)
 
-	err := lp.PrepareVolume(testVolume1RawPart)
+	err := lp.PrepareVolume(&testVolume1RawPart)
 	assert.Nil(t, err)
 }
 
@@ -94,7 +95,7 @@ func TestLVMProvisioner_PrepareVolume_Fail(t *testing.T) {
 	// in that case vgName will be searching in CRs and here we get error
 	vol.StorageClass = apiV1.StorageClassSystemLVG
 
-	err = lp.PrepareVolume(vol)
+	err = lp.PrepareVolume(&vol)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "unable to determine VG name")
 
@@ -102,7 +103,7 @@ func TestLVMProvisioner_PrepareVolume_Fail(t *testing.T) {
 	lvmOps.On("LVCreate", testVolume1.Id, mock.Anything, testVolume1.Location).
 		Return(errTest).Times(1)
 
-	err = lp.PrepareVolume(testVolume1)
+	err = lp.PrepareVolume(&testVolume1)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "unable to create LV")
 
@@ -114,7 +115,7 @@ func TestLVMProvisioner_PrepareVolume_Fail(t *testing.T) {
 	fsOps.On("CreateFSIfNotExist", fs.FileSystem(testVolume1.Type), devFile).
 		Return(errTest).Times(1)
 
-	err = lp.PrepareVolume(testVolume1)
+	err = lp.PrepareVolume(&testVolume1)
 	assert.NotNil(t, err)
 	assert.Equal(t, errTest, err)
 }
@@ -130,14 +131,14 @@ func TestLVMProvisioner_ReleaseVolume_Success(t *testing.T) {
 	fsOps.On("WipeFS", devFile).Return(nil).Times(1)
 	lvmOps.On("LVRemove", devFile).Return(nil).Times(1)
 
-	err = lp.ReleaseVolume(testVolume1)
+	err = lp.ReleaseVolume(&testVolume1, &api.Drive{})
 	assert.Nil(t, err)
 
 	// WipeFS failed, LV isn't exist - ReleaseVolume success
 	fsOps.On("WipeFS", devFile).Return(errTest).Times(1)
 	lvmOps.On("GetLVsInVG", testVolume1.Location).Return(nil, nil).Times(1)
 
-	err = lp.ReleaseVolume(testVolume1)
+	err = lp.ReleaseVolume(&testVolume1, &api.Drive{})
 	assert.Nil(t, err)
 }
 
@@ -151,7 +152,7 @@ func TestLVMProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	// in that case vgName will be searching in CRs and here we get error
 	vol.StorageClass = apiV1.StorageClassSystemLVG
 
-	err = lp.PrepareVolume(vol)
+	err = lp.PrepareVolume(&vol)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "unable to determine VG name")
 
@@ -160,7 +161,7 @@ func TestLVMProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	fsOps.On("WipeFS", devFile).Return(errTest).Times(1)
 	lvmOps.On("GetLVsInVG", testVolume1.Location).Return([]string{testVolume1.Id}, nil).Times(1)
 
-	err = lp.ReleaseVolume(testVolume1)
+	err = lp.ReleaseVolume(&testVolume1, &api.Drive{})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "failed to wipe FS")
 
@@ -168,7 +169,7 @@ func TestLVMProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	fsOps.On("WipeFS", devFile).Return(errTest).Times(1)
 	lvmOps.On("GetLVsInVG", testVolume1.Location).Return(nil, errTest).Times(1)
 
-	err = lp.ReleaseVolume(testVolume1)
+	err = lp.ReleaseVolume(&testVolume1, &api.Drive{})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "unable to remove LV")
 	assert.Contains(t, err.Error(), "and unable to list LVs in VG")
@@ -179,7 +180,7 @@ func TestLVMProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	lvmOps.On("GetLVsInVG", testVolume1.Location).
 		Return([]string{testVolume1.Id}, nil).Times(1)
 
-	err = lp.ReleaseVolume(testVolume1)
+	err = lp.ReleaseVolume(&testVolume1, &api.Drive{})
 	assert.NotNil(t, err)
 	assert.Equal(t, errTest, err)
 }
@@ -188,7 +189,7 @@ func TestLVMProvisioner_GetVolumePath_Success(t *testing.T) {
 	setupTestLVMProvisioner()
 
 	expectedPath := fmt.Sprintf("/dev/%s/%s", testVolume1.Location, testVolume1.Id)
-	currentPath, err := lp.GetVolumePath(testVolume1)
+	currentPath, err := lp.GetVolumePath(&testVolume1)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedPath, currentPath)
 }

--- a/pkg/node/provisioners/volumeprovisioner.go
+++ b/pkg/node/provisioners/volumeprovisioner.go
@@ -35,10 +35,10 @@ const (
 
 // Provisioner is a high-level interface that encapsulates all low-level work with volumes on node
 type Provisioner interface {
-	// Prepare volume for mount
-	PrepareVolume(volume api.Volume) error
-	// Completely release underlying resources that had consumed by volume
-	ReleaseVolume(volume api.Volume) error
-	// Return full path of device file that represent volume on node
-	GetVolumePath(volume api.Volume) (string, error)
+	// PrepareVolume prepares volume for mount
+	PrepareVolume(volume *api.Volume) error
+	// ReleaseVolume completely releases underlying resources that had consumed by volume
+	ReleaseVolume(volume *api.Volume, drive *api.Drive) error
+	// GetVolumePath returns full path of device file that represent volume on node
+	GetVolumePath(volume *api.Volume) (string, error)
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sCl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
+	crevent "sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	api "github.com/dell/csi-baremetal/api/generated/v1"
@@ -205,7 +205,7 @@ func NewVolumeManager(
 	}
 
 	partImpl := ph.NewWrapPartitionImpl(executor, logger)
-	lvm := lvm.NewLVM(executor, logger)
+	lvmOps := lvm.NewLVM(executor, logger)
 	fsOps := utilwrappers.NewFSOperationsImpl(executor, logger)
 	wbtOps := wbtops.NewWbt(executor)
 
@@ -221,7 +221,7 @@ func NewVolumeManager(
 			p.LVMBasedVolumeType:   p.NewLVMProvisioner(executor, k8sClient, logger),
 		},
 		fsOps:                  fsOps,
-		lvmOps:                 lvm,
+		lvmOps:                 lvmOps,
 		listBlk:                lsblk.NewLSBLK(logger),
 		partOps:                partImpl,
 		wbtOps:                 wbtOps,
@@ -234,7 +234,7 @@ func NewVolumeManager(
 		systemDrivesUUIDs:      make([]string, 0),
 		metricDriveMgrDuration: driveMgrDuration,
 		metricDriveMgrCount:    driveMgrCount,
-		dataDiscover:           datadiscover.NewDataDiscover(fsOps, partImpl, lvm),
+		dataDiscover:           datadiscover.NewDataDiscover(fsOps, partImpl, lvmOps),
 	}
 	return vm
 }
@@ -463,7 +463,7 @@ func (m *VolumeManager) prepareVolume(ctx context.Context, volume *volumecrd.Vol
 
 	newStatus := apiV1.Created
 
-	err := m.getProvisionerForVolume(&volume.Spec).PrepareVolume(volume.Spec)
+	err := m.getProvisionerForVolume(&volume.Spec).PrepareVolume(&volume.Spec)
 	if err != nil {
 		ll.Errorf("Unable to create volume size of %d bytes: %v. Set volume status to Failed", volume.Spec.Size, err)
 		newStatus = apiV1.Failed
@@ -511,18 +511,22 @@ func (m *VolumeManager) performVolumeRemoving(ctx context.Context, volume *volum
 		return apiV1.Removed, nil
 	}
 
-	if err := m.getProvisionerForVolume(&volume.Spec).ReleaseVolume(volume.Spec); err != nil {
+	// read Drive CR based on Volume.Location (vol.Location == Drive.UUID == Drive.Name)
+	drive := &drivecrd.Drive{}
+	if err := m.k8sClient.ReadCR(ctx, volume.Spec.Location, "", drive); err != nil {
+		return "", fmt.Errorf("failed to read drive CR with name %s, error %w", volume.Spec.Location, err)
+	}
+	ll.Debugf("Got drive %+v", drive)
+
+	if err := m.getProvisionerForVolume(&volume.Spec).ReleaseVolume(&volume.Spec, &drive.Spec); err != nil {
 		ll.Errorf("Failed to remove volume - %s. Error: %v. Set status to Failed", volume.Spec.Id, err)
-		drive := m.crHelper.GetDriveCRByUUID(volume.Spec.Location)
-		if drive != nil {
-			drive.Spec.Usage = apiV1.DriveUsageFailed
-			if err := m.k8sClient.UpdateCRWithAttempts(ctx, drive, 5); err != nil {
-				ll.Errorf("Unable to change drive %s usage status to %s, error: %v.",
-					drive.Name, drive.Spec.Usage, err)
-				return "", err
-			}
-			m.sendEventForDrive(drive, eventing.DriveRemovalFailed, deleteVolumeFailedMsg, volume.Name, err)
+		drive.Spec.Usage = apiV1.DriveUsageFailed
+		if err := m.k8sClient.UpdateCRWithAttempts(ctx, drive, 5); err != nil {
+			ll.Errorf("Unable to change drive %s usage status to %s, error: %v.",
+				drive.Name, drive.Spec.Usage, err)
+			return "", err
 		}
+		m.sendEventForDrive(drive, eventing.DriveRemovalFailed, deleteVolumeFailedMsg, volume.Name, err)
 		return apiV1.Failed, err
 	}
 
@@ -538,16 +542,16 @@ func (m *VolumeManager) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).
 		WithEventFilter(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
+			CreateFunc: func(e crevent.CreateEvent) bool {
 				return m.isCorrespondedToNodePredicate(e.Object)
 			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
+			DeleteFunc: func(e crevent.DeleteEvent) bool {
 				return m.isCorrespondedToNodePredicate(e.Object)
 			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
+			UpdateFunc: func(e crevent.UpdateEvent) bool {
 				return m.isCorrespondedToNodePredicate(e.ObjectOld)
 			},
-			GenericFunc: func(e event.GenericEvent) bool {
+			GenericFunc: func(e crevent.GenericEvent) bool {
 				return m.isCorrespondedToNodePredicate(e.Object)
 			},
 		}).
@@ -1163,7 +1167,7 @@ func (m *VolumeManager) handleExpandingStatus(ctx context.Context, volume *volum
 	ll := m.log.WithFields(logrus.Fields{
 		"method": "handleExpandingStatus",
 	})
-	volumePath, err := m.provisioners[p.LVMBasedVolumeType].GetVolumePath(volume.Spec)
+	volumePath, err := m.provisioners[p.LVMBasedVolumeType].GetVolumePath(&volume.Spec)
 	if err != nil {
 		ll.Errorf("Failed to get volume path, err: %v", err)
 		return ctrl.Result{Requeue: true}, err


### PR DESCRIPTION
## Purpose
### Resolves #764 

- Return specific error in `GetVolumePath` after driveCR reading error. Use this one to node change volume status to FAILED
- Remove `GetDriveCRByUUID`. This function copies `ReadCR`
- Don't try to send event for drive in `Release Volume` after driveCR reading error

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Tested via UT
