### PR TITLE
remove mount check when doing partition sync check.

### DIFF
--- a/pkg/node/provisioners/utilwrappers/partition_operations.go
+++ b/pkg/node/provisioners/utilwrappers/partition_operations.go
@@ -180,11 +180,9 @@ func (d *PartitionOperationsImpl) SearchPartName(device, partUUID string) (strin
 		// sync partition table
 		_, errStr, err := d.SyncPartitionTable(device)
 		if err != nil {
-			isMounted, _ := d.IsMounted(strings.Trim(device, "/dev"))
 			if _, ok := err.(*exec.ExitError); ok &&
-				strings.Contains(errStr, "Device or resource busy") &&
-				isMounted {
-				ll.Errorf("Unable to sync partition table for device %s: %v due to device is mounted already", device, err)
+				strings.Contains(errStr, "Device or resource busy") {
+				ll.Warningf("Unable to sync partition table for device %s: %v due to device is busy", device, err)
 			} else {
 				// log and ignore error
 				ll.Errorf("Unable to sync partition table for device %s: %v", device, err)


### PR DESCRIPTION
Signed-off-by: Libin Zhang <Libin_Z@dell.com>

## Purpose
### Resolves #928 

in previous commit,  an isMounted check is added for sync partition failure issue,  actually not only mounted device could hit this issue.  some raw block device is used but not mounted when sts pods restart, this cause failure. 

## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
1. doing sts pods restart, with fix,  pod can start running. 
