### PR TITLE
pv, volumes failed to remove after pvc was removed

### DIFF
--- a/pkg/base/linuxutils/partitionhelper/partition_helper.go
+++ b/pkg/base/linuxutils/partitionhelper/partition_helper.go
@@ -79,7 +79,7 @@ const (
 	GetPartitionUUIDCmdTmpl = sgdisk + "%s --info=%s"
 
 	// NumberOfRetriesToSyncPartTable how many times to sync fs tab
-	NumberOfRetriesToSyncPartTable = 5
+	NumberOfRetriesToSyncPartTable = 15
 	// SleepBetweenRetriesToSyncPartTable default timeout between fs tab sync attempt
 	SleepBetweenRetriesToSyncPartTable = 3 * time.Second
 )


### PR DESCRIPTION
pv, volumes failed to remove after pvc was removed when using storage class csi-baremetal-sc-nvme-raw-part in nvmeof kernel target env.  fix #930 

Signed-off-by: Libin Zhang <Libin_Z@dell.com>

## Purpose
wipe out disk partition failed due to partition is still not released by kernel nvmf target.

the change here is to leave enough time for the kernel nvmf target to release the partition. 

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
