### PR TITLE
[ISSUE-825] Retry sync partition table with timeout

### DIFF
--- a/cmd/drivemgr/loopbackmgr/main.go
+++ b/cmd/drivemgr/loopbackmgr/main.go
@@ -66,9 +66,11 @@ func main() {
 		logger.Fatalf("fail to create kubernetes client, error: %v", err)
 	}
 
-	nodeID, err := annotations.GetNodeIDByName(k8SClient, nodeName, *nodeIDAnnotation, "", featureConf)
+	// we need to obtain node ID first before proceeding with the initialization
+	nodeID, err := annotations.ObtainNodeIDWithRetries(k8SClient, featureConf, nodeName, *nodeIDAnnotation,
+		logger, annotations.NumberOfRetries, annotations.DelayBetweenRetries)
 	if err != nil {
-		logger.Fatalf("fail to get nodeID, error: %v", err)
+		logger.Fatalf("Unable to obtain node ID: %v", err)
 	}
 
 	// Server is insecure for now because credentials are nil

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -118,7 +118,8 @@ func main() {
 		logger.Fatalf("fail to create kubernetes client, error: %v", err)
 	}
 	// we need to obtain node ID first before proceeding with the initialization
-	nodeID, err := obtainNodeIDWithRetries(k8SClient, featureConf, logger)
+	nodeID, err := annotations.ObtainNodeIDWithRetries(k8SClient, featureConf, *nodeName, *nodeIDAnnotation,
+		logger, annotations.NumberOfRetries, annotations.DelayBetweenRetries)
 	if err != nil {
 		logger.Fatalf("Unable to obtain node ID: %v", err)
 	}
@@ -209,22 +210,6 @@ func main() {
 	}
 
 	logger.Info("Got SIGTERM signal")
-}
-
-func obtainNodeIDWithRetries(client k8sClient.Client, featureConf featureconfig.FeatureChecker,
-	logger *logrus.Logger) (nodeID string, err error) {
-	// try to obtain node ID
-	for i := 0; i < numberOfRetries; i++ {
-		logger.Info("Obtaining node ID...")
-		if nodeID, err = annotations.GetNodeIDByName(client, *nodeName, *nodeIDAnnotation, "", featureConf); err == nil {
-			logger.Infof("Node ID is %s", nodeID)
-			return nodeID, nil
-		}
-		logger.Warningf("Unable to get node ID due to %v, sleep and retry...", err)
-		time.Sleep(delayBeforeRetry * time.Second)
-	}
-	// return empty node ID and error
-	return "", fmt.Errorf("number of retries %d exceeded", numberOfRetries)
 }
 
 func waitForVolumeManagerReadiness(c *node.CSINodeService, logger *logrus.Logger) {

--- a/devkit/start_ide.sh
+++ b/devkit/start_ide.sh
@@ -16,7 +16,7 @@ if [[ ! -x $START_SCRIPT ]]; then
     exit 1
 fi
 
-$START_SCRIPT #&>/dev/null &
+$START_SCRIPT &>/dev/null &
 
 # sleep for a while to give a process a chance to start
 # if something is wrong, process will start and exit but we want it to start and work

--- a/pkg/base/linuxutils/partitionhelper/partitionhelper_test.go
+++ b/pkg/base/linuxutils/partitionhelper/partitionhelper_test.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	testLogger      = logrus.New()
-	testPartitioner = NewWrapPartitionImpl(mocks.NewMockExecutor(mocks.DiskCommands), testLogger)
+	testPartitioner = NewWrapPartitionImplWithParameters(mocks.NewMockExecutor(mocks.DiskCommands), testLogger, 1, 1)
 	testPartNum     = "1"
 	testCSILabel    = "CSI"
 	testPartUUID    = "64be631b-62a5-11e9-a756-00505680d67f"

--- a/pkg/mocks/provisioners/mock_parititoner.go
+++ b/pkg/mocks/provisioners/mock_parititoner.go
@@ -44,8 +44,8 @@ func (m *MockPartitionOps) ReleasePartition(p utilwrappers.Partition) error {
 }
 
 // SearchPartName is a mock implementation
-func (m *MockPartitionOps) SearchPartName(device, partUUID string) string {
+func (m *MockPartitionOps) SearchPartName(device, partUUID string) (string, error) {
 	args := m.Mock.Called(device, partUUID)
 
-	return args.String(0)
+	return args.String(0), args.Error(1)
 }

--- a/pkg/node/provisioners/drive_provisioner.go
+++ b/pkg/node/provisioners/drive_provisioner.go
@@ -156,10 +156,10 @@ func (d *DriveProvisioner) ReleaseVolume(vol *api.Volume, drive *api.Drive) erro
 		}
 	)
 
-	part.Name = d.partOps.SearchPartName(device, part.PartUUID)
-	if part.Name == "" {
+	part.Name, err = d.partOps.SearchPartName(device, part.PartUUID)
+	if err != nil {
 		return d.wipeDevice(device,
-			fmt.Errorf("unable to find partition name for volume %s", vol.Id), ll)
+			fmt.Errorf("unable to find partition name for volume %s: %w", vol.Id, err), ll)
 	}
 
 	// wipe FS on partition
