### PR TITLE
[ISSUE-885] Clean cache for deleted k8sNode if mapped bmNode also deleted

### DIFF
--- a/pkg/crcontrollers/node/controller.go
+++ b/pkg/crcontrollers/node/controller.go
@@ -267,7 +267,7 @@ func (bmc *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	return ctrl.Result{}, nil
 }
 
-// Clean deleted k8sNode from cache if mapped bmNode exists in cache and actually has also been deleted
+// Clean deleted k8sNode from cache if its cache entry exists and mapped bmNode has also been deleted
 func (bmc *Controller) cleanDeletedK8sNodeFromCacheIfNeeded(k8sNodeName string) {
 	ll := bmc.log.WithFields(logrus.Fields{
 		"method": "cleanDeletedK8sNodeFromCacheIfNeeded",


### PR DESCRIPTION
Signed-off-by: Shi, Crane <crane.shi@emc.com>

## Purpose
### Resolves #885

Clean deleted k8sNode from cache if its cache entry exists and mapped bmNode has also been deleted

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Has Tested the images built from the changed code on an Atlantic Cluster and they worked well as expected. In the Atlantic scale-down-and-then-up case, the cache of csi-node-controller refreshed the cache as expected and csi node pod on the scaled k8sNode obtained the valid new Node ID and was normally initialized up as expected.
