### PR TITLE
[ISSUE-811] Remove annotation in drive metadata for deleted volume

### DIFF
--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -301,7 +301,8 @@ func (m *VolumeManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			// drive must be present in the system
 			drive, _ := m.crHelper.GetDriveCRByVolume(volume)
 			if drive != nil {
-				m.addVolumeStatusAnnotation(drive, volume.Name, apiV1.Removed)
+				delete(drive.Annotations,
+					fmt.Sprintf("%s/%s", apiV1.DriveAnnotationVolumeStatusPrefix, volume.Name))
 				if err := m.k8sClient.UpdateCR(ctx, drive); err != nil {
 					ll.Errorf("Unable to update Drive annotations")
 				}

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -301,8 +301,9 @@ func (m *VolumeManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			// drive must be present in the system
 			drive, _ := m.crHelper.GetDriveCRByVolume(volume)
 			if drive != nil {
-				delete(drive.Annotations,
-					fmt.Sprintf("%s/%s", apiV1.DriveAnnotationVolumeStatusPrefix, volume.Name))
+				annotations := drive.GetAnnotations()
+				delete(annotations, fmt.Sprintf("%s/%s", apiV1.DriveAnnotationVolumeStatusPrefix, volume.Name))
+				drive.SetAnnotations(annotations)
 				if err := m.k8sClient.UpdateCR(ctx, drive); err != nil {
 					ll.Errorf("Unable to update Drive annotations")
 				}


### PR DESCRIPTION
## Purpose
### Resolves #811 

_Remove annotation in drive metadata for deleted volume_

## PR checklist
- [X] Add link to the issue
- [X] Choose Project
- [X] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
1. Deploy CSI
2. Deploy an application 
3. Delete an application
4. Delete all pvc-es
5. Make sure that a drive doesn't have a "status/pvc-name" in its metadata
