### PR TITLE
[ISSUE-780]: Return name, id, namespace to logging 

### DIFF
--- a/pkg/base/logger/objects/available_capacity.go
+++ b/pkg/base/logger/objects/available_capacity.go
@@ -9,7 +9,8 @@ import (
 type availableCapacity struct{}
 
 func (l *availableCapacity) Log(object *accrd.AvailableCapacity) (str string) {
-	return fmt.Sprintf("Labels: %+v, Annotations: %+v, Spec: %+v",
+	return fmt.Sprintf("ID: '%s', Name: '%s', Labels: %+v, Annotations: %+v, Spec: %+v",
+		object.ObjectMeta.UID, object.ObjectMeta.Name,
 		object.ObjectMeta.Labels, object.ObjectMeta.Annotations, object.Spec)
 }
 

--- a/pkg/base/logger/objects/available_capacity_reservation.go
+++ b/pkg/base/logger/objects/available_capacity_reservation.go
@@ -9,7 +9,8 @@ import (
 type availableCapacityReservation struct{}
 
 func (l *availableCapacityReservation) Log(object *acrcrd.AvailableCapacityReservation) (str string) {
-	return fmt.Sprintf("Labels: %+v, Annotations: %+v, Spec: %+v",
+	return fmt.Sprintf("ID: '%s', Name: '%s', Labels: %+v, Annotations: %+v, Spec: %+v",
+		object.ObjectMeta.UID, object.ObjectMeta.Name,
 		object.ObjectMeta.Labels, object.ObjectMeta.Annotations, object.Spec)
 }
 

--- a/pkg/base/logger/objects/drive.go
+++ b/pkg/base/logger/objects/drive.go
@@ -9,7 +9,8 @@ import (
 type drive struct{}
 
 func (l *drive) Log(object *drivecrd.Drive) (str string) {
-	return fmt.Sprintf("Labels: %+v, Annotations: %+v, Spec: %+v",
+	return fmt.Sprintf("ID: '%s', Name: '%s', Labels: %+v, Annotations: %+v, Spec: %+v",
+		object.ObjectMeta.UID, object.ObjectMeta.Name,
 		object.ObjectMeta.Labels, object.ObjectMeta.Annotations, object.Spec)
 }
 

--- a/pkg/base/logger/objects/logical_volume_group.go
+++ b/pkg/base/logger/objects/logical_volume_group.go
@@ -9,7 +9,8 @@ import (
 type logicalVolumeGroup struct{}
 
 func (l *logicalVolumeGroup) Log(object *lvgcrd.LogicalVolumeGroup) (str string) {
-	return fmt.Sprintf("Labels: %+v, Annotations: %+v, Spec: %+v",
+	return fmt.Sprintf("ID: '%s', Name: '%s', Labels: %+v, Annotations: %+v, Spec: %+v",
+		object.ObjectMeta.UID, object.ObjectMeta.Name,
 		object.ObjectMeta.Labels, object.ObjectMeta.Annotations, object.Spec)
 }
 

--- a/pkg/base/logger/objects/node.go
+++ b/pkg/base/logger/objects/node.go
@@ -9,7 +9,8 @@ import (
 type node struct{}
 
 func (l *node) Log(object *nodecrd.Node) (str string) {
-	return fmt.Sprintf("Labels: %+v, Annotations: %+v, Spec: %+v",
+	return fmt.Sprintf("ID: '%s', Name: '%s', Labels: %+v, Annotations: %+v, Spec: %+v",
+		object.ObjectMeta.UID, object.ObjectMeta.Name,
 		object.ObjectMeta.Labels, object.ObjectMeta.Annotations, object.Spec)
 }
 

--- a/pkg/base/logger/objects/volume.go
+++ b/pkg/base/logger/objects/volume.go
@@ -9,7 +9,8 @@ import (
 type volume struct{}
 
 func (l *volume) Log(object *volumecrd.Volume) (str string) {
-	return fmt.Sprintf("Labels: %+v, Annotations: %+v, Spec: %+v",
+	return fmt.Sprintf("ID: '%s', Name: '%s', Namespace: '%s', Labels: %+v, Annotations: %+v, Spec: %+v",
+		object.ObjectMeta.UID, object.ObjectMeta.Name, object.ObjectMeta.Namespace,
 		object.ObjectMeta.Labels, object.ObjectMeta.Annotations, object.Spec)
 }
 


### PR DESCRIPTION
## Purpose
### Resolves #780 

Returned name, id, namespace to logging 

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
Log example:
csi-baremetal-controller-798b48dd78-6hd59/controller@kind..rker: Mar 22 12:01:58.471 [INFO] [KubeClient] [UpdateCR] [Unknown] Updating CR 'AvailableCapacity': ID: '9a5f35b6-0172-45c6-9965-1be6ef797443', Name: '3898d752-1eba-4ada-8c61-25b49bb14288', Labels: map[app:csi-baremetal app.kubernetes.io/name:csi-baremetal], Annotations: map[], Spec: {Location:8fc7d112-e621-4ca6-a93a-2977d3cc5509 NodeId:f16ab28e-e0f9-4698-9c0a-d5cf767436d7 StorageClass:HDD Size:0 XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
```

