### PR TITLE
[ISSUE-839] Use Ubuntu 21.04 as a base image for loopback mgr

### DIFF
--- a/pkg/drivemgr/loopbackmgr/Dockerfile.build
+++ b/pkg/drivemgr/loopbackmgr/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM    ubuntu:22.04
+FROM    ubuntu:21.04
 
 # Remove bash packet to get rid of related CVEs
 RUN     apt update --no-install-recommends -y -q && apt remove --no-install-recommends -y --allow-remove-essential -q bash


### PR DESCRIPTION
## Purpose
### Resolves #839 

Revert a part of changes from https://github.com/dell/csi-baremetal/pull/831

Changes caused regression - stress test with loopback manager failed:
```
[DEBU] [Executor] [sgdisk -n 1:0:0 -c 1:CSI -u 1:1dc34670-667a-4f6a-a35e-eb1b90110392 /dev/loop92] [1.100000372s] [1100000372] stdout: Setting name!

[DEBU] [PartitionOperations] [SearchPartName] [1dc34670-667a-4f6a-a35e-eb1b90110392] Search partition number for device /dev/loop92 and uuid 1dc34670-667a-4f6a-a35e-eb1b90110392

[ERRO] [Executor] [blockdev --rereadpt -v /dev/loop92] [23.387079ms] [23387079] [pkg/base/command/cmdexec.go:186] [runCmdFromCmdObj] stdout: , stderr: blockdev: ioctl error on BLKRRPART: Invalid argument

....
[ERRO] [Executor] [blockdev --rereadpt -v /dev/loop92] [18.975902ms] [18975902] [pkg/base/command/cmdexec.go:186] [runCmdFromCmdObj] stdout: , stderr: blockdev: ioctl error on BLKRRPART: Invalid argument

[ERRO] [PartitionOperations] [SearchPartName] [1dc34670-667a-4f6a-a35e-eb1b90110392] [pkg/node/provisioners/utilwrappers/partition_operations.go:179] [SearchPartName] Unable to sync partition table for device /dev/loop92: exit status 1
```

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
