### PR TITLE
[ISSUE-889] Fix a set of CSI Devkit issues

### DIFF
--- a/devkit/Dockerfile
+++ b/devkit/Dockerfile
@@ -19,6 +19,7 @@ ARG           arg_kubectl_ver
 ARG           arg_helm_ver
 ARG           arg_protobuf_ver
 ARG           arg_protoc_gen_go_ver
+ARG           arg_python_ver
 
 ENV           GOPATH="/usr/share/go"
 ENV           GOROOT="/usr/local/go"
@@ -48,7 +49,9 @@ RUN           zypper --no-gpg-checks --non-interactive refresh \
               MozillaFirefox \
               libasound2 \
               libgbm1 \
-              libxshmfence1
+              libxshmfence1 \
+              python3-devel-${arg_python_ver} \
+              bash-completion
 # install go
 RUN           wget https://go.dev/dl/go${arg_go_ver}.linux-amd64.tar.gz \
 &&            tar -C /usr/local -xzf go${arg_go_ver}.linux-amd64.tar.gz \
@@ -75,6 +78,8 @@ RUN           curl -LO https://get.helm.sh/helm-v${arg_helm_ver}-linux-amd64.tar
 &&            mv linux-amd64/helm /usr/local/bin/helm \
 &&            rm helm-v${arg_helm_ver}-linux-amd64.tar.gz \
 &&            rm -rf linux-amd64
+
+RUN           ln --symbolic /usr/bin/python3 /usr/bin/python
 
 # copy kind from builder
 COPY          --from=builder /kind/kind /usr/local/bin

--- a/devkit/Dockerfile
+++ b/devkit/Dockerfile
@@ -79,8 +79,6 @@ RUN           curl -LO https://get.helm.sh/helm-v${arg_helm_ver}-linux-amd64.tar
 &&            rm helm-v${arg_helm_ver}-linux-amd64.tar.gz \
 &&            rm -rf linux-amd64
 
-RUN           ln --symbolic /usr/bin/python3 /usr/bin/python
-
 # copy kind from builder
 COPY          --from=builder /kind/kind /usr/local/bin
 RUN           chmod +x /usr/local/bin/kind

--- a/devkit/Makefile
+++ b/devkit/Makefile
@@ -33,7 +33,7 @@ PROTOC_GEN_GO_VER ?= v1.3.2
 KUBECTL_VERSION ?= 1.23.4
 HELM_VERSION ?= 3.8.1
 KIND_BUILDER ?= golang:1.16
-
+PYTHON_VERSION ?= 3.6.15
 
 #
 # docker arguments
@@ -49,6 +49,7 @@ DOCKER_BUILD_ARGS = --tag ${IMAGE_REPO_TAG} \
               --build-arg arg_kubectl_ver=${KUBECTL_VERSION} \
 	      --build-arg arg_helm_ver=${HELM_VERSION} \
 	      --build-arg KIND_BUILDER=${KIND_BUILDER} \
+		  --build-arg arg_python_ver=${PYTHON_VERSION} \
               ${PWD}
 
 ifdef CACHE_IMAGE

--- a/devkit/devkit-entrypoint.sh
+++ b/devkit/devkit-entrypoint.sh
@@ -204,6 +204,10 @@ function setup_bashrc() {
     fi
 
     chmod a+x $USER_HOME_DIR/.bashrc
+    
+    echo "export PATH=$PATH" >> $USER_HOME_DIR/.bashrc
+    echo "source /etc/bash_completion.d/git.sh" >> $USER_HOME_DIR/.bashrc
+    kubectl completion bash >/etc/bash_completion.d/kubectl 
 
     return $?
 }


### PR DESCRIPTION
Signed-off-by: Dutova <Ann.Dutova@Dell.com>

## Purpose
### Resolves #889

Add `python`, `git` and `kubectl` autocomplete, set `PATH`
Command `su user_name` not set Path env, if add flag `-m` needed to add `Home/User`.  In all cases need to do something with env variables. ENV from last git package image(0.0.0-1.5c171bb):  
```
USER_NAME=ann
USER=ann
DEVKIT_SOFTWARE_HOST_DIR_PATH=/opt
STDOUT=true
DEVKIT_GOLAND_SHARED_BOOL=true
GOENV=/usr/share/go/.cache/go/env
GOPATH=/usr/share/go
HOME=/home/ann
GOROOT=/usr/local/go
SHELL=/bin/bash
PATH=/usr/local/bin:/bin:/usr/bin
ENV_ROOTPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
GOCACHE=/usr/share/go/.cache/go-build
PROTOPATH=/usr/local/proto
```
ENV_ROOTPATH - came from `/etc/login.defs` configuration files, which consist all default variables. When we don't set `Path`, it reads from this file. If you put `Path` in `.bashrc`,  it will read `env` from there:
Final result: 
```
USER_NAME=ann
USER=ann
DEVKIT_SOFTWARE_HOST_DIR_PATH=/opt
STDOUT=true
DEVKIT_GOLAND_SHARED_BOOL=true
GOENV=/usr/share/go/.cache/go/env
GOPATH=/usr/share/go
HOME=/home/ann
GOROOT=/usr/local/go
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/go/bin:/usr/local/go/bin:/usr/local/proto/bin
GOCACHE=/usr/share/go/.cache/go-build
PROTOPATH=/usr/local/proto
``` 
We have next error without python:  
![err-python-interpreter](https://user-images.githubusercontent.com/100381613/176902779-1606eddb-4a7c-42bb-8486-ab4e35e943ec.png)
After adding python, you need to set the path to python env in the idea settings.
![add_env](https://user-images.githubusercontent.com/100381613/176905021-0ed593f5-2011-48c1-ab6d-5fa80329932d.png)


## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
test run shows all changes.
