### PR TITLE
[ISSUE-885] Fix CSINode Pod Crash When Atlantic Cluster Scale Down and then Scale Up

### DIFF
--- a/pkg/crcontrollers/node/controller.go
+++ b/pkg/crcontrollers/node/controller.go
@@ -405,6 +405,7 @@ func (bmc *Controller) reconcileForCSIBMNode(bmNode *nodecrd.Node) (ctrl.Result,
 			bmc.cleanNodeFromCache(bmNode.Name, k8sNodeName)
 		} else {
 			bmc.disableForNode(k8sNode.Name)
+			bmc.cache.remove(bmNode.Name, k8sNodeName)
 			if err := bmc.removeLabelsAndAnnotation(k8sNode); err != nil {
 				ll.Errorf("Unable to remove annotations or labels from node %s: %v", k8sNode.Name, err)
 				bmc.enableForNode(k8sNode.Name)

--- a/pkg/crcontrollers/node/controller.go
+++ b/pkg/crcontrollers/node/controller.go
@@ -405,7 +405,7 @@ func (bmc *Controller) reconcileForCSIBMNode(bmNode *nodecrd.Node) (ctrl.Result,
 			bmc.cleanNodeFromCache(bmNode.Name, k8sNodeName)
 		} else {
 			bmc.disableForNode(k8sNode.Name)
-			bmc.cache.remove(bmNode.Name, k8sNodeName)
+			bmc.cache.remove(k8sNodeName, bmNode.Name)
 			if err := bmc.removeLabelsAndAnnotation(k8sNode); err != nil {
 				ll.Errorf("Unable to remove annotations or labels from node %s: %v", k8sNode.Name, err)
 				bmc.enableForNode(k8sNode.Name)


### PR DESCRIPTION
Signed-off-by: Shi, Crane <crane.shi@emc.com>

## Purpose
### Resolves #885 
Ensure to clean nodes cache when csi-node CR deleted

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
