### PR TITLE
[ISSUE-906] workaround for fake attach

### DIFF
--- a/docs/fake-attach.md
+++ b/docs/fake-attach.md
@@ -15,7 +15,7 @@ Thus single volume failure might prevent service to run and cause data unavailab
 ## Proposal
 
 If a volume is inaccessible when a Pod is being restarted, the BM CSI will fake the attach temporary volume in
-read-only mode.
+read-write mode.
 
 ## Rationale
 
@@ -43,9 +43,11 @@ Event FakeAttachInvolved generated when `fake-attach: yes` annotation is setting
 Event FakeAttachCleared generated when `fake-attach: yes` annotation is deleting.
 
 ### NodePublishVolume 
-CSI must check `fake-attach` annotation and mount tmpfs volume in read-only mode.
+CSI must check `fake-attach` annotation and mount tmpfs volume in read-write mode.
 
-Command to mount tmpfs volume: `mount -t tmpfs -o size=1M,ro <volumeID> <destination folder>`
+Command to mount tmpfs volume: `mount -t tmpfs -o size=1M,rw <volumeID> <destination folder>`
+
+rw option is used as workaround for issue-906 (OpenShift 4.8)
 
 ### NodeUnpublishVolume 
 tmpfs volume must be unmounted usually.

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -158,7 +158,7 @@ func (fsOp *FSOperationsImpl) UnmountWithCheck(path string) error {
 func (fsOp *FSOperationsImpl) MountFakeTmpfs(volumeID, dst string) error {
 	/*
 		CMD example:
-			mount -t tmpfs -o size=1M,ro <volumeID> <dst>
+			mount -t tmpfs -o size=1M,rw <volumeID> <dst>
 	*/
 	ll := fsOp.log.WithFields(logrus.Fields{
 		"method": "MountFakeTmpfs",

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -175,8 +175,8 @@ func (fsOp *FSOperationsImpl) MountFakeTmpfs(volumeID, dst string) error {
 			return err
 		}
 	}
-
-	return fsOp.Mount(volumeID, dst, "-t tmpfs -o size=1M,ro")
+	// rw option is used as workaround for issue-906
+	return fsOp.Mount(volumeID, dst, "-t tmpfs -o size=1M,rw")
 }
 
 // CreateFSIfNotExist checks FS and creates one if not exist

--- a/pkg/node/provisioners/utilwrappers/fs_operations_test.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations_test.go
@@ -351,7 +351,7 @@ func TestFSOperationsImpl_MountFakeTmpfs(t *testing.T) {
 		wrapFS     = &mocklu.MockWrapFS{}
 		dst        = "~/some/unusual/name"
 		src        = "/tmp"
-		bindOption = []string{"-t tmpfs -o size=1M,rw"} // for bind == false and empty mount opts
+		bindOption = []string{"-t tmpfs -o size=1M,rw"}
 		mkDirError = errors.New("MkDir error")
 		mountError = errors.New("Mount error")
 		err        error


### PR DESCRIPTION
## Purpose
### Resolves #906

Workaround for issue with Openshift 4.8
CRI-O tries to add label to path which mounted by csi. Adding labels requests read and write permissions for file.
But CSI mounts tmpfs with RO options for Fake Attach.
CRI-O can't set label for path, and fails StartContainer procedure. [Here](https://github.com/cri-o/cri-o/blob/0ba47c9b3e52eee95d898be84500c38c9fe032c9/server/container_create_linux.go#L997) or [here](https://github.com/cri-o/cri-o/blob/0ba47c9b3e52eee95d898be84500c38c9fe032c9/server/container_create.go#L145)
Looks like CRI-O tries to set [here](https://github.com/cri-o/cri-o/blob/0ba47c9b3e52eee95d898be84500c38c9fe032c9/server/container_create_linux.go#L997) but it shouldn't, because `m.SelinuxRelabel` is `false`:

```
# crictl inspect <container>
...
       "containerPath": "/usr/share/nginx/html",
        "hostPath": "/var/lib/kubelet/pods/a790c02a-23b1-46c5-80b4-37bd35e7bbc4/volumes/kubernetes.io~csi/pvc-e2355549-8b1d-42d2-a028-2794b096d916/mount",
        "propagation": "PROPAGATION_PRIVATE",
        "readonly": false,
        "selinuxRelabel": false
...
        "containerPath": "/usr/share/nginx/data",
        "hostPath": "/var/lib/kubelet/pods/a790c02a-23b1-46c5-80b4-37bd35e7bbc4/volumes/kubernetes.io~csi/pvc-52bbe763-3703-431a-9b78-962957f0abb1/mount",
        "propagation": "PROPAGATION_PRIVATE",
        "readonly": true,
        "selinuxRelabel": false
```


## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Reproduce FakeAttach on Openshift 4.8.
result: pod successful runs 
