### PR TITLE
[ISSUE-893] Handle CRs updating errors in DeleteVolume

### DIFF
--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -49,7 +49,7 @@ import (
 type VolumeOperations interface {
 	CreateVolume(ctx context.Context, v api.Volume) (*api.Volume, error)
 	DeleteVolume(ctx context.Context, volumeID string) error
-	UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string)
+	UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string) error
 	WaitStatus(ctx context.Context, volumeID string, statuses ...string) error
 	ExpandVolume(ctx context.Context, volume *volumecrd.Volume, requiredBytes int64) error
 	UpdateCRsAfterVolumeExpansion(ctx context.Context, volID string, requiredBytes int64)
@@ -391,7 +391,7 @@ func (vo *VolumeOperationsImpl) DeleteVolume(ctx context.Context, volumeID strin
 // UpdateCRsAfterVolumeDeletion should be considered as a second step in DeleteVolume,
 // remove Volume CR and if volume was in LogicalVolumeGroup SC - update corresponding AC CR
 // does not return anything because that method does not change real drive on the node
-func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string) {
+func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string) error {
 	defer vo.metrics.EvaluateDurationForMethod("UpdateCRsAfterVolumeDeletion")()
 	ll := vo.log.WithFields(logrus.Fields{
 		"method":   "UpdateCRsAfterVolumeDeletion",
@@ -408,32 +408,27 @@ func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context
 	namespace, err := vo.cache.Get(volumeID)
 	if err != nil {
 		ll.Errorf("Unable to get volume namespace: %v", err)
-		return
+		return nil
 	}
 
 	if err = vo.k8sClient.ReadCR(ctx, volumeID, namespace, &volumeCR); err != nil {
 		if !k8sError.IsNotFound(err) {
 			ll.Errorf("Unable to read volume CR %s: %v. Volume CR will not be removed", volumeID, err)
+			return nil
 		}
-		return
+		return err
 	}
-
-	if err = vo.k8sClient.DeleteCR(ctx, &volumeCR); err != nil {
-		ll.Errorf("unable to delete volume CR %s: %v", volumeID, err)
-	}
-
-	vo.cache.Delete(volumeID)
 
 	// Update AC and LVG after volume deletion
 	acCR, err := vo.crHelper.GetACByLocation(volumeCR.Spec.Location)
 	if err != nil {
 		ll.Errorf("AC not found for Volume %s by location %s: %v", volumeCR.Name, volumeCR.Spec.Location, err)
-		return
+		return err
 	}
 	driveCR, lvgCR, err := vo.crHelper.GetDriveCRAndLVGCRByVolume(&volumeCR)
 	if err != nil {
 		ll.Errorf("Unable to read Drive CR for Volume %s : %v", volumeCR.Name, err)
-		return
+		return err
 	}
 
 	if util.IsStorageClassLVG(volumeCR.Spec.StorageClass) {
@@ -462,12 +457,20 @@ func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context
 	}
 
 	if err = vo.DoAction(ctx, ll, acCR, acAction, "AC"); err != nil {
-		return
+		return err
 	}
 
 	if err = vo.DoAction(ctx, ll, lvgCR, lvgAction, "LVG"); err != nil {
-		return
+		return err
 	}
+
+	if err = vo.k8sClient.DeleteCR(ctx, &volumeCR); err != nil {
+		ll.Errorf("unable to delete volume CR %s: %v", volumeID, err)
+		return err
+	}
+
+	vo.cache.Delete(volumeID)
+	return nil
 }
 
 // DoAction do UpdateCR or DeleteCR with CR

--- a/pkg/common/volume_operations.go
+++ b/pkg/common/volume_operations.go
@@ -408,14 +408,16 @@ func (vo *VolumeOperationsImpl) UpdateCRsAfterVolumeDeletion(ctx context.Context
 	namespace, err := vo.cache.Get(volumeID)
 	if err != nil {
 		ll.Errorf("Unable to get volume namespace: %v", err)
+		// volume CR was removed, no need to return error
 		return nil
 	}
 
 	if err = vo.k8sClient.ReadCR(ctx, volumeID, namespace, &volumeCR); err != nil {
-		if !k8sError.IsNotFound(err) {
-			ll.Errorf("Unable to read volume CR %s: %v. Volume CR will not be removed", volumeID, err)
+		if k8sError.IsNotFound(err) {
+			// volume CR was removed, no need to return error
 			return nil
 		}
+		ll.Errorf("Unable to read volume CR %s: %v. Volume CR will not be removed", volumeID, err)
 		return err
 	}
 

--- a/pkg/common/volume_operations_test.go
+++ b/pkg/common/volume_operations_test.go
@@ -525,86 +525,182 @@ func TestVolumeOperationsImpl_WaitStatus_Fails(t *testing.T) {
 
 func TestVolumeOperationsImpl_UpdateCRsAfterVolumeDeletion(t *testing.T) {
 	var (
-		err        error
-		svc        = setupVOOperationsTest(t)
-		volumeHDD  = testVolume1.DeepCopy()
-		volume1    = testVolumeLVG1.DeepCopy()
-		volume2    = testVolumeLVG1.DeepCopy()
-		ac         = testAC1.DeepCopy()
-		drive      = testDriveCR1.DeepCopy()
+		err     error
+		svc     = setupVOOperationsTest(t)
+		volume1 = testVolumeLVG1.DeepCopy()
+		volume2 = testVolumeLVG1.DeepCopy()
+
 		lvg        = testLVG.DeepCopy()
 		lvgUpdated = &lvgcrd.LogicalVolumeGroup{}
 		ACUpdated  = &accrd.AvailableCapacity{}
 	)
 
-	// Test Case 1: volume with HDD SC, removed
-	err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
-	assert.Nil(t, err)
-	err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
-	assert.Nil(t, err)
-	err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
-	assert.Nil(t, err)
-	svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
-	err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
-	assert.Nil(t, err)
+	t.Run("volume with HDD SC (removed)", func(t *testing.T) {
+		volumeHDD := testVolume1.DeepCopy()
+		ac := testAC1.DeepCopy()
+		drive := testDriveCR1.DeepCopy()
 
-	err = svc.k8sClient.ReadCR(testCtx, volumeHDD.Name, volumeHDD.Namespace, &volumecrd.Volume{})
-	assert.NotNil(t, err)
-	assert.True(t, k8sError.IsNotFound(err))
+		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
+		assert.Nil(t, err)
+		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
+		assert.Nil(t, err)
+		err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
+		assert.Nil(t, err)
+		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
+		assert.Nil(t, err)
 
-	// Test Case 2: volumes with HDDLVG SC
-	// create AC, LVG and Volumes with LVG
-	volume2.Name = testVolumeLVG2Name
-	volume2.Spec.Id = testVolumeLVG2Name
+		err = svc.k8sClient.ReadCR(testCtx, volumeHDD.Name, volumeHDD.Namespace, &volumecrd.Volume{})
+		assert.NotNil(t, err)
+		assert.True(t, k8sError.IsNotFound(err))
+	})
 
-	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testAC4.Name, &testAC4))
-	lvg.Spec.VolumeRefs = []string{volume1.Name, volume2.Name}
-	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, lvg.Name, lvg))
-	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testDriveCR4.Name, &testDriveCR4))
-	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume1.Name, volume1))
-	svc.cache.Set(volume1.Name, volume1.Namespace)
-	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume2.Name, volume2))
-	svc.cache.Set(volume2.Name, volume2.Namespace)
+	t.Run("create AC, LVG and Volumes with LVG", func(t *testing.T) {
+		volume2.Name = testVolumeLVG2Name
+		volume2.Spec.Id = testVolumeLVG2Name
 
-	// remove one volume from two
-	err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volume1.Name)
-	assert.Nil(t, err)
+		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testAC4.Name, &testAC4))
+		lvg.Spec.VolumeRefs = []string{volume1.Name, volume2.Name}
+		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, lvg.Name, lvg))
+		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testDriveCR4.Name, &testDriveCR4))
+		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume1.Name, volume1))
+		svc.cache.Set(volume1.Name, volume1.Namespace)
+		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume2.Name, volume2))
+		svc.cache.Set(volume2.Name, volume2.Namespace)
 