@@ -224,10 +224,10 @@ func (d *DriveProvisioner) GetVolumePath(vol *api.Volume) (string, error) {
 	}
 	volumeUUID, _ = util.GetVolumeUUID(volumeUUID)
 
-	partNum := d.partOps.SearchPartName(device, volumeUUID)
-	if partNum == "" {
+	partNum, err := d.partOps.SearchPartName(device, volumeUUID)
+	if err != nil {
 		// on device disconnect or node reboot device name might change and we need to re-sync drive info
-		return "", fmt.Errorf("unable to find part name for device %s by uuid %s", device, volumeUUID)
+		return "", fmt.Errorf("unable to find part name for device %s by uuid %s: %w", device, volumeUUID, err)
 	}
 	return device + partNum, nil
 }

--- a/pkg/node/provisioners/drive_provisioner_test.go
+++ b/pkg/node/provisioners/drive_provisioner_test.go
@@ -259,7 +259,7 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 
 	// SearchPartName returns empty string and GetBlockDevices return error
 	mockPH.On("SearchPartName", deviceFile, testVolume2.Id).
-		Return("").Once()
+		Return("", errTest).Once()
 	mockLsblk.On("GetBlockDevices", deviceFile).
 		Return(nil, errTest)
 
@@ -270,7 +270,7 @@ func TestDriveProvisioner_ReleaseVolume_Fail(t *testing.T) {
 	// next scenarios rely on SearchPartName passes
 	var partName = "p1n1"
 	mockPH.On("SearchPartName", deviceFile, testVolume2.Id).
-		Return(partName)
+		Return(partName, nil)
 
 	// WipeFS failed
 	mockFS.On("WipeFS", deviceFile+partName).Return(errTest).Once()
@@ -349,7 +349,7 @@ func TestDriveProvisioner_GetVolumePath_Fail(t *testing.T) {
 	mockLsblk.On("SearchDrivePath", mock.Anything).
 		Return(deviceFile, nil).Once()
 	mockPH.On("SearchPartName", deviceFile, testVolume2.Id).
-		Return("").Once()
+		Return("", errTest).Once()
 
 	fullPath, err = dp.GetVolumePath(&testVolume2)
 	assert.Error(t, err)

--- a/tests/app/nginx.yaml
+++ b/tests/app/nginx.yaml
@@ -4,7 +4,7 @@ metadata:
   name: web
 spec:
   serviceName: "nginx"
-  replicas: 4
+  replicas: 3
   podManagementPolicy: Parallel
   selector:
     matchLabels:

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+if [ $# -gt 1 ]; then
+    echo "deploy.sh <number of devices>"
+fi
+
+# TODO check for REGISTRY env var
+export REGISTRY=asdrepo.isus.emc.com:9042
+
+NUMBER_OF_DEVICES=3
+if [ $# -eq 1 ]; then
+    NUMBER_OF_DEVICES=$1
+fi
+echo "Number of loopback devices per node:" $NUMBER_OF_DEVICES
+
+
+# build binaries
+make DRIVE_MANAGER_TYPE=loopbackmgr build
+if [ $? -ne 0 ]; then
+    echo "Failed to build binaries"
+    exit 1
+fi
+
+# build final images
+make DRIVE_MANAGER_TYPE=loopbackmgr images
+if [ $? -ne 0 ]; then
+    echo "Failed to build final images"
+    exit 1
+fi
+
+# pull sidecar images
+make kind-pull-sidecar-images
+if [ $? -ne 0 ]; then
+    echo "Failed to build final images"
+    exit 1
+fi
+
+# load to kind cluster
+make kind-tag-images
+if [ $? -ne 0 ]; then
+    echo "Failed to tag images"
+    exit 1
+fi
+
+make kind-load-images KIND=`which kind`
+if [ $? -ne 0 ]; then
+    echo "Failed to load images"
+    exit 1
+fi
+
+export OPERATOR_VERSION=`cd ../csi-baremetal-operator && make version`
+make load-operator-image KIND=`which kind`
+if [ $? -ne 0 ]; then
+    echo "Failed to load operator image"
+    exit 1
+fi
+
+export CSI_VERSION=`make version`
+export CSI_OPERATOR_VERSION=$OPERATOR_VERSION
+export SHORT_CI_TIMEOUT=20m
+export CHARTS_DIR=../csi-baremetal-operator/charts
+
+#CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v test/e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -ginkgo.failFast -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR}


### PR DESCRIPTION
## Purpose
### Resolves #825

First part sync executed immediately after partition creation might fail with error:
```
Jan 11 10:26:32.728 [ERRO] [Executor] [blockdev --rereadpt -v /dev/sdd] [602.84µs] [602840] stdout: , stderr: blockdev: ioctl error on BLKRRPART: Device or resource busy
```
## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
CI [passed](https://github.com/dell/csi-baremetal/actions/runs/2378830276)