### PR TITLE
[ISSUE-818] Can't open .md files in devkit

### DIFF
--- a/devkit/Dockerfile
+++ b/devkit/Dockerfile
@@ -42,7 +42,11 @@ RUN           zypper --no-gpg-checks --non-interactive refresh \
               wget \
               xorg-x11 \
               xorg-x11-fonts \
-              unzip
+              unzip \
+              MozillaFirefox \
+              libasound2 \
+              libgbm1 \
+              libxshmfence1
 # install go
 RUN           wget https://go.dev/dl/go${arg_go_ver}.linux-amd64.tar.gz \
 &&            tar -C /usr/local -xzf go${arg_go_ver}.linux-amd64.tar.gz \


### PR DESCRIPTION
Signed-off-by: Dutova <Ann.Dutova@Dell.com>

## Purpose
### Resolves #818

JCEF browser render source markdown code to html page automatically in IDE from JetBrains. To support it need to add [their solution](https://github.com/JetBrains/jcef), but it's suitable for Java-based applications, or install default browser. IDE picks chrome and firefox as default and sets path to them without user interaction. 
 
## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
How error log view: 
![bug818](https://user-images.githubusercontent.com/100381613/163806132-5891ccaa-9aeb-44c2-9e0d-1cabcee065d2.png)
After with preview: 
![bugfix818](https://user-images.githubusercontent.com/100381613/163806539-edf4c381-343d-4299-ac34-ff50fdbd70c6.png)