-	// check that Volume was removed
-	err = svc.k8sClient.ReadCR(testCtx, volume1.Name, volume1.Namespace, &volumecrd.Volume{})
-	assert.NotNil(t, err)
-	assert.True(t, k8sError.IsNotFound(err))
+		// remove one volume from two
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volume1.Name)
+		assert.Nil(t, err)
 
-	// check that decreased LVG VolumeRefs
-	err = svc.k8sClient.ReadCR(testCtx, testLVGName, "", lvgUpdated)
-	assert.Nil(t, err)
-	assert.Equal(t, len(lvgUpdated.Spec.VolumeRefs), 1)
-	// check that AC size was increased
-	err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
-	assert.Nil(t, err)
-	assert.Equal(t, ACUpdated.Spec.Size, testAC4.Spec.Size+volume1.Spec.Size)
+		// check that Volume was removed
+		err = svc.k8sClient.ReadCR(testCtx, volume1.Name, volume1.Namespace, &volumecrd.Volume{})
+		assert.NotNil(t, err)
+		assert.True(t, k8sError.IsNotFound(err))
 
-	// remove last volume from two
-	err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volume2.Name)
-	assert.Nil(t, err)
+		// check that decreased LVG VolumeRefs
+		err = svc.k8sClient.ReadCR(testCtx, testLVGName, "", lvgUpdated)
+		assert.Nil(t, err)
+		assert.Equal(t, len(lvgUpdated.Spec.VolumeRefs), 1)
+		// check that AC size was increased
+		err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
+		assert.Nil(t, err)
+		assert.Equal(t, ACUpdated.Spec.Size, testAC4.Spec.Size+volume1.Spec.Size)
 
-	// check that Volume was removed
-	err = svc.k8sClient.ReadCR(testCtx, volume2.Name, volume2.Namespace, &volumecrd.Volume{})
-	assert.NotNil(t, err)
-	assert.True(t, k8sError.IsNotFound(err))
+		// remove last volume from two
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volume2.Name)
+		assert.Nil(t, err)
 
