### PR TITLE
[ISSUE-796]: support shorter file paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-scheduler \
 build-node-controller
 
 build-drivemgr:
-	GOOS=linux go build -o ./build/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/$(DRIVE_MANAGER_TYPE) ./cmd/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/main.go
+	GOOS=linux go build -o ./build/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/$(DRIVE_MANAGER_TYPE) ${LDFLAGS} ./cmd/${DRIVE_MANAGER}/$(DRIVE_MANAGER_TYPE)/main.go
 
 build-node:
 	CGO_ENABLED=0 GOOS=linux go build -o ./build/${NODE}/${NODE} ${LDFLAGS} ./cmd/${NODE}/main.go
@@ -40,13 +40,13 @@ build-controller:
 	CGO_ENABLED=0 GOOS=linux go build -o ./build/${CONTROLLER}/${CONTROLLER} ${LDFLAGS} ./cmd/${CONTROLLER}/main.go
 
 build-extender:
-	CGO_ENABLED=0 GOOS=linux go build -o ./build/${SCHEDULING_PKG}/${EXTENDER}/${EXTENDER} ./cmd/${SCHEDULING_PKG}/${EXTENDER}/main.go
+	CGO_ENABLED=0 GOOS=linux go build -o ./build/${SCHEDULING_PKG}/${EXTENDER}/${EXTENDER} ${LDFLAGS} ./cmd/${SCHEDULING_PKG}/${EXTENDER}/main.go
 
 build-scheduler:
-	CGO_ENABLED=0 GOOS=linux go build -o ./build/${SCHEDULING_PKG}/${SCHEDULER}/${SCHEDULER} ./cmd/${SCHEDULING_PKG}/${SCHEDULER}/main.go
+	CGO_ENABLED=0 GOOS=linux go build -o ./build/${SCHEDULING_PKG}/${SCHEDULER}/${SCHEDULER} ${LDFLAGS} ./cmd/${SCHEDULING_PKG}/${SCHEDULER}/main.go
 
 build-node-controller:
-	CGO_ENABLED=0 GOOS=linux go build -o ./build/${CR_CONTROLLERS}/${NODE_CONTROLLER}/${CONTROLLER} ./cmd/${NODE_CONTROLLER}/main.go
+	CGO_ENABLED=0 GOOS=linux go build -o ./build/${CR_CONTROLLERS}/${NODE_CONTROLLER}/${CONTROLLER} ${LDFLAGS} ./cmd/${NODE_CONTROLLER}/main.go
 
 ### Clean artifacts
 clean-all: clean clean-images

--- a/Makefile.validation
+++ b/Makefile.validation
@@ -11,12 +11,12 @@ coverage:
 	go tool cover -html=coverage.out -o coverage.html
 
 test:
-	${GO_ENV_VARS} go test `go list ./... | grep -v halmgr | grep pkg` -race -cover -coverprofile=coverage.out -covermode=atomic
+	${GO_ENV_VARS} go test ${LDFLAGS} `go list ./... | grep -v halmgr | grep pkg` -race -cover -coverprofile=coverage.out -covermode=atomic
 
 # Run tests for pr-validation with writing output to log file
 # Test are different (ginkgo, go testing, etc.) so can't use native ginkgo methods to print junit output.
 test-pr-validation:
-	${GO_ENV_VARS} go test `go list ./... | grep -v halmgr` -v -race -cover -coverprofile=coverage.out > log.txt
+	${GO_ENV_VARS} go test ${LDFLAGS} `go list ./... | grep -v halmgr` -v -race -cover -coverprofile=coverage.out > log.txt
 
 install-junit-report:
 	${GO_ENV_VARS} go get -u github.com/jstemmer/go-junit-report
@@ -31,14 +31,14 @@ pr-validation-junit:
 # Run e2e tests for CI. All of these tests use ginkgo so we can use native ginkgo methods to print junit output.
 # Also go test doesn't provide functionnality to save test's log into the file. Use > to archieve artifatcs.
 test-ci:
