### PR TITLE
[ISSUE-803] Replace golangci-lint in CSI devkit 

### DIFF
--- a/devkit/Dockerfile
+++ b/devkit/Dockerfile
@@ -48,13 +48,13 @@ RUN           wget https://go.dev/dl/go${arg_go_ver}.linux-amd64.tar.gz \
 &&            tar -C /usr/local -xzf go${arg_go_ver}.linux-amd64.tar.gz \
 &&            rm go${arg_go_ver}.linux-amd64.tar.gz
 # install bin golangci
-RUN           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${arg_golandci_ver}
+RUN           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${arg_golandci_ver}
 # install proto
 RUN 	      curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${arg_protobuf_ver}/protoc-${arg_protobuf_ver}-linux-x86_64.zip \
 &&    	      unzip protoc-${arg_protobuf_ver}-linux-x86_64.zip -d $PROTOPATH \
+&&            rm protoc-${arg_protobuf_ver}-linux-x86_64.zip
 # TODO update to google.golang.org/protobuf - https://github.com/dell/csi-baremetal/issues/613
 &&        	  go install github.com/golang/protobuf/protoc-gen-go@${arg_protoc_gen_go_ver}
-
 # bind start_ide.sh
 RUN           ln --symbolic /usr/bin/start_ide.sh    /usr/bin/idea \
 &&            ln --symbolic /usr/bin/start_ide.sh    /usr/bin/goland

--- a/devkit/Dockerfile
+++ b/devkit/Dockerfile
@@ -52,7 +52,7 @@ RUN           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lin
 # install proto
 RUN 	      curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${arg_protobuf_ver}/protoc-${arg_protobuf_ver}-linux-x86_64.zip \
 &&    	      unzip protoc-${arg_protobuf_ver}-linux-x86_64.zip -d $PROTOPATH \
-&&            rm protoc-${arg_protobuf_ver}-linux-x86_64.zip
+&&            rm protoc-${arg_protobuf_ver}-linux-x86_64.zip \
 # TODO update to google.golang.org/protobuf - https://github.com/dell/csi-baremetal/issues/613
 &&        	  go install github.com/golang/protobuf/protoc-gen-go@${arg_protoc_gen_go_ver}
 # bind start_ide.sh


### PR DESCRIPTION
## Purpose
### Resolves #803

Default docker args while using devkit `script`:
```
--interactive --privileged --name devkit-c42419c0-a776-404e-9541-41f1aafc0791 --memory 8G --memory-swappiness 10 --env EUID=0 --env EGID=0 --env USER_NAME=root --env STDOUT=true --workdir /workspace --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --tty --network host --ipc=host --env XAUTHORITY=/home/user/.xauth --env DISPLAY=:0 --volume /home/user/Workspace:/workspace:z --volume /home/user/.devkit/.var-lib-docker:/var/lib/docker:z --volume /home/user/.devkit/.docker:/home/user/.docker:z --volume /home/user/.devkit/.config:/home/user/.config:z --volume /home/user/.devkit/.kube:/home/user/.kube:z --volume /home/user/.devkit/.go:/usr/share/go:z --volume /home/user/.ssh:/root/.ssh:z --volume /tmp/.X11-unix:/tmp/.X11-unix:z --volume /home/user/.devkit/.IntelliJIdea:/root/.IntelliJIdea:z --volume /home/user/.devkit/.java:/home/user/.java:z --volume /home/user/.devkit/.GoLand:/home/user/.GoLand:z --volume /dev:/dev:z --volume /run/udev:/run/udev:z --volume /home/user/.devkit/.xauth:/home/user/.xauth:z --volume /home/user/.devkit/.bash_history:/home/user/.bash_history:z --volume /home/user/.gitconfig:/root/.gitconfig:z --volume /home/user/.bashrc:/root/.bashrc:z --volume /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:z
```

To keep go cache we mount `GOPATH` to local folder `--volume /home/user/.devkit/.go:/usr/share/go:z`. So if local folder is empty, all info from devkit image from this path will be cleared.

Need to replace golangci-lint binary from `GOPATH` to `/bin`

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
DEVKIT: docker daemon................[+]
DEVKIT: 'devkit' is started with 'docker start' command, which is generally not recommended. Please, set DEVKIT_DOCKER_RM_BOOL to false to use 'devkit' in a stateless mode.
DEVKIT: start IntelliJ IDEA..........[-]
DEVKIT: start CLion..................[-]
DEVKIT: bash session.................[+]
root@user-vm:/workspace# ls /usr/local/bin
golangci-lint  helm  kind  kubectl
root@user-vm:/workspace# golangci-lint version
golangci-lint has version 1.44.0 built from 617470fa on 2022-01-25T11:31:17Z
```