-	// check that LVG was removed
-	err = svc.k8sClient.ReadCR(testCtx, lvg.Name, "", &lvgcrd.LogicalVolumeGroup{})
-	assert.NotNil(t, err)
-	assert.True(t, k8sError.IsNotFound(err))
+		// check that Volume was removed
+		err = svc.k8sClient.ReadCR(testCtx, volume2.Name, volume2.Namespace, &volumecrd.Volume{})
+		assert.NotNil(t, err)
+		assert.True(t, k8sError.IsNotFound(err))
 
-	// check that AC size was increased
-	err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
-	assert.Nil(t, err)
-	assert.Equal(t, testAC4.Spec.Size+volume1.Spec.Size+volume2.Spec.Size, ACUpdated.Spec.Size)
-	// check that AC convert from LVG to Drive
-	assert.Equal(t, ACUpdated.Spec.Location, testDriveCR4.Name)
-	assert.Equal(t, ACUpdated.Spec.StorageClass, util.ConvertDriveTypeToStorageClass(testDriveCR4.Spec.Type))
+		// check that LVG was removed
+		err = svc.k8sClient.ReadCR(testCtx, lvg.Name, "", &lvgcrd.LogicalVolumeGroup{})
+		assert.NotNil(t, err)
+		assert.True(t, k8sError.IsNotFound(err))
+
+		// check that AC size was increased
+		err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
+		assert.Nil(t, err)
+		assert.Equal(t, testAC4.Spec.Size+volume1.Spec.Size+volume2.Spec.Size, ACUpdated.Spec.Size)
+		// check that AC convert from LVG to Drive
+		assert.Equal(t, ACUpdated.Spec.Location, testDriveCR4.Name)
+		assert.Equal(t, ACUpdated.Spec.StorageClass, util.ConvertDriveTypeToStorageClass(testDriveCR4.Spec.Type))
+	})
+
+	t.Run("volume not in cache", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, "some-name")
+		assert.Nil(t, err)
+	})
+
+	t.Run("volume not found", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+
+		svc.cache.Set("some-name", "some-ns")
+
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, "some-name")
+		assert.Nil(t, err)
+	})
+
+	t.Run("volume get error", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+
+		svc.cache.Set("some-name", "some-ns")
+
+		err = svc.UpdateCRsAfterVolumeDeletion(k8s.GetFailCtx, "some-name")
+		assert.NotNil(t, err)
+	})
+
+	t.Run("ac not found", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+		volumeHDD := testVolume1.DeepCopy()
+
+		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
+		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
+		assert.Nil(t, err)
+
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("drive not found", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+		volumeHDD := testVolume1.DeepCopy()
+		ac := testAC1.DeepCopy()
+
+		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
+		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
+		assert.Nil(t, err)
+
+		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
+		assert.Nil(t, err)
+
+		err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("ac update failed", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+		volumeHDD := testVolume1.DeepCopy()
+		ac := testAC1.DeepCopy()
+		drive := testDriveCR1.DeepCopy()
+
+		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
+		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
+		assert.Nil(t, err)
+
+		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
+		assert.Nil(t, err)
+
+		err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
+		assert.Nil(t, err)
+
+		err = svc.UpdateCRsAfterVolumeDeletion(k8s.UpdateFailCtx, volumeHDD.Name)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("volume deletion failed", func(t *testing.T) {
+		svc = setupVOOperationsTest(t)
+		volumeHDD := testVolume1.DeepCopy()
+		ac := testAC1.DeepCopy()
+		drive := testDriveCR1.DeepCopy()
+
+		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
+		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
+		assert.Nil(t, err)
+
+		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
+		assert.Nil(t, err)
+
+		err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
+		assert.Nil(t, err)
+
+		err = svc.UpdateCRsAfterVolumeDeletion(k8s.DeleteFailCtx, volumeHDD.Name)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestVolumeOperationsImpl_ExpandVolume_DifferentStatuses(t *testing.T) {

--- a/pkg/common/volume_operations_test.go
+++ b/pkg/common/volume_operations_test.go
@@ -525,182 +525,86 @@ func TestVolumeOperationsImpl_WaitStatus_Fails(t *testing.T) {
 
 func TestVolumeOperationsImpl_UpdateCRsAfterVolumeDeletion(t *testing.T) {
 	var (
-		err     error
-		svc     = setupVOOperationsTest(t)
-		volume1 = testVolumeLVG1.DeepCopy()
-		volume2 = testVolumeLVG1.DeepCopy()
-
+		err        error
+		svc        = setupVOOperationsTest(t)
+		volumeHDD  = testVolume1.DeepCopy()
+		volume1    = testVolumeLVG1.DeepCopy()
+		volume2    = testVolumeLVG1.DeepCopy()
+		ac         = testAC1.DeepCopy()
+		drive      = testDriveCR1.DeepCopy()
 		lvg        = testLVG.DeepCopy()
 		lvgUpdated = &lvgcrd.LogicalVolumeGroup{}
 		ACUpdated  = &accrd.AvailableCapacity{}
 	)
 
-	t.Run("volume with HDD SC (removed)", func(t *testing.T) {
-		volumeHDD := testVolume1.DeepCopy()
-		ac := testAC1.DeepCopy()
-		drive := testDriveCR1.DeepCopy()
+	// Test Case 1: volume with HDD SC, removed
+	err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
+	assert.Nil(t, err)
+	err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
+	assert.Nil(t, err)
+	err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
+	assert.Nil(t, err)
+	svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
+	err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
+	assert.Nil(t, err)
 
-		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
-		assert.Nil(t, err)
-		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
-		assert.Nil(t, err)
-		err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
-		assert.Nil(t, err)
-		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
-		//assert.Nil(t, err)
+	err = svc.k8sClient.ReadCR(testCtx, volumeHDD.Name, volumeHDD.Namespace, &volumecrd.Volume{})
+	assert.NotNil(t, err)
+	assert.True(t, k8sError.IsNotFound(err))
 
-		err = svc.k8sClient.ReadCR(testCtx, volumeHDD.Name, volumeHDD.Namespace, &volumecrd.Volume{})
-		assert.NotNil(t, err)
-		assert.True(t, k8sError.IsNotFound(err))
-	})
+	// Test Case 2: volumes with HDDLVG SC
+	// create AC, LVG and Volumes with LVG
+	volume2.Name = testVolumeLVG2Name
+	volume2.Spec.Id = testVolumeLVG2Name
 
-	t.Run("create AC, LVG and Volumes with LVG", func(t *testing.T) {
-		volume2.Name = testVolumeLVG2Name
-		volume2.Spec.Id = testVolumeLVG2Name
+	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testAC4.Name, &testAC4))
+	lvg.Spec.VolumeRefs = []string{volume1.Name, volume2.Name}
+	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, lvg.Name, lvg))
+	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testDriveCR4.Name, &testDriveCR4))
+	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume1.Name, volume1))
+	svc.cache.Set(volume1.Name, volume1.Namespace)
+	assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume2.Name, volume2))
+	svc.cache.Set(volume2.Name, volume2.Namespace)
 
