### PR TITLE
[ISSUE-802] Proposal for deploying csi on k3s

### DIFF
--- a/docs/proposals/deploy-csi-to-k3s.md
+++ b/docs/proposals/deploy-csi-to-k3s.md
@@ -14,8 +14,8 @@ Currently csi is compatible with Vanilla Kubernetes, RKE2, OpenShift and Kind, b
 ## Proposal
 
 Need to create next config file in directory `/var/lib/rancher/k3s/agent/pod-manifests`:
-
-`apiVersion: kubescheduler.config.k8s.io/v1beta1
+```
+apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 extenders:
   - urlPrefix: "http://127.0.0.1:8889"
@@ -29,8 +29,8 @@ extenders:
 leaderElection:
   leaderElect: true
 clientConnection:
-  kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig`
-
+  kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
+```
 For passing it to k3s server component use `--kube-scheduler-arg=config`
 
 

--- a/docs/proposals/deploy-csi-to-k3s.md
+++ b/docs/proposals/deploy-csi-to-k3s.md
@@ -1,15 +1,15 @@
-# Proposal: Deploy CSI on K3s cluster 
+# Proposal:  K3s Kubernetes distribution 
 
-Last updated: 8.04.22
+Last updated: 12.04.22
 
 
 ## Abstract
 
-Deploy CSI on K3s cluster, test it work and add steps for manual patching scheduler 
+Specify required changes to support working CSI on k3s, describe steps for manual patching scheduler 
 
 ## Background
 
-Currently csi is compatible with Vanilla Kubernetes, RKE2, OpenShift and Kind, but only for test purpose. We want to deploy csi to new platform.  
+Currently csi is compatible with Vanilla Kubernetes, RKE2, OpenShift and Kind. However, Kind is only used for testing purposes. We want to support new platform.  
 
 ## Proposal
 
@@ -31,8 +31,14 @@ leaderElection:
 clientConnection:
   kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
 ```
-For passing it to k3s server component use `--kube-scheduler-arg=config`
+After that there are two ways:
+1. If you haven't started the service yet, run service creation command with the following flag `k3s server --kube-scheduler-arg=config=/var/lib/rancher/k3s/agent/pod-manifests/scheduler/config.yaml`
+2. If you already have a running service, modify  `/etc/systemd/system/k3s.service`. Add at the end of the file `--kube-scheduler-arg=config=/var/lib/rancher/k3s/agent/pod-manifests/scheduler/config.yaml` and manually run the command for reloading daemon `systemctl daemon-reload && systemctl restart k3s`.
 
+## Rationale
+
+1. First method will modify the default service script with the required configuration file and start the service. If the service is already running this command will not be able to modify it. It will try to run another one in parallel with the default configuration and run into the problem of running two servers on the same host.
+2. Second method is suitable for a situation with a running service. The problem of the method is the lack of automatic reload. 
 
 ## Compatibility
 
@@ -45,6 +51,7 @@ Tasks:
 2.	Pass it to the k3s application server with appropriate flag
 3.	Reload daemon 
 4.	Test with temp pod
+5.  Uninstall CSI
 
 
 ## Open issues (if applicable)

--- a/docs/proposals/deploy-csi-to-k3s.md
+++ b/docs/proposals/deploy-csi-to-k3s.md
@@ -1,11 +1,11 @@
 # Proposal:  K3s Kubernetes distribution 
 
-Last updated: 12.04.22
+Last updated: 20.04.22
 
 
 ## Abstract
 
-Specify required changes to support working CSI on k3s, describe steps for manual patching scheduler 
+Specify required changes to support working CSI on k3s, describe steps for manual patching scheduler and for automated patching.  
 
 ## Background
 
@@ -33,7 +33,9 @@ clientConnection:
 ```
 After that there are two ways:
 1. If you haven't started the service yet, run service creation command with the following flag `k3s server --kube-scheduler-arg=config=/var/lib/rancher/k3s/agent/pod-manifests/scheduler/config.yaml`
-2. If you already have a running service, modify  `/etc/systemd/system/k3s.service`. Add at the end of the file `--kube-scheduler-arg=config=/var/lib/rancher/k3s/agent/pod-manifests/scheduler/config.yaml` and manually run the command for reloading daemon `systemctl daemon-reload && systemctl restart k3s`.
+2. If you already have a running service, modify  `/etc/systemd/system/k3s.service`. Add at the option `ExecStart` (end of the file) next string `--kube-scheduler-arg=config=/var/lib/rancher/k3s/agent/pod-manifests/scheduler/config.yaml` and manually run the command for reloading daemon `systemctl daemon-reload && systemctl restart k3s`. Don't worry about installation `systemctl` because k3s doesn't work without that and install it by default.   
+
+It's suggested to use the second method to automatically patch scheduller. We will pass `k3s.service` to patcher, change `ExecStart` parameter and remember what we add. We cann't save the state of the entire file, because this file refers to the operation of the entire service (components inscribed in it). And how this file is changed by us, it can also be changed by other people. After that user used to reload systemd manager configuration and k3s service manually.  
 
 ## Rationale
 
