### PR TITLE
[ISSUE-817] Permission denied error in devkit

### DIFF
--- a/devkit/devkit-entrypoint.sh
+++ b/devkit/devkit-entrypoint.sh
@@ -258,7 +258,7 @@ function start() {
     devkit_echo 1 "bash session.................[$(state true)]"
 
     if ! $CMD_PROVIDED; then
-        su $USER_NAME -m <&0
+        su $USER_NAME <&0
     else
         su $USER_NAME -c "$CMD_OPT_VAL" <&0
     fi


### PR DESCRIPTION
Signed-off-by: Dutova <Ann.Dutova@Dell.com>

## Purpose
### Resolves #817

The reason of permission denied is incorrectly set HOME variable. 
Looking at the logs when entering the devkit, you can see that all env are set correctly. 
```
HOME=/home/ann
DEVKIT_SSH_HOST_DIR_PATH=/home/ann/.ssh
DEVKIT_GIT_CONF_HOST_FILE_PATH=/home/ann/.gitconfig
DEVKIT_BASH_RC_HOST_FILE_PATH=/home/ann/.bashrc
```
But already inside the devkit, the variables are change or even disappear. Due to this offers to fix one line with the entrance to the devkit.
From linux manual page:
```
-m, -p, --preserve-environment
              Preserve  the  entire  environment,  i.e.  it does not set HOME,
              SHELL, USER nor LOGNAME.
```

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Start:
```
DEVKIT: docker daemon................[+]
Group 'mail' not found. Creating the user mailbox file with 0600 mode.
DEVKIT: start IntelliJ IDEA..........[-]
DEVKIT: start CLion..................[-]
DEVKIT: bash session.................[+]
ann@ubuntu:~/Workspace> kubectl version 
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.4", GitCommit:"e6c093d87ea4cbb530a7b2ae91e54c0842d8308a", GitTreeState:"clean", BuildDate:"2022-02-16T12:38:05Z", GoVersion:"go1.17.7", Compiler:"gc", Platform:"linux/amd64"}
```
env:
```
DISPLAY=:0.0
HOSTNAME=ubuntu
GPG_TTY=/dev/pts/2
USER_NAME=ann
XDG_SESSION_ID=c2
USER=ann
STDOUT=true
GOENV=/usr/share/go/.cache/go/env
GOPATH=/usr/share/go
PWD=/home/ann/Workspace
HOME=/home/ann
GOROOT=/usr/local/go
XDG_SESSION_TYPE=tty
EGID=1000
SHELL=/bin/bash
TERM=xterm
XDG_SESSION_CLASS=user
SHLVL=2
EUID=1000
LOGNAME=ann
XAUTHORITY=/home/ann/.xauth
PATH=/usr/local/bin:/bin:/usr/bin
ENV_ROOTPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
GOCACHE=/usr/share/go/.cache/go-build
PROTOPATH=/usr/local/proto
_=/usr/bin/env
```