### PR TITLE
[ISSUE-79] Hardcoded PluginVersion 

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -22,14 +22,14 @@ import "time"
 // CtxKey variable type uses for keys in context WithValue
 type CtxKey string
 
+// PluginVersion is a version of current CSI plugin
+var PluginVersion = ""
+
 const (
 	// RequestUUID is the constant for context request
 	RequestUUID CtxKey = "RequestUUID"
 	// PluginName is a name of current CSI plugin
 	PluginName = "csi-baremetal"
-	// PluginVersion is a version of current CSI plugin
-	// TODO: get rid of hardcoded value https://github.com/dell/csi-baremetal/issues/79
-	PluginVersion = "1.1.0"
 	// DefaultDriveMgrEndpoint is the default gRPC endpoint for drivemgr
 	DefaultDriveMgrEndpoint = "tcp://:8888"
 	// DefaultHealthIP is the default gRPC IP for Health server

--- a/variables.mk
+++ b/variables.mk
@@ -75,7 +75,8 @@ CLIENT_GO_VER      := v0.22.5
 
 ### Ingest information to the binary at the compile time
 METRICS_PACKAGE := github.com/dell/csi-baremetal/pkg/metrics
-LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH}"
+CONSTANT_PACKAGE := github.com/dell/csi-baremetal/pkg/base
+LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${CONSTANT_PACKAGE}.PluginVersion=${PRODUCT_VERSION}"
 
 ### Kind
 KIND_DIR := test/kind

--- a/variables.mk
+++ b/variables.mk
@@ -74,9 +74,10 @@ PROTOC_GEN_GO_VER  := v1.3.2
 CLIENT_GO_VER      := v0.22.5
 
 ### Ingest information to the binary at the compile time
-METRICS_PACKAGE := github.com/dell/csi-baremetal/pkg/metrics
-CONSTANT_PACKAGE := github.com/dell/csi-baremetal/pkg/base
-LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${CONSTANT_PACKAGE}.PluginVersion=${PRODUCT_VERSION}"
+PACKAGE_NAME := github.com/dell/csi-baremetal
+METRICS_PACKAGE := ${PACKAGE_NAME}/pkg/metrics
+BASE_PACKAGE := ${PACKAGE_NAME}/pkg/base
+LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${BASE_PACKAGE}.PluginVersion=${PRODUCT_VERSION}"
 
 ### Kind
 KIND_DIR := test/kind


### PR DESCRIPTION
Signed-off-by: Dutova <Ann.Dutova@Dell.com>

## Purpose

Need to delete hardcode string in `constants.go`

### Resolves #79 

- Add extra flag for `LDFLAGS` in `variables.mk`
- Delete PluginVersion from constants and set it as `var`  

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Pass unit tests
Also temporary add Logrus info message in step with starting node service: 
```
{"level":"info","msg":"Starting Node Service","time":"2022-03-14T14:52:10Z"}
{"level":"info","msg":"PluginVersion 1.1.0","time":"2022-03-14T14:52:10Z"}
```
