### PR TITLE
[ISSUE-859] Rewrite node-removal documentation

### DIFF
--- a/docs/node-removal.md
+++ b/docs/node-removal.md
@@ -43,25 +43,25 @@ Removal:
 
 ### Manual
 
-If user aims to delete node from cluster, he/she must perform following steps for CSI.  
+If user aims to delete node from cluster, he/she must perform following steps for CSI. 
 
 #### Node is healthy
 
 After node drain:
-1) Determine removing Node UUID 
+1) Determine removing Node UUID
 2) Delete PVCs used by Pods, which were run on deleted node
 
 #### Node is unhealthy
 
 Before node deletion:
-1) Determine removing Node UUID 
+1) Determine removing Node UUID
 
 After node deletion:
 1) Delete PVCs used by Pods, which were run on deleted node
 
 #### User actions
 After node deletion:
-1) Patch according Volumes custom resources with empty finalizer  
+1) Patch according Volumes custom resources with empty finalizer
 ```
 kubectl get volume | grep <node_id> | awk '{print $1}' | xargs kubectl patch volume --type merge -p '{"metadata":{"finalizers":null}}'
 ```
@@ -73,27 +73,23 @@ kubectl get volume | grep <node_id> | awk '{print $1}' | xargs kubectl delete vo
 ```
 kubectl get lvg | grep <node_id> | awk '{print $1}' | xargs kubectl patch lvg --type merge -p '{"metadata":{"finalizers":null}}'
 ```
-4) Delete LVG CR with according node id
+4) Delete LVG CR with according node id
 ```
 kubectl get lvg | grep <node_id> | awk '{print $1}' | xargs kubectl delete lvg
 ```
-5) Patch according CSI bare-metal Node custom resources with empty finalizer
-``` 
-kubectl get csibmnode | grep <node_id> | awk '{print $1}' | xargs kubectl patch csibmnode --type merge -p '{"metadata":{"finalizers":null}}'
-```
-6) Delete CSI bare-metal Node custom resource
+5) Delete CSI bare-metal Node custom resource
 ``` 
 kubectl get csibmnode | grep <node_id> | awk '{print $1}' | xargs kubectl delete csibmnode
 ```
-7) Delete available capacity CR with according node id
+6) Delete available capacity CR with according node id
 ``` 
 kubectl get ac | grep <node_id> | awk '{print $1}' | xargs kubectl delete ac
 ```
-8) Delete drive CR with according node id 
+7) Delete drive CR with according node id 
 ``` 
 kubectl get drive | grep <node_id> | awk '{print $1}' | xargs kubectl delete drive
 ```
-9) Restart new created Pods to create new PVCs for them or create manually necessary PVCs for Pods
+8) Restart new created Pods to create new PVCs for them or create manually necessary PVCs for Pods
 
 ## Compatibility
 


### PR DESCRIPTION
Signed-off-by: Dutova <Ann.Dutova@Dell.com>

## Purpose
### Resolves #859

The reason of CrashLoop is taint mark after restart, to delete it need to call [CleanNode](https://github.com/dell/csi-baremetal/blob/a0bce1fa10f5f75806a6e18194cde26a88b609ed/pkg/crcontrollers/node/controller.go#L405) function from controller.  

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
 
[node_removal_log.txt](https://github.com/dell/csi-baremetal/files/8755896/node_removal_log.txt) - how to reproduce the problem and the result of removing the patching step 
