### PR TITLE
ISSUE-957 Fix regex to match nvme drive used as system drive

### DIFF
--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -873,7 +873,7 @@ func (m *VolumeManager) discoverLVGOnSystemDrive() error {
 	var systemPVName string
 	for _, pv := range pvs {
 		// LogicalVolumeGroup could be configured on partition on the system drive, handle this case
-		matched, _ := regexp.Match(fmt.Sprintf("^%s\\d*$", driveCR.Spec.Path), []byte(pv))
+		matched, _ := regexp.Match(fmt.Sprintf("^%sp?\\d*$", driveCR.Spec.Path), []byte(pv))
 		if matched {
 			systemPVName = pv
 			break


### PR DESCRIPTION
Signed-off-by: Libin Zhang <Libin_Z@dell.com>

## Purpose
### Resolves #957 
fix regrex to match nvme drive as a system drive. 
previously the regex only can match strings like sda1/hda1..,  but nvme partition have name as nvme0n1p1. 

## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [x] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
