### PR TITLE
[ISSUE-915] reset source for ubuntu 21.04 (cherry-pick to release)

### DIFF
--- a/pkg/drivemgr/loopbackmgr/Dockerfile.build
+++ b/pkg/drivemgr/loopbackmgr/Dockerfile.build
@@ -1,5 +1,7 @@
 FROM    ubuntu:21.04
 
+RUN     sed -i -re 's/archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list \
+&&      sed -i -re 's/deb|deb-src/& \[trusted=yes\]/' /etc/apt/sources.list
 # Remove bash packet to get rid of related CVEs
 RUN     apt update --no-install-recommends -y -q && apt remove --no-install-recommends -y --allow-remove-essential -q bash
 


### PR DESCRIPTION
## Purpose
### Resolves #915

Changes only for loopback manager driver
Changed file `/etc/apt/sources.list`
Replace repos `archive.ubuntu.com` and `security.ubuntu.com` to `old-releases.ubuntu.com`
Add [trusted=yes] for ignore issue like:
```
E: The repository 'http://old-releases.ubuntu.com/ubuntu hirsute InRelease' is not signed.
```

## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Build and e2e
