### PR TITLE
[ISSUE-395] CSI must handle deletion of volumes CRs which are in FAILED state

### DIFF
--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -295,11 +295,8 @@ func (m *VolumeManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			volume.Spec.CSIStatus = apiV1.Removing
 			ll.Debug("Change volume status from Created to Removing")
 		case apiV1.Removing:
-		// Failed drive shouldn't be cleaned up - might cause DU
-		case apiV1.Failed:
-			// remove finalizer only
-			return m.removeFinalizer(ctx, volume)
-		case apiV1.Removed:
+		// Failed drive shouldn't be cleaned up - to avoid data loss
+		case apiV1.Removed, apiV1.Failed:
 			// we need to update annotation on related drive CRD
 			// todo can we do polling instead?
 			ll.Infof("Volume %s is removed. Updating related", volume.Name)

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -2043,3 +2043,14 @@ func TestVolumeManager_reactivateVG(t *testing.T) {
 		assert.Equal(t, eventing.VolumeGroupReactivateFailed, recorderMock.Calls[1].Event)
 	})
 }
+
+func TestVolumeManager_failedToRemoveFinalizer(t *testing.T) {
+	kubeClient, err := k8s.GetFakeKubeClient(testNs, testLogger)
+	assert.Nil(t, err)
+	vm := NewVolumeManager(nil, nil, testLogger, kubeClient, kubeClient, new(mocks.NoOpRecorder), nodeID, nodeName)
+	volumeCR := volCR.DeepCopy()
+	volumeCR.ObjectMeta.Finalizers = append(volumeCR.ObjectMeta.Finalizers, volumeFinalizer)
+	// not found error
+	_, err = vm.removeFinalizer(context.TODO(), volumeCR)
+	assert.NotNil(t, err)
+}

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -450,6 +450,39 @@ func TestReconcile_SuccessDeleteVolume(t *testing.T) {
 	assert.Equal(t, res, ctrl.Result{})
 }
 
