### PR TITLE
[ISSUE-814] Deprecate Controller_Publish/Unpublish capability

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -383,7 +383,7 @@ func (c *CSIControllerService) ControllerGetCapabilities(context.Context, *csi.C
 	caps := make([]*csi.ControllerServiceCapability, 0)
 	for _, c := range []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+		//csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 	} {
 		caps = append(caps, newCap(c))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -299,31 +299,7 @@ func (c *CSIControllerService) DeleteVolume(ctx context.Context, req *csi.Delete
 // Returns CSI Spec ControllerPublishVolumeResponse or error if something went wrong
 func (c *CSIControllerService) ControllerPublishVolume(ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	ll := c.log.WithFields(logrus.Fields{
-		"method":   "ControllerPublishVolume",
-		"volumeID": req.GetVolumeId(),
-	})
-
-	if req.NodeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume: Node ID must be provided")
-	}
-
-	if req.VolumeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume: Volume ID must be provided")
-	}
-
-	if req.VolumeCapability == nil {
-		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume: Volume capabilities"+
-			" must be provided")
-	}
-	if _, err := c.crHelper.GetVolumeByID(req.VolumeId); err != nil {
-		ll.Errorf("k8s client can't read volume CR")
-		return nil, status.Error(codes.NotFound, "Volume is not found")
-	}
-
-	ll.Info("Return empty response, ok.")
-
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return nil, status.Error(codes.Unimplemented, "not implemented yet")
 }
 
 // ControllerUnpublishVolume is the implementation of CSI Spec ControllerUnpublishVolume.
@@ -332,18 +308,7 @@ func (c *CSIControllerService) ControllerPublishVolume(ctx context.Context,
 // Returns CSI Spec ControllerUnpublishVolumeResponse or error if Volume ID is not provided in request
 func (c *CSIControllerService) ControllerUnpublishVolume(ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	ll := c.log.WithFields(logrus.Fields{
-		"method":   "ControllerUnpublishVolume",
-		"volumeID": req.GetVolumeId(),
-	})
-
-	if req.VolumeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume: Volume ID must be provided")
-	}
-
-	ll.Info("Return empty response, ok")
-
-	return &csi.ControllerUnpublishVolumeResponse{}, nil
+	return nil, status.Error(codes.Unimplemented, "not implemented yet")
 }
 
 // ValidateVolumeCapabilities is not implemented yet
