### PR TITLE
[ISSUE-947]downgrade base image ubuntu to 22.10, because 23.04 is not stable.

### DIFF
--- a/pkg/drivemgr/basemgr/Dockerfile.build
+++ b/pkg/drivemgr/basemgr/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM    ubuntu:22.04
+FROM    ubuntu:22.10
 
 # Remove bash packet to get rid of related CVEs
 RUN     apt update --no-install-recommends -y -q \

--- a/pkg/drivemgr/loopbackmgr/Dockerfile.build
+++ b/pkg/drivemgr/loopbackmgr/Dockerfile.build
@@ -1,7 +1,7 @@
-FROM    ubuntu:22.10
+FROM    ubuntu:21.04
 
-# RUN     sed -i -re 's/archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list \
-# &&      sed -i -re 's/deb|deb-src/& \[trusted=yes\]/' /etc/apt/sources.list
+RUN     sed -i -re 's/archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list \
+&&      sed -i -re 's/deb|deb-src/& \[trusted=yes\]/' /etc/apt/sources.list
 # Remove bash packet to get rid of related CVEs
 RUN     apt update --no-install-recommends -y -q && apt remove --no-install-recommends -y --allow-remove-essential -q bash
 

--- a/pkg/node/Dockerfile-kernel-5.4.build
+++ b/pkg/node/Dockerfile-kernel-5.4.build
@@ -1,4 +1,4 @@
-FROM    ubuntu:23.04
+FROM    ubuntu:22.04
 
 ADD     health_probe    health_probe
 

--- a/pkg/node/Dockerfile.build
+++ b/pkg/node/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM    ubuntu:23.04
+FROM    ubuntu:22.04
 
 ADD     health_probe    health_probe
 


### PR DESCRIPTION
## Purpose
to fix e2e test failure. #947 


downgrade base image version from 23.04 to 22.10.
## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