+func TestReconcile_DeleteFailedVolume(t *testing.T) {
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: testNs, Name: volCR.Name}}
+	kubeClient, err := k8s.GetFakeKubeClient(testNs, testLogger)
+	assert.Nil(t, err)
+	vm := NewVolumeManager(nil, nil, testLogger, kubeClient, kubeClient, new(mocks.NoOpRecorder), nodeID, nodeName)
+	newVolumeCR := volCR.DeepCopy()
+	newVolumeCR.Spec.CSIStatus = apiV1.Failed
+	err = vm.k8sClient.CreateCR(testCtx, newVolumeCR.Name, newVolumeCR)
+
+	// add finalizer
+	res, err := vm.Reconcile(testCtx, req)
+	assert.Nil(t, err)
+	assert.Equal(t, res, ctrl.Result{})
+	// check finalizer
+	err = vm.k8sClient.ReadCR(testCtx, newVolumeCR.Name, newVolumeCR.Namespace, newVolumeCR)
+	assert.Nil(t, err)
+	assert.Contains(t, newVolumeCR.ObjectMeta.Finalizers, volumeFinalizer)
+
+	// set deletion timestamp
+	timeNow := v1.NewTime(time.Now())
+	newVolumeCR.ObjectMeta.SetDeletionTimestamp(&timeNow)
+	err = vm.k8sClient.UpdateCR(testCtx, newVolumeCR)
+	assert.Nil(t, err)
+
+	res, err = vm.Reconcile(testCtx, req)
+	assert.Nil(t, err)
+	assert.Equal(t, res, ctrl.Result{})
+
+	// check that CR is removed
+	err = vm.k8sClient.ReadCR(testCtx, newVolumeCR.Name, newVolumeCR.Namespace, newVolumeCR)
+	assert.NotNil(t, err)
+}
+
 func TestVolumeManager_handleCreatingVolumeInLVG(t *testing.T) {
 	var (
 		vm                 *VolumeManager

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -54,9 +54,9 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-export CSI_VERSION=`make version`
-export CSI_OPERATOR_VERSION=$OPERATOR_VERSION
-export SHORT_CI_TIMEOUT=20m
-export CHARTS_DIR=../csi-baremetal-operator/charts
+echo export CSI_VERSION=`make version`
+echo export CSI_OPERATOR_VERSION=$OPERATOR_VERSION
+#export SHORT_CI_TIMEOUT=20m
+echo export CSI_CHARTS_PATH=../csi-baremetal-operator/charts
 
 #CI=true CSI_VERSION=${CSI_VERSION} OPERATOR_VERSION=${OPERATOR_VERSION} go test -v test/e2e/baremetal_e2e_test.go -ginkgo.v -ginkgo.progress -ginkgo.failFast -all-tests -kubeconfig=${HOME}/.kube/config -chartsDir ${CHARTS_DIR}


### PR DESCRIPTION
## Purpose
### Resolves #395 

CSI does remove finalizer on Volume CR delete and doesn't clean any data. Manual data cleanup is recommended.

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
- Single volume in FAILED state
```
$ kubectl get volumes
NAME                                       SIZE        STORAGE CLASS   HEALTH   CSI_STATUS   LOCATION                               NODE
pvc-0b4b8d6a-d31e-4c9b-a20c-9ca00b83252c   105906176   HDD             GOOD     FAILED       c74c63b7-5968-45db-9082-47bb3dd53b74   7b2335b3-38e6-4e4a-be06-41e745d02e92
pvc-171da801-85e6-4de1-baae-dc921996b634   105906176   HDD             GOOD     CREATED      6a38617d-d2e5-4be0-b17f-bd91456892a2   71b65ed1-797e-4d78-b59a-26030c2b8355
pvc-2be19685-6b71-4f09-90c4-46487743d835   105906176   HDD             GOOD     CREATED      c941122d-b4e0-4232-82ce-713d508b494e   7b2335b3-38e6-4e4a-be06-41e745d02e92
pvc-8d5ca3f9-1723-41de-9a90-edeee925520b   105906176   HDD             GOOD     CREATED      d294672f-0b01-4978-9b21-ed297a6c9839   71b65ed1-797e-4d78-b59a-26030c2b8355
pvc-9628c7e5-361e-47c9-89b1-3de70c329430   105906176   HDD             GOOD     CREATED      3a3b2eea-b5fc-42f0-b39d-41762e993eed   90400676-89d9-410f-b1cd-f9a6ca5f3ba6
pvc-9e0acbff-e2fd-45c7-844c-84fff99e7dca   105906176   HDD             GOOD     CREATED      276be2bb-db2a-4aec-a37d-627495fa7e98   7b2335b3-38e6-4e4a-be06-41e745d02e92
pvc-aeabe94d-fa39-480d-ba4e-d357a99ec724   105906176   HDD             GOOD     CREATED      471670bc-69e3-415b-97ab-423cb58094d9   90400676-89d9-410f-b1cd-f9a6ca5f3ba6
pvc-e118cc32-85e0-48a1-8cf8-62dd58d55e45   105906176   HDD             GOOD     CREATED      b3db9afa-627b-43f9-a465-f2bfab3c5c50   90400676-89d9-410f-b1cd-f9a6ca5f3ba6
pvc-e4a3d6c8-98b6-4ad5-abe7-4318a3a1b726   105906176   HDD             GOOD     CREATED      a4749104-2a7b-4b4d-9ec5-59d392d9b3ff   71b65ed1-797e-4d78-b59a-26030c2b8355
```
- List partitions
```
$ docker exec -it kind-worker lsblk | grep part | grep loop
`-loop15p1 259:4    0   100M  0 part 
`-loop16p1 259:6    0   100M  0 part 
`-loop17p1 259:1    0   100M  0 part 
`-loop18p1 259:2    0   100M  0 part 
`-loop19p1 259:3    0   100M  0 part 
`-loop20p1 259:0    0   100M  0 part 
`-loop21p1 259:5    0   100M  0 part 
`-loop22p1 259:8    0   100M  0 part 
`-loop23p1 259:7    0   100M  0 part 
```
- Get volume path
```
$ kubectl get drive c74c63b7-5968-45db-9082-47bb3dd53b74 -o custom-columns=Path:spec.Path
Path
/dev/loop15
```
- Delete PVCs
```
$ kubectl delete pvc --all
persistentvolumeclaim "data-web-0" deleted
persistentvolumeclaim "data-web-1" deleted
persistentvolumeclaim "data-web-2" deleted
persistentvolumeclaim "logs-web-0" deleted
persistentvolumeclaim "logs-web-1" deleted
persistentvolumeclaim "logs-web-2" deleted
persistentvolumeclaim "www-web-0" deleted
persistentvolumeclaim "www-web-1" deleted
persistentvolumeclaim "www-web-2" deleted

$ kubectl get volumes
NAME                                       SIZE        STORAGE CLASS   HEALTH   CSI_STATUS   LOCATION                               NODE
pvc-0b4b8d6a-d31e-4c9b-a20c-9ca00b83252c   105906176   HDD             GOOD     FAILED       c74c63b7-5968-45db-9082-47bb3dd53b74   7b2335b3-38e6-4e4a-be06-41e745d02e92
$ kubectl get pvc
No resources found in default namespace.
```
- Delete failed volume and check that partition still present
```
$ kubectl delete volumes pvc-0b4b8d6a-d31e-4c9b-a20c-9ca00b83252c
volume.csi-baremetal.dell.com "pvc-0b4b8d6a-d31e-4c9b-a20c-9ca00b83252c" deleted
$ kubectl get volumes
No resources found in default namespace.
$ docker exec -it kind-worker lsblk | grep part | grep loop
`-loop15p1 259:4    0   100M  0 part 
```
- List available capacity
```
$ kubectl get ac
NAME                                   SIZE        STORAGE CLASS   LOCATION                               NODE
1b5be3e5-8dbd-446f-ad54-adb7cb848621   105906176   HDD             276be2bb-db2a-4aec-a37d-627495fa7e98   7b2335b3-38e6-4e4a-be06-41e745d02e92
3dcb8658-95a5-413a-bcb9-61ce511b3f3b               HDD             c74c63b7-5968-45db-9082-47bb3dd53b74   7b2335b3-38e6-4e4a-be06-41e745d02e92
75a29936-7e84-4c25-85c2-c4196b975cdc   105906176   HDD             6a38617d-d2e5-4be0-b17f-bd91456892a2   71b65ed1-797e-4d78-b59a-26030c2b8355
804ba17d-6d82-4f4d-865e-a6a799e6d0af   105906176   HDD             d294672f-0b01-4978-9b21-ed297a6c9839   71b65ed1-797e-4d78-b59a-26030c2b8355
9ef42e67-0c5c-4e9a-8e5f-e8f03a1bd752   105906176   HDD             b3db9afa-627b-43f9-a465-f2bfab3c5c50   90400676-89d9-410f-b1cd-f9a6ca5f3ba6
abf9c6f4-0c34-4422-86b6-3f4668003d93   105906176   HDD             c941122d-b4e0-4232-82ce-713d508b494e   7b2335b3-38e6-4e4a-be06-41e745d02e92
b34913d4-c5b6-46c9-83f3-eab9d33dfb38   105906176   HDD             a4749104-2a7b-4b4d-9ec5-59d392d9b3ff   71b65ed1-797e-4d78-b59a-26030c2b8355
b555cbd9-34d0-48e9-8674-63e361819358   105906176   HDD             3a3b2eea-b5fc-42f0-b39d-41762e993eed   90400676-89d9-410f-b1cd-f9a6ca5f3ba6
bd43b599-ee25-4a95-b799-cbb8f9401bb5   105906176   HDD             471670bc-69e3-415b-97ab-423cb58094d9   90400676-89d9-410f-b1cd-f9a6ca5f3ba6
```