### PR TITLE
[ISSUE-938] The  e2e.yml workflow that can be triggered by anyone from the PR's comments.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,8 @@ name: e2e
 on:
   push:
     branches: [ master ]
-  issue_comment:
-    types: [ created ]
-
+  pull_request:
+    branches: [ master ]
 env:
   REGISTRY: 'ghcr.io/dell/csi-baremetal'
   go_version: '1.17.7'


### PR DESCRIPTION
… that can be triggered by anyone from the PR's comments.

## Purpose  
### Resolves #938  
Issue short description: The [dell/csi-baremetal](https://github.com/dell/csi-baremetal) repo contains the [e2e.yml](https://github.com/dell/csi-baremetal/blob/75706a20204f60e1c817dce91c06bf5b074ea198/.github/workflows/e2e.yml) workflow that can be triggered by anyone from the PR's comments.

Solution: disable e2e workflow CI trigger when creating an issue comment, enable e2e workflow when PR is created and approved.

## PR checklist  
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
see this PR.