-	cd tests && ${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
+	cd tests && ${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test ${LDFLAGS} -v e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
 
 # Run e2e tests and run community tests only.
 test-short-ci:
-	cd tests && ${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -ginkgo.failFast -timeout-short-ci=${SHORT_CI_TIMEOUT} -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
+	cd tests && ${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test ${LDFLAGS} -v e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -ginkgo.failFast -timeout-short-ci=${SHORT_CI_TIMEOUT} -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} -timeout 0 > log.txt
 
 test-sanity-ci:
-	cd tests && ${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v e2e/baremetal_e2e_test.go -timeout 0 -ginkgo.focus="$(strip $(subst ',, ${SANITY_TEST}))" -ginkgo.v -ginkgo.progress -all-tests  -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} > log.txt
+	cd tests && ${GO_ENV_VARS} CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test ${LDFLAGS} -v e2e/baremetal_e2e_test.go -timeout 0 -ginkgo.focus="$(strip $(subst ',, ${SANITY_TEST}))" -ginkgo.v -ginkgo.progress -all-tests  -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR} > log.txt
 
 # Run commnity sanity tests for CSI. TODO https://github.com/dell/csi-baremetal/issues/298 Make sanity test work for expansion
 # TODO enable tests back - https://github.com/dell/csi-baremetal/issues/371

--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -25,6 +25,9 @@ type CtxKey string
 // PluginVersion is a version of current CSI plugin
 var PluginVersion = ""
 
+// ProjectPath is the current path of a project
+var ProjectPath = ""
+
 const (
 	// RequestUUID is the constant for context request
 	RequestUUID CtxKey = "RequestUUID"

--- a/pkg/base/logger/runtime_formatter.go
+++ b/pkg/base/logger/runtime_formatter.go
@@ -37,7 +37,11 @@ func (f *RuntimeFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		// setting function name
 		data[FunctionKey] = functionName
 		// setting modified filepath: removing base project path and redundant delimiter
-		data[FileKey] = strings.TrimPrefix(strings.TrimPrefix(file, base.ProjectPath), "/") + ":" + line
+		adaptedFilepath := strings.TrimPrefix(file, base.ProjectPath)
+		if adaptedFilepath != file { // if current file's path is a subdirectory of passed project path - then trim prefix delimiter
+			adaptedFilepath = strings.TrimPrefix(adaptedFilepath, "/")
+		}
+		data[FileKey] = adaptedFilepath + ":" + line
 	}
 	for k, v := range entry.Data {
 		data[k] = v

--- a/pkg/base/logger/runtime_formatter.go
+++ b/pkg/base/logger/runtime_formatter.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/dell/csi-baremetal/pkg/base"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,12 +34,15 @@ func (f *RuntimeFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		packageEnd := strings.LastIndex(function, ".")
 		functionName := function[packageEnd+1:]
 
+		// setting function name
 		data[FunctionKey] = functionName
-		data[FileKey] = file + ":" + line
+		// setting modified filepath: removing base project path and redundant delimiter
+		data[FileKey] = strings.TrimPrefix(strings.TrimPrefix(file, base.ProjectPath), "/") + ":" + line
 	}
 	for k, v := range entry.Data {
 		data[k] = v
 	}
+
 	entry.Data = data
 
 	return f.ChildFormatter.Format(entry)

--- a/pkg/base/logger/runtime_formatter_test.go
+++ b/pkg/base/logger/runtime_formatter_test.go
@@ -3,7 +3,7 @@ package logger
 import (
 	"bytes"
 	"encoding/json"
-	"os"
+	"path"
 	"reflect"
 	"testing"
 
@@ -47,7 +47,7 @@ func TestRuntimeFormatter(t *testing.T) {
 	logrus.SetOutput(buffer)
 
 	decoder := json.NewDecoder(buffer)
-	currentDirectory, _ := os.Getwd()
+	currentDirectory := path.Join("pkg", "base", "logger")
 	currentFile := "runtime_formatter_test.go"
 
 	foo()
@@ -90,7 +90,7 @@ func TestFunctionInFunctionFormatter(t *testing.T) {
 	logrus.SetOutput(buffer)
 
 	decoder := json.NewDecoder(buffer)
-	currentDirectory, _ := os.Getwd()
+	currentDirectory := path.Join("pkg", "base", "logger")
 	currentFile := "runtime_formatter_test.go"
 
 	funcInFunc()

--- a/variables.mk
+++ b/variables.mk
@@ -1,5 +1,6 @@
 # project name
 PROJECT          := csi-baremetal
+PROJECT_PATH     := ${PWD}
 
 ### common path
 CSI_OPERATOR_PATH=../csi-baremetal-operator
@@ -76,7 +77,7 @@ CLIENT_GO_VER      := v0.22.5
 PACKAGE_NAME := github.com/dell/csi-baremetal
 METRICS_PACKAGE := ${PACKAGE_NAME}/pkg/metrics
 BASE_PACKAGE := ${PACKAGE_NAME}/pkg/base
-LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${BASE_PACKAGE}.PluginVersion=${PRODUCT_VERSION}"
+LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${BASE_PACKAGE}.PluginVersion=${PRODUCT_VERSION} -X ${BASE_PACKAGE}.PROJECT_PATH=${PROJECT_PATH}"
 
 ### Kind
 KIND_BUILD_DIR		:= ${PWD}/devkit/kind

--- a/variables.mk
+++ b/variables.mk
@@ -77,7 +77,7 @@ CLIENT_GO_VER      := v0.22.5
 PACKAGE_NAME := github.com/dell/csi-baremetal
 METRICS_PACKAGE := ${PACKAGE_NAME}/pkg/metrics
 BASE_PACKAGE := ${PACKAGE_NAME}/pkg/base
-LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${BASE_PACKAGE}.PluginVersion=${PRODUCT_VERSION} -X ${BASE_PACKAGE}.PROJECT_PATH=${PROJECT_PATH}"
+LDFLAGS := -ldflags "-X ${METRICS_PACKAGE}.Revision=${RELEASE_STR} -X ${METRICS_PACKAGE}.Branch=${BRANCH} -X ${BASE_PACKAGE}.PluginVersion=${PRODUCT_VERSION} -X ${BASE_PACKAGE}.ProjectPath=${PROJECT_PATH}"
 
 ### Kind
 KIND_BUILD_DIR		:= ${PWD}/devkit/kind


### PR DESCRIPTION
## Purpose
### Resolves #796 

Currently at error level logs we use full file path, where error was occurred. This PR allowed to use paths relative to the build directory.

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
Apr  1 15:39:43.892 [ERRO] [cmd/node/main.go:262] [Discovering] Discover finished with error: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp [::1]:8888: connect: connection refused"
Apr  1 15:39:53.893 [ERRO] [cmd/node/main.go:262] [Discovering] Discover finished with error: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp [::1]:8888: connect: connection refused"
Apr  1 15:41:20.404 [ERRO] [CSINodeService] [NodeUnstageVolume] [pvc-5f93cb67-b91b-4af3-b1d4-0f47e41b7ac7] [pkg/node/node.go:303] [NodeUnstageVolume] Unable to find volume with ID pvc-5f93cb67-b91b-4af3-b1d4-0f47e41b7ac7
```