@@ -46,16 +48,23 @@ There is no problem with compatibility
 
 ## Implementation
 
-Tasks:
+Tasks for manuall patching:
 1.	Create new config for scheduler 
 2.	Pass it to the k3s application server with appropriate flag
-3.	Reload daemon 
+3.	Reload daemon and restart k3s with new kube scheduller parameters manually 
 4.	Test with temp pod
-5.  Uninstall CSI
+5.  For uninstall CSI need to change k3s.service file back and reload as it was in a priviouse step 
 
+Tasks for automated patching:
+1.  Need to set parameter `scheduler.patcher.enable=true` in installation step
+2.  Reload daemon and restart k3s
+3.  Check scheduller patcher redines with test pod
+4.  Uninstall CSI without changes  
 
 ## Open issues (if applicable)
 
 | ID      | Name | Descriptions | Status | Comments |
 |---------|------|--------------|--------|----------|
 | ISSUE-1 | Update installation guide | Add steps for deploying csi on k3s |   |   |
+| ISSUE-2 | Parse .service file | Add function(s) to change k3s.service file  |   |   |
+| ISSUE-3 | Test scheduller patcher | Test your changes  |   |   |

--- a/docs/proposals/deploy-csi-to-k3s.md
+++ b/docs/proposals/deploy-csi-to-k3s.md
@@ -1,0 +1,54 @@
+# Proposal: Deploy CSI on K3s cluster 
+
+Last updated: 8.04.22
+
+
+## Abstract
+
+Deploy CSI on K3s cluster, test it work and add steps for manual patching scheduler 
+
+## Background
+
+Currently csi is compatible with Vanilla Kubernetes, RKE2, OpenShift and Kind, but only for test purpose. We want to deploy csi to new platform.  
+
+## Proposal
+
+Need to create next config file in directory `/var/lib/rancher/k3s/agent/pod-manifests`:
+
+`apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+extenders:
+  - urlPrefix: "http://127.0.0.1:8889"
+    filterVerb: filter
+    prioritizeVerb: prioritize
+    weight: 1
+    enableHTTPS: false
+    nodeCacheCapable: false
+    ignorable: true
+    httpTimeout: 15s
+leaderElection:
+  leaderElect: true
+clientConnection:
+  kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig`
+
+For passing it to k3s server component use `--kube-scheduler-arg=config`
+
+
+## Compatibility
+
+There is no problem with compatibility
+
+## Implementation
+
+Tasks:
+1.	Create new config for scheduler 
+2.	Pass it to the k3s application server with appropriate flag
+3.	Reload daemon 
+4.	Test with temp pod
+
+
+## Open issues (if applicable)
+
+| ID      | Name | Descriptions | Status | Comments |
+|---------|------|--------------|--------|----------|
+| ISSUE-1 | Update installation guide | Add steps for deploying csi on k3s |   |   |


### PR DESCRIPTION
## Purpose
### Resolves #802

