### PR TITLE
[ISSUE-863] send MissingDriveReplacementInitiated normal event on DR for OFFLINE disk

### DIFF
--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -172,6 +172,11 @@ var (
 		severity:    WarningType,
 		symptomCode: NoneSymptomCode,
 	}
+	MissingDriveReplacementInitiated = &EventDescription{
+		reason:      "MissingDriveReplacementInitiated",
+		severity:    NormalType,
+		symptomCode: DriveStatusChangedSymptomCode,
+	}
 
 	VolumeGroupScanInvolved = &EventDescription{
 		reason:      "VolumeGroupScanInvolved",

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1176,6 +1176,7 @@ func (m *VolumeManager) createEventForDriveHealthOverridden(
 	m.sendEventForDrive(drive, event,
 		msgTemplate, overriddenHealth, realHealth)
 }
+
 // createEventForMissingDriveReplacementInitiated creates MissingDriveReplacementInitiated with Normal severity
 func (m *VolumeManager) createEventForMissingDriveReplacementInitiated(drive *drivecrd.Drive) {
 	msgTemplate := "Drive replacement process for missing disk initiated."


### PR DESCRIPTION
## Purpose
### Resolves #863

New event `MissingDriveReplacementInitiated ` was added to cleanup `DriveStatusChanged` issue when disk replacement initiated.

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
- Simulate "missing" disk
```
$ kubectl get cm loopback-config -o yaml
apiVersion: v1
data:
  config.yaml: |-
    defaultDrivePerNodeCount: 3
    defaultDriveSize: 101Mi
    nodes:
    - nodeID: kind-worker2
      drives:
        driveCount: 3
        - serialNumber: LOOPBACK3134674231
          removed: true
kind: ConfigMap
...
$ kubectl get drives 13953b36-a83f-4695-9f1e-4c714fc570c7 -o custom-columns=Id:metadata.name,Size:spec.Size,Type:spec.Type,SN:spec.SerialNumber,Health:spec.Health,Usage:spec.Usage,Status:spec.Status,Node:spec.NodeId
Id                                     Size        Type   SN                   Health   Usage      Status    Node
13953b36-a83f-4695-9f1e-4c714fc570c7   105906176   HDD    LOOPBACK3134674231   GOOD     IN_USE   OFFLINE   9787095b-1ef4-4bea-948f-53c370c70fcc
```
- Check events with `SymptomID=CSI-03`
```
$ kubectl get events -l SymptomID=CSI-03
LAST SEEN   TYPE    REASON               OBJECT                                       MESSAGE
9m38s       Error   DriveStatusOffline   drive/13953b36-a83f-4695-9f1e-4c714fc570c7   Drive status is: OFFLINE, previous status: ONLINE. Drive Details: SN='LOOPBACK3134674231', Model='Test Loopback', Type='HDD', Size='105906176', NodeName='kind-worker2'
```
- Start disk replacement procedure
```
$ kubectl annotate drive 13953b36-a83f-4695-9f1e-4c714fc570c7 health=bad
drive.csi-baremetal.dell.com/13953b36-a83f-4695-9f1e-4c714fc570c7 annotated

$ kubectl get drives 13953b36-a83f-4695-9f1e-4c714fc570c7 -o custom-columns=Id:metadata.name,Size:spec.Size,Type:spec.Type,SN:spec.SerialNumber,Health:spec.Health,Usage:spec.Usage,Status:spec.Status,Node:spec.NodeId
Id                                     Size        Type   SN                   Health   Usage      Status    Node
13953b36-a83f-4695-9f1e-4c714fc570c7   105906176   HDD    LOOPBACK3134674231   BAD      RELEASED   OFFLINE   9787095b-1ef4-4bea-948f-53c370c70fcc

$ kubectl get events -l SymptomID=CSI-01
LAST SEEN   TYPE      REASON                 OBJECT                                       MESSAGE
80s         Error     DriveHealthFailure     drive/13953b36-a83f-4695-9f1e-4c714fc570c7   Drive health is: BAD, previous state: GOOD. Drive Details: SN='LOOPBACK3134674231', Model='Test Loopback', Type='HDD', Size='105906176', NodeName='kind-worker2'
80s         Warning   DriveReadyForRemoval   drive/13953b36-a83f-4695-9f1e-4c714fc570c7   Drive is ready for documented removal procedure. Drive Details: SN='LOOPBACK3134674231', Model='Test Loopback', Type='HDD', Size='105906176'
```
- Check events with `SymptomID=CSI-03` again
```
$ kubectl get events -l SymptomID=CSI-03
LAST SEEN   TYPE     REASON                             OBJECT                                       MESSAGE
13m         Error    DriveStatusOffline                 drive/13953b36-a83f-4695-9f1e-4c714fc570c7   Drive status is: OFFLINE, previous status: ONLINE. Drive Details: SN='LOOPBACK3134674231', Model='Test Loopback', Type='HDD', Size='105906176', NodeName='kind-worker2'
49s         Normal   MissingDriveReplacementInitiated   drive/13953b36-a83f-4695-9f1e-4c714fc570c7   Drive replacement process for missing disk initiated. Drive Details: SN='LOOPBACK3134674231', Model='Test Loopback', Type='HDD', Size='105906176', NodeName='kind-worker2'
```