### PR TITLE
pv, volumes failed to remove after pvc was removed

### DIFF
--- a/pkg/base/linuxutils/partitionhelper/partition_helper.go
+++ b/pkg/base/linuxutils/partitionhelper/partition_helper.go
@@ -79,7 +79,7 @@ const (
 	GetPartitionUUIDCmdTmpl = sgdisk + "%s --info=%s"
 
 	// NumberOfRetriesToSyncPartTable how many times to sync fs tab
-	NumberOfRetriesToSyncPartTable = 5
+	NumberOfRetriesToSyncPartTable = 15
 	// SleepBetweenRetriesToSyncPartTable default timeout between fs tab sync attempt
 	SleepBetweenRetriesToSyncPartTable = 3 * time.Second
 )


### PR DESCRIPTION
pv, volumes failed to remove after pvc was removed when using storage class csi-baremetal-sc-nvme-raw-part in nvmeof kernel target env.

Signed-off-by: Libin Zhang <Libin_Z@dell.com>

## Purpose
### Resolves #930 
The patch enlarges the maximum retry time when we do the partition table sync.  when volumes are being removing,  nvmf 
kernel target will trigger deletion, this timeout extension could make sure when we are doing the underlying wipeout of the partition,  the partition is no longer used by any other process(mount, nvmf kernel configuration). 

## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