Add proposal for discussion steps of deploying csi on k3s 

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
csi-k3s-sles-micro-108:~ # kubectl logs csi-baremetal-se-66scm 
Apr  4 12:38:54.427 [INFO] Starting scheduler extender for CSI-Baremetal ...
Apr  4 12:38:55.042 [INFO] Starting extender on port 8889 ...
Apr  4 12:38:55.042 [INFO] Registering for filter stage ... 
Apr  4 12:38:55.042 [INFO] Registering for prioritize stage ... 
Apr  4 12:38:55.042 [INFO] Registering for bind stage ... 
Apr  4 12:38:55.042 [INFO] Starting Controller Health server
Apr  4 12:38:55.042 [INFO] Create server for endpoint ":9999" on "tcp" socket
Apr  4 12:38:55.042 [INFO] Registering health check service
Apr  4 12:38:55.043 [INFO] [ServerRunner] Starting gRPC server for endpoint :9999 and socket tcp
Apr  4 12:44:11.017 [INFO] [Extender] [FilterHandler] [1fea9810-fe1b-4320-a1c4-e2618f812748] Processing request: &{POST /filter HTTP/1.1 1 1 map[Accept-Encoding:[gzip] Content-Length:[27497] Content-Type:[application/json] User-Agent:[Go-http-client/1.1]] 0xc000740000 <nil> 27497 [] false 127.0.0.1:8889 map[] map[] <nil> map[] 127.0.0.1:47612 /filter <nil> <nil> <nil> 0xc000740040}
Apr  4 12:44:11.023 [INFO] [Extender] [FilterHandler] [web-0] [1fea9810-fe1b-4320-a1c4-e2618f812748] Filtering
Apr  4 12:44:11.033 [INFO] [KubeClient] [CreateCR] [1fea9810-fe1b-4320-a1c4-e2618f812748] Creating CR 'AvailableCapacityReservation': &{TypeMeta:{Kind:AvailableCapacityReservation APIVersion:csi-baremetal.dell.com/v1} ObjectMeta:{Name:default-web-0 GenerateName: Namespace: SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{Namespace:default Status:REQUESTED NodeRequests:Requested:"19182a40-315f-43c3-ab1b-720b9a1b8d6c" Requested:"301185b5-b345-45c3-93f4-b1bef214b43d" Requested:"183226f6-00f1-42da-acd2-70a3bf6cb6c4"  ReservationRequests:[CapacityRequest:<Name:"www-web-0" StorageClass:"ANY" Size:62914560 >  CapacityRequest:<Name:"data-web-0" StorageClass:"ANY" Size:62914560 >  CapacityRequest:<Name:"logs-web-0" StorageClass:"ANY" Size:62914560 > ] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}}
Apr  4 12:44:11.059 [INFO] [KubeClient] [CreateCR] [1fea9810-fe1b-4320-a1c4-e2618f812748] CR AvailableCapacityReservation default-web-0 created
Apr  4 12:44:11.060 [INFO] [Extender] [FilterHandler] [web-0] [1fea9810-fe1b-4320-a1c4-e2618f812748] Construct response. Get 3 nodes in request. Among them suitable nodes count is 0. Filtered out nodes - map[]
Apr  4 12:45:29.555 [INFO] [Extender] [FilterHandler] [d98523c2-1c26-4bbb-a790-8479363440e3] Processing request: &{POST /filter HTTP/1.1 1 1 map[Accept-Encoding:[gzip] Content-Length:[28009] Content-Type:[application/json] User-Agent:[Go-http-client/1.1]] 0xc0008a4580 <nil> 28009 [] false 127.0.0.1:8889 map[] map[] <nil> map[] 127.0.0.1:47612 /filter <nil> <nil> <nil> 0xc0008a45c0}
Apr  4 12:45:29.558 [INFO] [Extender] [FilterHandler] [web-0] [d98523c2-1c26-4bbb-a790-8479363440e3] Filtering
Apr  4 12:45:29.569 [INFO] [Extender] [FilterHandler] [web-0] [d98523c2-1c26-4bbb-a790-8479363440e3] Construct response. Get 3 nodes in request. Among them suitable nodes count is 3. Filtered out nodes - map[]
Apr  4 12:45:29.573 [INFO] [Extender] [PrioritizeHandler] [38a87d3e-915a-4382-b343-cda98ba9c8d9] Processing request: &{POST /prioritize HTTP/1.1 1 1 map[Accept-Encoding:[gzip] Content-Length:[28009] Content-Type:[application/json] User-Agent:[Go-http-client/1.1]] 0xc0008a56c0 <nil> 28009 [] false 127.0.0.1:8889 map[] map[] <nil> map[] 127.0.0.1:48076 /prioritize <nil> <nil> <nil> 0xc0008a5700}
Apr  4 12:45:29.576 [INFO] [Extender] [PrioritizeHandler] [38a87d3e-915a-4382-b343-cda98ba9c8d9] Scoring
Apr  4 12:45:29.576 [INFO] [Extender] [PrioritizeHandler] [38a87d3e-915a-4382-b343-cda98ba9c8d9] Score results: [{csi-k3s-sles-micro-109 0} {csi-k3s-sles-micro-110 0} {csi-k3s-sles-micro-108 0}]
```
k3s server log:
```
Apr 19 14:43:43 csi-k3s-sles-micro-108 k3s[6402]: time="2022-04-19T14:43:43Z" level=info msg="Running kube-scheduler --authentication-kubeconfig=/var/lib/rancher/k3s/server/cred/scheduler.kubeconfig --authorization-kubeconfig=/var/lib/rancher/k3s/server/cred/scheduler.kubeconfig --bind-address=127.0.0.1 --config=/var/lib/rancher/k3s/agent/pod-manifests/scheduler/config.yaml --kubeconfig=/var/lib/rancher/k3s/server/cred/scheduler.kubeconfig --leader-elect=false --profiling=false --secure-port=10259"
```