-		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testAC4.Name, &testAC4))
-		lvg.Spec.VolumeRefs = []string{volume1.Name, volume2.Name}
-		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, lvg.Name, lvg))
-		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, testDriveCR4.Name, &testDriveCR4))
-		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume1.Name, volume1))
-		svc.cache.Set(volume1.Name, volume1.Namespace)
-		assert.Nil(t, svc.k8sClient.CreateCR(testCtx, volume2.Name, volume2))
-		svc.cache.Set(volume2.Name, volume2.Namespace)
+	// remove one volume from two
+	err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volume1.Name)
+	assert.Nil(t, err)
 
-		// remove one volume from two
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, volume1.Name)
-		//assert.Nil(t, err)
+	// check that Volume was removed
+	err = svc.k8sClient.ReadCR(testCtx, volume1.Name, volume1.Namespace, &volumecrd.Volume{})
+	assert.NotNil(t, err)
+	assert.True(t, k8sError.IsNotFound(err))
 
-		// check that Volume was removed
-		err = svc.k8sClient.ReadCR(testCtx, volume1.Name, volume1.Namespace, &volumecrd.Volume{})
-		assert.NotNil(t, err)
-		assert.True(t, k8sError.IsNotFound(err))
+	// check that decreased LVG VolumeRefs
+	err = svc.k8sClient.ReadCR(testCtx, testLVGName, "", lvgUpdated)
+	assert.Nil(t, err)
+	assert.Equal(t, len(lvgUpdated.Spec.VolumeRefs), 1)
+	// check that AC size was increased
+	err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
+	assert.Nil(t, err)
+	assert.Equal(t, ACUpdated.Spec.Size, testAC4.Spec.Size+volume1.Spec.Size)
 
-		// check that decreased LVG VolumeRefs
-		err = svc.k8sClient.ReadCR(testCtx, testLVGName, "", lvgUpdated)
-		assert.Nil(t, err)
-		assert.Equal(t, len(lvgUpdated.Spec.VolumeRefs), 1)
-		// check that AC size was increased
-		err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
-		assert.Nil(t, err)
-		assert.Equal(t, ACUpdated.Spec.Size, testAC4.Spec.Size+volume1.Spec.Size)
+	// remove last volume from two
+	err = svc.UpdateCRsAfterVolumeDeletion(testCtx, volume2.Name)
+	assert.Nil(t, err)
 
-		// remove last volume from two
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, volume2.Name)
-		//assert.Nil(t, err)
+	// check that Volume was removed
+	err = svc.k8sClient.ReadCR(testCtx, volume2.Name, volume2.Namespace, &volumecrd.Volume{})
+	assert.NotNil(t, err)
+	assert.True(t, k8sError.IsNotFound(err))
 
