### PR TITLE
[ISSUE-856] report non default namespace drive event

### DIFF
--- a/pkg/events/recorder/recorder.go
+++ b/pkg/events/recorder/recorder.go
@@ -70,6 +70,7 @@ func (sr *SimpleRecorder) makeEvent(ref *v1.ObjectReference, labels map[string]s
 	if namespace == "" {
 		if key := os.Getenv("NAMESPACE"); key != "" {
 			namespace = os.Getenv("NAMESPACE")
+			ref.Namespace = namespace
 		} else {
 			namespace = metav1.NamespaceDefault
 		}

--- a/pkg/events/recorder/recorder.go
+++ b/pkg/events/recorder/recorder.go
@@ -20,6 +20,7 @@ package recorder
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -67,7 +68,11 @@ func (sr *SimpleRecorder) makeEvent(ref *v1.ObjectReference, labels map[string]s
 	t := metav1.NewTime(now)
 	namespace := ref.Namespace
 	if namespace == "" {
-		namespace = metav1.NamespaceDefault
+		if key := os.Getenv("NAMESPACE"); key != "" {
+			namespace = os.Getenv("NAMESPACE")
+		} else {
+			namespace = metav1.NamespaceDefault
+		}
 	}
 	return &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/events/recorder/recorder_test.go
+++ b/pkg/events/recorder/recorder_test.go
@@ -155,7 +155,7 @@ func TestSimpleRecorder_Eventf(t *testing.T) {
 				InvolvedObject: v1.ObjectReference{
 					Kind:       "Drive",
 					Name:       "drive1-uuid",
-					Namespace:  "",
+					Namespace:  "atlantic",
 					APIVersion: "csi-baremetal.dell.com/v1",
 				},
 				FirstTimestamp: metaFixedtime,


### PR DESCRIPTION
## Purpose
### Resolves #856 

_Describe your changes_
Update the code in https://github.com/dell/csi-baremetal/blob/master/pkg/events/recorder/recorder.go function makeEvent() to generate events for drives in the same namespace where CSI is installed.


## PR checklist
- [x] Add link to the issue  
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing

1. When CSI is installed in non-default namespace, drive event reports on corresponding non-default namespace.
```
admin@logan-dirt:~> kubectl get pods -A | grep csi
atlantic          csi-baremetal-controller-6bf87d6b48-7v998               3/4     Running     0          16s
atlantic          csi-baremetal-node-2hz59                                3/4     Running     0          16s
atlantic          csi-baremetal-node-6pk8q                                3/4     Running     0          16s
atlantic          csi-baremetal-node-controller-79d68f5878-bq2tr          1/1     Running     0          16s
atlantic          csi-baremetal-node-t6r94                                3/4     Running     0          16s
atlantic          csi-baremetal-operator-68f59d584-dmrmw                  1/1     Running     0          36s
atlantic          csi-baremetal-se-patcher-9glwp                          1/1     Running     0          16s
atlantic          csi-baremetal-se-vp5cq                                  0/1     Running     0          16s
admin@logan-dirt:~>
admin@logan-dirt:~>  kubectl annotate drive 5597f431-cced-4383-bdf1-64c58938a123 health=bad  --overwrite
drive.csi-baremetal.dell.com/5597f431-cced-4383-bdf1-64c58938a123 annotated
admin@logan-dirt:~> kubectl get events -A | grep 5597f431-cced-4383-bdf1-64c58938a123
atlantic          16s         Warning   DriveHealthOverridden   drive/5597f431-cced-4383-bdf1-64c58938a123                  Drive health is overridden with: BAD, real state: GOOD. Drive Details: SN='8010A09XTAJR', Model='0x1179 Dell Express Flash CD5 7.68T SFF', Type='NVME', Size='7681000000000', Firmware='1.1.1', Slot='Slot 7 Bay 1', NodeName='murray-dirt'
atlantic          16s         Error     DriveHealthFailure      drive/5597f431-cced-4383-bdf1-64c58938a123                  Drive health is: BAD, previous state: GOOD. Drive Details: SN='8010A09XTAJR', Model='0x1179 Dell Express Flash CD5 7.68T SFF', Type='NVME', Size='7681000000000', Firmware='1.1.1', Slot='Slot 7 Bay 1', NodeName='murray-dirt'
```
2.  When CSI is installed in default namespace, drive event reports on default namespace
```
admin@logan-dirt:~> kubectl get pods -A | grep csi
default           csi-baremetal-controller-6bf87d6b48-mc9qg               4/4     Running     0          3h41m
default           csi-baremetal-node-controller-79d68f5878-sl2hq          1/1     Running     0          3h41m
default           csi-baremetal-node-dxcl6                                4/4     Running     0          3h41m
default           csi-baremetal-node-rbs4d                                4/4     Running     0          3h41m
default           csi-baremetal-node-xwcnd                                4/4     Running     0          3h41m
default           csi-baremetal-operator-68f59d584-kc4kc                  1/1     Running     0          3h42m
default           csi-baremetal-se-6pxpd                                  1/1     Running     0          3h41m
default           csi-baremetal-se-patcher-vhb25                          1/1     Running     0          3h41m
admin@logan-dirt:~>  kubectl annotate drive 5597f431-cced-4383-bdf1-64c58938a123 health=bad  --overwrite
drive.csi-baremetal.dell.com/5597f431-cced-4383-bdf1-64c58938a123 annotated
admin@logan-dirt:~> kubectl get events -A | grep 5597f431-cced-4383-bdf1-64c58938a123
default           10s         Warning   DriveHealthOverridden   drive/5597f431-cced-4383-bdf1-64c58938a123                  Drive health is overridden with: BAD, real state: GOOD. Drive Details: SN='8010A09XTAJR', Model='0x1179 Dell Express Flash CD5 7.68T SFF', Type='NVME', Size='7681000000000', Firmware='1.1.1', Slot='Slot 7 Bay 1', NodeName='murray-dirt'
default           10s         Error     DriveHealthFailure      drive/5597f431-cced-4383-bdf1-64c58938a123                  Drive health is: BAD, previous state: GOOD. Drive Details: SN='8010A09XTAJR', Model='0x1179 Dell Express Flash CD5 7.68T SFF', Type='NVME', Size='7681000000000', Firmware='1.1.1', Slot='Slot 7 Bay 1', NodeName='murray-dirt'
admin@logan-dirt:~>
```