@@ -383,7 +348,7 @@ func (c *CSIControllerService) ControllerGetCapabilities(context.Context, *csi.C
 	caps := make([]*csi.ControllerServiceCapability, 0)
 	for _, c := range []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		//csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+		// csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 	} {
 		caps = append(caps, newCap(c))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -293,21 +293,15 @@ func (c *CSIControllerService) DeleteVolume(ctx context.Context, req *csi.Delete
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
-// ControllerPublishVolume is the implementation of CSI Spec ControllerPublishVolume. This method just checks existence
-// of provided Volume CR and returns success response if the Volume CR exists.
-// Receives golang context and CSI Spec ControllerPublishVolumeRequest
-// Returns CSI Spec ControllerPublishVolumeResponse or error if something went wrong
-func (c *CSIControllerService) ControllerPublishVolume(ctx context.Context,
-	req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+// ControllerPublishVolume is not implemented yet
+func (c *CSIControllerService) ControllerPublishVolume(_ context.Context,
+	_ *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented yet")
 }
 
-// ControllerUnpublishVolume is the implementation of CSI Spec ControllerUnpublishVolume.
-// This method just returns empty response.
-// Receives golang context and CSI Spec ControllerUnpublishVolumeRequest
-// Returns CSI Spec ControllerUnpublishVolumeResponse or error if Volume ID is not provided in request
-func (c *CSIControllerService) ControllerUnpublishVolume(ctx context.Context,
-	req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+// ControllerUnpublishVolume is not implemented yet
+func (c *CSIControllerService) ControllerUnpublishVolume(_ context.Context,
+	_ *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented yet")
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -342,7 +342,6 @@ func (c *CSIControllerService) ControllerGetCapabilities(context.Context, *csi.C
 	caps := make([]*csi.ControllerServiceCapability, 0)
 	for _, c := range []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		// csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 	} {
 		caps = append(caps, newCap(c))

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -630,7 +630,6 @@ var _ = Describe("CSIControllerService ControllerGetCapabilities", func() {
 			err                       error
 			expectedCapabilitiesTypes = []csi.ControllerServiceCapability_RPC_Type{
 				csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-				csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 				csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			}
 		)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -938,6 +938,16 @@ func TestController_UnimplementedMethods(t *testing.T) {
 		_, err := controller.GetCapacity(testCtx, nil)
 		assert.True(t, strings.Contains(err.Error(), expected))
 	})
+
+	t.Run("ControllerPublishVolume", func(t *testing.T) {
+		_, err := controller.ControllerPublishVolume(testCtx, nil)
+		assert.True(t, strings.Contains(err.Error(), expected))
+	})
+
+	t.Run("ControllerUnpublishVolume", func(t *testing.T) {
+		_, err := controller.ControllerUnpublishVolume(testCtx, nil)
+		assert.True(t, strings.Contains(err.Error(), expected))
+	})
 }
 
 // create and instance of CSIControllerService with scheme for working with CRD


### PR DESCRIPTION
## Purpose
### Resolves #814

**Failure case**
1. Install CSI and some PVCs
```
[root@servicenode ~]# oc get po
NAME                                             READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-77c5b7c94c-vjzf9        4/4     Running   0          38s
csi-baremetal-node-controller-6654755d7d-c49dj   1/1     Running   0          39s
csi-baremetal-node-fdg7b                         4/4     Running   0          38s
csi-baremetal-node-gpq42                         3/4     Running   0          38s
csi-baremetal-node-nnnrw                         4/4     Running   0          38s
csi-baremetal-node-nvtcr                         4/4     Running   0          38s
csi-baremetal-node-nzrnl                         3/4     Running   0          38s
csi-baremetal-node-prtkk                         4/4     Running   0          38s
csi-baremetal-node-qmjlz                         3/4     Running   0          38s
csi-baremetal-operator-644c67d6d-jwtf6           1/1     Running   0          110m
csi-baremetal-se-djvbx                           0/1     Running   0          38s
csi-baremetal-se-gqbbb                           0/1     Running   0          38s
csi-baremetal-se-zg5l4                           0/1     Running   0          38s
web-0                                            1/1     Running   0          83m
[root@servicenode ~]# oc get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
data-web-0   Bound    pvc-99b08fa4-62ce-46f5-93b9-51063e8614ab   8001G      RWO            csi-baremetal-sc   83m
logs-web-0   Bound    pvc-7ddfb040-7a2c-4aae-8d88-83b94fcd8115   8001G      RWO            csi-baremetal-sc   83m
www-web-0    Bound    pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c   8001G      RWO            csi-baremetal-sc   83m
```

2. Delete CSI
`helm delete csi-baremetal`

3. Wait some time until VolumeAttachements has been created for PVs
```
NAME                                                                   ATTACHER        PV                                         NODE                      ATTACHED   AGE
csi-02fb4531aa5fef007f4e8e930da752282742f4fd5aed88887aa027210563cae6   csi-baremetal   pvc-99b08fa4-62ce-46f5-93b9-51063e8614ab   worker1.ocp4.oil-bd.com   false      68m
csi-864b81f4fcbbfd3cbbe3f3aa59780dc63f8fa9aad628ab063c3d50153de0264f   csi-baremetal   pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c   worker1.ocp4.oil-bd.com   false      68m
csi-b19745fccc7937c15e65263467a525b55c47776eaa42432b299dda7e41e303d8   csi-baremetal   pvc-7ddfb040-7a2c-4aae-8d88-83b94fcd8115   worker1.ocp4.oil-bd.com   false      68m
```

4. Reinstall CSI, try to delete PVCs and check csi-provisioner logs
```
I0408 14:38:07.836772       1 controller.go:1471] delete "pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9": started
E0408 14:38:07.836824       1 controller.go:1481] delete "pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9": volume deletion failed: persistentvolume pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9 is still attached to node worker3.ocp4.oil-bd.com
W0408 14:38:07.836859       1 controller.go:989] Retrying syncing volume "pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9", failure 0
E0408 14:38:07.836879       1 controller.go:1007] error syncing volume "pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9": persistentvolume pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9 is still attached to node worker3.ocp4.oil-bd.com
```

**RCA**
Provisioner checks VolumeAttachments and rejects volume deletion if it exists - https://github.com/kubernetes-csi/external-provisioner/blob/3d640ea319ecde1eae0e9e36318d1fe2ca30bbd4/pkg/controller/controller.go#L1221
PV controller checks CSIDriverSpec.attachRequired and skip VolumeAttachments creation step if false. But when we deleted CSIDriver resource this condition doesn't work and VA are created anyway

Log
```
I0408 13:18:16.552617       1 reconciler.go:295] attacherDetacher.AttachVolume started for volume "pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c" (UniqueName: "kubernetes.io/csi/csi-baremetal^pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c") from node "worker1.ocp4.oil-bd.com" 
E0408 13:20:16.563298       1 csi_attacher.go:501] kubernetes.io/csi: attachdetacher.WaitForDetach timeout after 2m0s [volume=pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c; attachment.ID=csi-864b81f4fcbbfd3cbbe3f3aa59780dc63f8fa9aad628ab063c3d50153de0264f]
I0408 13:20:16.563411       1 actual_state_of_world.go:350] Volume "kubernetes.io/csi/csi-baremetal^pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c" is already added to attachedVolume list to node "worker1.ocp4.oil-bd.com", update device path ""
```

Link to code - https://github.com/kubernetes/kubernetes/blob/c285e781331a3785a7f436042c65c5641ce8a9e9/pkg/controller/volume/attachdetach/attach_detach_controller.go#L449
Link to behavior description - https://www.pulumi.com/registry/packages/kubernetes/api-docs/storage/v1/csidriver/#attachrequired_nodejs

**Resolution**
Disable csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME
CSI-provisioner watches VA only if it is set - https://github.com/kubernetes-csi/external-provisioner/blob/7e4143c9fbb6a0b2c7eb2d4a7da7c467950d7fbe/cmd/csi-provisioner/csi-provisioner.go#L281
Check will be skipped and all volumes will be deleted successfully

```
I0408 14:20:18.767427       1 controller.go:1471] delete "pvc-99b08fa4-62ce-46f5-93b9-51063e8614ab": started
I0408 14:20:18.770899       1 controller.go:1471] delete "pvc-7ddfb040-7a2c-4aae-8d88-83b94fcd8115": started
I0408 14:20:18.780493       1 controller.go:1471] delete "pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c": started
I0408 14:20:23.838640       1 controller.go:1486] delete "pvc-99b08fa4-62ce-46f5-93b9-51063e8614ab": volume deleted
I0408 14:20:23.843562       1 controller.go:1531] delete "pvc-99b08fa4-62ce-46f5-93b9-51063e8614ab": persistentvolume deleted
I0408 14:20:23.843579       1 controller.go:1536] delete "pvc-99b08fa4-62ce-46f5-93b9-51063e8614ab": succeeded
I0408 14:20:24.856171       1 controller.go:1486] delete "pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c": volume deleted
I0408 14:20:24.861172       1 controller.go:1531] delete "pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c": persistentvolume deleted
I0408 14:20:24.861191       1 controller.go:1536] delete "pvc-75dd34f7-d01f-4a4e-a5ae-90269b35c32c": succeeded
I0408 14:20:25.852297       1 controller.go:1486] delete "pvc-7ddfb040-7a2c-4aae-8d88-83b94fcd8115": volume deleted
I0408 14:20:25.857565       1 controller.go:1531] delete "pvc-7ddfb040-7a2c-4aae-8d88-83b94fcd8115": persistentvolume deleted
I0408 14:20:25.857586       1 controller.go:1536] delete "pvc-7ddfb040-7a2c-4aae-8d88-83b94fcd8115": succeeded
```

But VA are still in cluster, we need to delete them manually
```
[root@servicenode ~]# oc get  volumeattachments
NAME                                                                   ATTACHER        PV                                         NODE                      ATTACHED   AGE
csi-517bee61b7310f9e7a3a4dcad62c32234809aa1b6f16eae931faa9685c84350c   csi-baremetal   pvc-ccb12d86-70d7-4acf-b968-6cfb55b862c2   worker3.ocp4.oil-bd.com   false      19m
csi-9806b73e0091478000be81784457c1e283f751815859da42958e790709cb0bc1   csi-baremetal   pvc-2194ba7b-3158-4b49-915c-0a92dab6e6e9   worker3.ocp4.oil-bd.com   false      19m
csi-9bcef0c6702ee6da33eb2c3f6fa3e5b25c2807a4561f22b6da7cc56997e19420   csi-baremetal   pvc-550c8b74-19e6-4f0b-bef6-f46084c531cc   worker3.ocp4.oil-bd.com   false      29m
csi-ed529dd707dff6081945c417181d0008003118be5f770186bf260a8242c514dc   csi-baremetal   pvc-3feaef8e-a28c-4001-ac72-61d97cf0fab0   worker3.ocp4.oil-bd.com   false      29m
csi-ed95479ddf5a93a96d7ca7fdce0825bf7953071228cacc7a424eae3a04cc9f46   csi-baremetal   pvc-28e19922-68c1-4be0-a0b8-2eed5a6ccd84   worker3.ocp4.oil-bd.com   false      29m
csi-f6bff61449cf3f51b622cc4b307103b2c490faa69acc26f2de4a3b7536c48eaa   csi-baremetal   pvc-96359859-0916-4599-aa8d-00eb200419d4   worker3.ocp4.oil-bd.com   false      19m
```

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