-		// check that Volume was removed
-		err = svc.k8sClient.ReadCR(testCtx, volume2.Name, volume2.Namespace, &volumecrd.Volume{})
-		assert.NotNil(t, err)
-		assert.True(t, k8sError.IsNotFound(err))
+	// check that LVG was removed
+	err = svc.k8sClient.ReadCR(testCtx, lvg.Name, "", &lvgcrd.LogicalVolumeGroup{})
+	assert.NotNil(t, err)
+	assert.True(t, k8sError.IsNotFound(err))
 
-		// check that LVG was removed
-		err = svc.k8sClient.ReadCR(testCtx, lvg.Name, "", &lvgcrd.LogicalVolumeGroup{})
-		assert.NotNil(t, err)
-		assert.True(t, k8sError.IsNotFound(err))
-
-		// check that AC size was increased
-		err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
-		assert.Nil(t, err)
-		assert.Equal(t, testAC4.Spec.Size+volume1.Spec.Size+volume2.Spec.Size, ACUpdated.Spec.Size)
-		// check that AC convert from LVG to Drive
-		assert.Equal(t, ACUpdated.Spec.Location, testDriveCR4.Name)
-		assert.Equal(t, ACUpdated.Spec.StorageClass, util.ConvertDriveTypeToStorageClass(testDriveCR4.Spec.Type))
-	})
-
-	t.Run("volume not in cache", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, "some-name")
-		//assert.Nil(t, err)
-	})
-
-	t.Run("volume not found", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-
-		svc.cache.Set("some-name", "some-ns")
-
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, "some-name")
-		//assert.Nil(t, err)
-	})
-
-	t.Run("volume get error", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-
-		svc.cache.Set("some-name", "some-ns")
-
-		svc.UpdateCRsAfterVolumeDeletion(k8s.GetFailCtx, "some-name")
-		//assert.NotNil(t, err)
-	})
-
-	t.Run("ac not found", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-		volumeHDD := testVolume1.DeepCopy()
-
-		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
-		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
-		assert.Nil(t, err)
-
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
-		//assert.NotNil(t, err)
-	})
-
-	t.Run("drive not found", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-		volumeHDD := testVolume1.DeepCopy()
-		ac := testAC1.DeepCopy()
-
-		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
-		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
-		assert.Nil(t, err)
-
-		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
-		assert.Nil(t, err)
-
-		svc.UpdateCRsAfterVolumeDeletion(testCtx, volumeHDD.Name)
-		//assert.NotNil(t, err)
-	})
-
-	t.Run("ac update failed", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-		volumeHDD := testVolume1.DeepCopy()
-		ac := testAC1.DeepCopy()
-		drive := testDriveCR1.DeepCopy()
-
-		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
-		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
-		assert.Nil(t, err)
-
-		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
-		assert.Nil(t, err)
-
-		err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
-		assert.Nil(t, err)
-
-		svc.UpdateCRsAfterVolumeDeletion(k8s.UpdateFailCtx, volumeHDD.Name)
-		//assert.NotNil(t, err)
-	})
-
-	t.Run("volume deletion failed", func(t *testing.T) {
-		svc = setupVOOperationsTest(t)
-		volumeHDD := testVolume1.DeepCopy()
-		ac := testAC1.DeepCopy()
-		drive := testDriveCR1.DeepCopy()
-
-		svc.cache.Set(volumeHDD.Name, volumeHDD.Namespace)
-		err = svc.k8sClient.CreateCR(testCtx, volumeHDD.Name, volumeHDD)
-		assert.Nil(t, err)
-
-		err = svc.k8sClient.CreateCR(testCtx, ac.Name, ac)
-		assert.Nil(t, err)
-
-		err = svc.k8sClient.CreateCR(testCtx, drive.Name, drive)
-		assert.Nil(t, err)
-
-		svc.UpdateCRsAfterVolumeDeletion(k8s.DeleteFailCtx, volumeHDD.Name)
-		//assert.NotNil(t, err)
-	})
+	// check that AC size was increased
+	err = svc.k8sClient.ReadCR(testCtx, testAC4Name, "", ACUpdated)
+	assert.Nil(t, err)
+	assert.Equal(t, testAC4.Spec.Size+volume1.Spec.Size+volume2.Spec.Size, ACUpdated.Spec.Size)
+	// check that AC convert from LVG to Drive
+	assert.Equal(t, ACUpdated.Spec.Location, testDriveCR4.Name)
+	assert.Equal(t, ACUpdated.Spec.StorageClass, util.ConvertDriveTypeToStorageClass(testDriveCR4.Spec.Type))
 }
 
 func TestVolumeOperationsImpl_ExpandVolume_DifferentStatuses(t *testing.T) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -299,7 +299,10 @@ func (c *CSIControllerService) DeleteVolume(ctx context.Context, req *csi.Delete
 		ll.Warningf("Context canceled or timed out")
 		return nil, status.Error(codes.DeadlineExceeded, "Context canceled or timed out")
 	}
-	c.svc.UpdateCRsAfterVolumeDeletion(ctxWithID, req.VolumeId)
+	if err := c.svc.UpdateCRsAfterVolumeDeletion(ctxWithID, req.VolumeId); err != nil {
+		ll.Errorf("Unable to update CRs after volume deletion: %s", err.Error())
+		return nil, status.Error(codes.DeadlineExceeded, "Unable to update CRs after volume deletion")
+	}
 	c.reqLock.Unlock()
 
 	ll.Debug("Volume was successfully deleted")
