### PR TITLE
[ISSUE-920] Don't delete k8s node until csibmnode labeled with node.dell.com/drain=drain

### DIFF
--- a/tests/e2e/scenarios/setup.go
+++ b/tests/e2e/scenarios/setup.go
@@ -59,8 +59,7 @@ var _ = utils.SIGDescribe("CSI Volumes", func() {
 		DefineStressTestSuite(curDriver)
 		DefineDifferentSCTestSuite(curDriver)
 		DefineSchedulerTestSuite(curDriver)
-		//TODO: uncomment after solving #861
-		//DefineNodeRemovalTestSuite(curDriver)
+		DefineNodeRemovalTestSuite(curDriver)
 		DefineLabeledDeployTestSuite()
 	})
 })


### PR DESCRIPTION
Signed-off-by: Shi, Crane <crane.shi@emc.com>

## Purpose
### Resolves #920 

Wait until corresponding csibmnode labeled with node.dell.com/drain=drain and then delete k8s node to ensure the trigger of CSI CR resources deletion on the deleted k8s node.

## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
The node-removal ci test case can stably pass now
Following is the log and test report of 1 job of all successful ci jobs including this node-removal case.
The following log part shows the time point when executing node taint and deletion:
```
Aug  8 14:41:43.638: INFO: Pod pvc-tester-q6zhk with PVC baremetal-csi-pvc created.
Aug  8 14:41:43.641: INFO: Node kind-worker3 has nodeID 675db088-91e3-49f9-8d5e-3b53676d7384
Aug  8 14:41:44.087 [DEBU] [Executor] [kubectl taint node kind-worker3 node.dell.com/drain=drain:NoSchedule] [446.280231ms] [446280231] stdout: node/kind-worker3 tainted

Aug  8 14:41:54.123: INFO: csibmnode 675db088-91e3-49f9-8d5e-3b53676d7384 labeled with node.dell.com/drain=drain
Aug  8 14:41:54.229 [DEBU] [Executor] [kubectl delete node kind-worker3] [105.212207ms] [105212207] stdout: node "kind-worker3" deleted

Aug  8 14:41:54.229: INFO: Waiting for csibmnode to be deleted...
Aug  8 14:41:54.238: INFO: Node 675db088-91e3-49f9-8d5e-3b53676d7384 exist
Aug  8 14:42:24.250: INFO: Node 675db088-91e3-49f9-8d5e-3b53676d7384 exist
Aug  8 14:42:54.359 [DEBU] [Executor] [kubectl get drive] [98.579314ms] [98579314] stdout: NAME                                   SIZE        TYPE   HEALTH   SERIAL NUMBER        NODE                                   SLOT
1df44582-f09b-4d38-a3eb-ec17b842f530   105906176   HDD    GOOD     LOOPBACK1253049743   3a73ab50-7732-47a0-b710-f51fa4400aea   
67c5e0bc-7f5b-4e94-b445-94886883d7f2   105906176   HDD    GOOD     LOOPBACK1628600311   3a73ab50-7732-47a0-b710-f51fa4400aea   
cb2686d4-d966-4b4f-8569-4d5585bbbefd   105906176   HDD    GOOD     LOOPBACK2050653090   e8f69908-2b4a-4623-90fb-3df5a3dd6f2b   
e9918151-24df-4f3d-92b5-28b8729416b7   105906176   HDD    GOOD     LOOPBACK3884377441   e8f69908-2b4a-4623-90fb-3df5a3dd6f2b   
eb42cb3d-e285-487f-94e7-b91a8bd39408   105906176   HDD    GOOD     LOOPBACK2394366583   3a73ab50-7732-47a0-b710-f51fa4400aea   
f701ab0a-744c-4efe-9231-0dca93d46a04   105906176   HDD    GOOD     LOOPBACK428992777    e8f69908-2b4a-4623-90fb-3df5a3dd6f2b   

Aug  8 14:42:54.453 [DEBU] [Executor] [kubectl get ac] [94.187728ms] [94187728] stdout: NAME                                   SIZE        STORAGE CLASS   LOCATION                               NODE
0a812048-3edb-49e1-9ac9-187720944a8b   105906176   HDD             f701ab0a-744c-4efe-9231-0dca93d46a04   e8f69908-2b4a-4623-90fb-3df5a3dd6f2b
0b1c9678-4c04-4e78-8225-99b19ddab9b5   105906176   HDD             e9918151-24df-4f3d-92b5-28b8729416b7   e8f69908-2b4a-4623-90fb-3df5a3dd6f2b
5586f126-4246-44dd-b6a9-afba7b0886c4   105906176   HDD             67c5e0bc-7f5b-4e94-b445-94886883d7f2   3a73ab50-7732-47a0-b710-f51fa4400aea
58b49710-94ec-4bae-a701-783ae10480d9   105906176   HDD             eb42cb3d-e285-487f-94e7-b91a8bd39408   3a73ab50-7732-47a0-b710-f51fa4400aea
6fb9e296-70b8-4a8a-ad1e-801df9c39550   105906176   HDD             1df44582-f09b-4d38-a3eb-ec17b842f530   3a73ab50-7732-47a0-b710-f51fa4400aea
df0c7c30-2075-46f0-812f-baaed25e58a1   105906176   HDD             cb2686d4-d966-4b4f-8569-4d5585bbbefd   e8f69908-2b4a-4623-90fb-3df5a3dd6f2b
```
You can find the successful deletion of csibmnode 675db088-91e3-49f9-8d5e-3b53676d7384 and other corresponding ACs and drives on deleted k8s node kind-worker3 at that point.

The following is test results part of the log:
```
[32m• [SLOW TEST:262.812 seconds][0m
[sig-storage] CSI Volumes
[90m/usr/share/go/pkg/mod/k8s.io/kubernetes@v1.22.5/test/e2e/storage/utils/framework.go:23[0m
  [Driver: csi-baremetal]
  [90m/var/jenkins_home/workspace/csi-custom-ci/tests/e2e/scenarios/setup.go:54[0m
    Baremetal-csi node remove test
    [90m/var/jenkins_home/workspace/csi-custom-ci/tests/e2e/scenarios/node-remove.go:41[0m
      CSI node resources should be deleted after node removal
      [90m/var/jenkins_home/workspace/csi-custom-ci/tests/e2e/scenarios/node-remove.go:99[0m
[90m------------------------------[0m

JUnit report was created: /var/jenkins_home/workspace/csi-custom-ci/tests/e2e/reports/report.xml

--- PASS: Test (262.82s)
PASS
ok  	command-line-arguments	262.864s
```

The content of the JUnit report:
```
<?xml version="1.0" encoding="UTF-8"?>
  <testsuite name="CSI Suite" tests="1" failures="0" errors="0" time="262.812">
      <testcase name="[sig-storage] CSI Volumes [Driver: csi-baremetal] Baremetal-csi node remove test CSI node resources should be deleted after node removal" classname="CSI Suite" time="262.811699423"></testcase>
  </testsuite>
```