@@ -386,7 +389,7 @@ func (c *CSIControllerService) ListSnapshots(context.Context, *csi.ListSnapshots
 }
 
 // ControllerGetVolume is not implemented yet
-func (c *CSIControllerService) ControllerGetVolume(ctx context.Context, request *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+func (c *CSIControllerService) ControllerGetVolume(_ context.Context, _ *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented yet")
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -300,7 +300,7 @@ func (c *CSIControllerService) DeleteVolume(ctx context.Context, req *csi.Delete
 		return nil, status.Error(codes.DeadlineExceeded, "Context canceled or timed out")
 	}
 	if err := c.svc.UpdateCRsAfterVolumeDeletion(ctxWithID, req.VolumeId); err != nil {
-		ll.Errorf("Unable to update CRs after volume deletion: %s", err.Error())
+		ll.Errorf("Unable to update CRs after volume deletion: %s", err)
 		return nil, status.Error(codes.Internal, "Unable to update CRs after volume deletion")
 	}
 	c.reqLock.Unlock()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -301,7 +301,7 @@ func (c *CSIControllerService) DeleteVolume(ctx context.Context, req *csi.Delete
 	}
 	if err := c.svc.UpdateCRsAfterVolumeDeletion(ctxWithID, req.VolumeId); err != nil {
 		ll.Errorf("Unable to update CRs after volume deletion: %s", err.Error())
-		return nil, status.Error(codes.DeadlineExceeded, "Unable to update CRs after volume deletion")
+		return nil, status.Error(codes.Internal, "Unable to update CRs after volume deletion")
 	}
 	c.reqLock.Unlock()
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -299,11 +299,13 @@ func (c *CSIControllerService) DeleteVolume(ctx context.Context, req *csi.Delete
 		ll.Warningf("Context canceled or timed out")
 		return nil, status.Error(codes.DeadlineExceeded, "Context canceled or timed out")
 	}
-	if err := c.svc.UpdateCRsAfterVolumeDeletion(ctxWithID, req.VolumeId); err != nil {
+	err = c.svc.UpdateCRsAfterVolumeDeletion(ctxWithID, req.VolumeId)
+	c.reqLock.Unlock()
+
+	if err != nil {
 		ll.Errorf("Unable to update CRs after volume deletion: %s", err)
 		return nil, status.Error(codes.Internal, "Unable to update CRs after volume deletion")
 	}
-	c.reqLock.Unlock()
 
 	ll.Debug("Volume was successfully deleted")
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"errors"
 	"fmt"
-	"github.com/dell/csi-baremetal/api/v1/drivecrd"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +40,7 @@ import (
 	apiV1 "github.com/dell/csi-baremetal/api/v1"
 	acrcrd "github.com/dell/csi-baremetal/api/v1/acreservationcrd"
 	accrd "github.com/dell/csi-baremetal/api/v1/availablecapacitycrd"
+	"github.com/dell/csi-baremetal/api/v1/drivecrd"
 	"github.com/dell/csi-baremetal/api/v1/lvgcrd"
 	vcrd "github.com/dell/csi-baremetal/api/v1/volumecrd"
 	"github.com/dell/csi-baremetal/pkg/base/cache"

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"github.com/dell/csi-baremetal/api/v1/drivecrd"
 	"strings"
 	"testing"
 	"time"
@@ -56,7 +57,6 @@ import (
 
 var (
 	testLogger    = logrus.New()
-	testID        = "someID"
 	testNs        = "default"
 	testApp       = "app"
 	testAppLabels = map[string]string{}
@@ -69,23 +69,6 @@ var (
 	testDriveLocation2 = "drive2-sn"
 	testDriveLocation4 = "drive4-sn"
 	testNode4Name      = "preferredNode"
-
-	testVolume = vcrd.Volume{
-		TypeMeta: k8smetav1.TypeMeta{Kind: "Volume", APIVersion: apiV1.APIV1Version},
-		ObjectMeta: k8smetav1.ObjectMeta{
-			Name:              testID,
-			Namespace:         testNs,
-			CreationTimestamp: k8smetav1.Time{Time: time.Now()},
-		},
-		Spec: api.Volume{
-			Id:       testID,
-			NodeId:   "pod",
-			Size:     1000,
-			Type:     string(fs.XFS),
-			Location: "location",
-			Mode:     apiV1.ModeFS,
-		},
-	}
 
 	testAC1Name = fmt.Sprintf("%s-%s", testNode1Name, strings.ToLower(testDriveLocation1))
 	testAC1     = accrd.AvailableCapacity{
@@ -169,6 +152,20 @@ var (
 			StorageClass: apiV1.StorageClassHDDLVG,
 			Location:     testDriveLocation4,
 			NodeId:       testNode2Name,
+		},
+	}
+
+	testDrive1 = drivecrd.Drive{
+		TypeMeta: k8smetav1.TypeMeta{
+			Kind:       "Drive",
+			APIVersion: apiV1.APIV1Version,
+		},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name: testDriveLocation1,
+		},
+		Spec: api.Drive{
+			Size:   1024 * 1024 * 1024,
+			NodeId: testNode1Name,
 		},
 	}
 )
@@ -565,6 +562,15 @@ var _ = Describe("CSIControllerService DeleteVolume", func() {
 			err = controller.k8sclient.CreateCR(testCtx, volumeID, volumeCrd)
 			Expect(err).To(BeNil())
 
+			ac := testAC1.DeepCopy()
+			ac.Spec.Size = 0
+			err = controller.k8sclient.CreateCR(testCtx, testAC1Name, ac)
+			Expect(err).To(BeNil())
+
+			drive := testDrive1.DeepCopy()
+			err = controller.k8sclient.CreateCR(testCtx, testDriveLocation1, drive)
+			Expect(err).To(BeNil())
+
 			fillCache(controller, volumeCrd.Spec.Id, namespace)
 
 			go testutils.VolumeReconcileImitation(controller.k8sclient, volumeCrd.Spec.Id, namespace, apiV1.Removed)
@@ -581,44 +587,90 @@ var _ = Describe("CSIControllerService DeleteVolume", func() {
 			err := testutils.AddAC(controller.k8sclient, &testAC3) // create AC CR, expect that size of that AC will be increased
 			Expect(err).To(BeNil())
 			var (
-				capacity = int64(1024 * 101)
-				volume   = api.Volume{
-					Id:           uuid,
+				capacity   = int64(1024 * 101)
+				capacityV  = int64(1024 * 50)
+				volumeName = "test-volume"
+				lvgName    = "test-lvg"
+				driveName  = "test-drive"
+				ACName     = "test-ac"
+				volume     = api.Volume{
+					Id:           volumeName,
 					NodeId:       testNode2Name,
-					Location:     testDriveLocation4, // testAC4
-					Size:         capacity,
+					Location:     lvgName, // testAC4
+					Size:         capacityV,
 					StorageClass: apiV1.StorageClassHDDLVG,
 					CSIStatus:    apiV1.Created,
+					LocationType: apiV1.LocationTypeLVM,
 				}
 				volumeCrd = vcrd.Volume{
 					ObjectMeta: k8smetav1.ObjectMeta{
-						Name:      uuid,
+						Name:      volumeName,
 						Namespace: controller.k8sclient.Namespace,
 					},
 					Spec: volume,
 				}
 				logicalVolumeGroup = api.LogicalVolumeGroup{
-					Name:       testDriveLocation4,
+					Name:       lvgName,
 					Node:       testNode2Name,
-					Locations:  []string{testDriveLocation4},
-					VolumeRefs: []string{uuid},
+					Locations:  []string{driveName},
+					VolumeRefs: []string{volumeName},
 					Status:     apiV1.Creating,
 					Size:       capacity,
 				}
 				lvgCR = lvgcrd.LogicalVolumeGroup{
+					TypeMeta: k8smetav1.TypeMeta{
+						Kind:       "LogicalVolumeGroup",
+						APIVersion: apiV1.APIV1Version,
+					},
 					ObjectMeta: k8smetav1.ObjectMeta{
-						Name:      testDriveLocation4,
-						Namespace: controller.k8sclient.Namespace,
+						Name: lvgName,
 					},
 					Spec: logicalVolumeGroup,
 				}
+				driveCrd = drivecrd.Drive{
+					TypeMeta: k8smetav1.TypeMeta{
+						Kind:       "Drive",
+						APIVersion: apiV1.APIV1Version,
+					},
+					ObjectMeta: k8smetav1.ObjectMeta{
+						Name: driveName,
+					},
+					Spec: api.Drive{
+						Size:   capacity,
+						NodeId: testNode2Name,
+					},
+				}
+				acCrd = accrd.AvailableCapacity{
+					TypeMeta: k8smetav1.TypeMeta{
+						Kind:       "AvailableCapacity",
+						APIVersion: apiV1.APIV1Version,
+					},
+					ObjectMeta: k8smetav1.ObjectMeta{
+						Name:      ACName,
+						Namespace: controller.k8sclient.Namespace,
+					},
+					Spec: api.AvailableCapacity{
+						Size:         capacity - capacityV,
+						StorageClass: apiV1.StorageClassHDDLVG,
+						Location:     lvgName,
+						NodeId:       testNode2Name,
+					},
+				}
 			)
 			// create volume CR that should be deleted (created in BeforeEach)
-			err = controller.k8sclient.CreateCR(testCtx, uuid, &volumeCrd)
+			err = controller.k8sclient.CreateCR(testCtx, volumeName, &volumeCrd)
 			Expect(err).To(BeNil())
 
 			// create LogicalVolumeGroup CR
-			err = controller.k8sclient.CreateCR(testCtx, uuid, &lvgCR)
+			err = controller.k8sclient.CreateCR(testCtx, lvgName, &lvgCR)
+			Expect(err).To(BeNil())
+
+			// create drive CR
+			err = controller.k8sclient.CreateCR(testCtx, driveName, &driveCrd)
+			Expect(err).To(BeNil())
+
+			// create ac CR
+			err = controller.k8sclient.CreateCR(testCtx, ACName, &acCrd)
 			Expect(err).To(BeNil())
 
 			lvgCRs := &lvgcrd.LogicalVolumeGroupList{}
@@ -626,7 +678,7 @@ var _ = Describe("CSIControllerService DeleteVolume", func() {
 			Expect(err).To(BeNil())
 			fillCache(controller, volumeCrd.Spec.Id, volumeCrd.Namespace)
 			go testutils.VolumeReconcileImitation(controller.k8sclient, volumeCrd.Spec.Id, volumeCrd.Namespace, apiV1.Removed)
-			resp, err := controller.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: uuid})
+			resp, err := controller.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: volumeCrd.Spec.Id})
 			Expect(resp).To(Equal(&csi.DeleteVolumeResponse{}))
 			Expect(err).To(BeNil())
 
@@ -635,33 +687,6 @@ var _ = Describe("CSIControllerService DeleteVolume", func() {
 			err = controller.k8sclient.ReadList(testCtx, &vList)
 			Expect(err).To(BeNil())
 			Expect(len(vList.Items)).To(Equal(0))
-		})
-		It("Volume is deleted successful, LogicalVolumeGroup AC recreated", func() {
-			removeAllCrds(controller.k8sclient) // remove CRs that was created in BeforeEach()
-			fullLVGsizeVolume := testVolume
-			fullLVGsizeVolume.Spec.StorageClass = apiV1.StorageClassHDDLVG
-			fullLVGsizeVolume.Spec.CSIStatus = apiV1.Created
-
-			// create volume CR that should be deleted
-			err := controller.k8sclient.CreateCR(testCtx, testID, &fullLVGsizeVolume)
-			Expect(err).To(BeNil())
-
-			fillCache(controller, fullLVGsizeVolume.Spec.Id, fullLVGsizeVolume.Namespace)
-			go testutils.VolumeReconcileImitation(controller.k8sclient, fullLVGsizeVolume.Spec.Id, fullLVGsizeVolume.Namespace, apiV1.Removed)
-			resp, err := controller.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: testID})
-			Expect(resp).To(Equal(&csi.DeleteVolumeResponse{}))
-			Expect(err).To(BeNil())
-
-			// check that there are no any volume CR (was removed)
-			vList := vcrd.VolumeList{}
-			err = controller.k8sclient.ReadList(testCtx, &vList)
-			Expect(err).To(BeNil())
-			Expect(len(vList.Items)).To(Equal(0))
-			// check that AC size still not exist
-			acList := accrd.AvailableCapacityList{}
-			err = controller.k8sclient.ReadList(context.Background(), &acList)
-			Expect(err).To(BeNil())
-			Expect(len(acList.Items)).To(Equal(0))
 		})
 	})
 })

--- a/pkg/crcontrollers/lvg/lvgcontroller_test.go
+++ b/pkg/crcontrollers/lvg/lvgcontroller_test.go
@@ -259,7 +259,7 @@ func TestReconcile_TryToDeleteLVGWithVolume(t *testing.T) {
 
 	res, err := c.Reconcile(tCtx, req)
 	assert.Nil(t, err)
-	assert.Equal(t, res, ctrl.Result{})
+	assert.Equal(t, res, ctrl.Result{RequeueAfter: lvgDeletionRetryTimeout})
 
 	lvg := &lvgcrd.LogicalVolumeGroup{}
 	err = c.k8sClient.ReadCR(tCtx, lvgToDell.Name, "", lvg)
@@ -286,7 +286,7 @@ func TestReconcile_DeletionFailed(t *testing.T) {
 	res, err := c.Reconcile(tCtx, req)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "there are LVs in LogicalVolumeGroup")
-	assert.Equal(t, res, ctrl.Result{})
+	assert.Equal(t, res, ctrl.Result{Requeue: true})
 }
 
 func TestReconcile_FailedNoPVs(t *testing.T) {

--- a/pkg/mocks/volume_operations.go
+++ b/pkg/mocks/volume_operations.go
@@ -50,8 +50,10 @@ func (vo *VolumeOperationsMock) DeleteVolume(ctx context.Context, volumeID strin
 }
 
 // UpdateCRsAfterVolumeDeletion is the mock implementation of UpdateCRsAfterVolumeDeletion
-func (vo *VolumeOperationsMock) UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string) {
+func (vo *VolumeOperationsMock) UpdateCRsAfterVolumeDeletion(ctx context.Context, volumeID string) error {
+	args := vo.Mock.Called(ctx, volumeID)
 
+	return args.Error(0)
 }
 
 // WaitStatus is the mock implementation of WaitStatus. Simulates waiting of Volume to be reached one of provided


### PR DESCRIPTION
## Purpose
### Resolves #893 

Restore #894 

- return error on DeleteVolume after Volume, AC or LVG CRs updating failed
- remove AC and update LVG before deleting Volume (volume should be in REMOVED, so drive is clean)
- retry LVG deletion after errors

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
