### PR TITLE
[ISSUE-962] Distinguish between Disk LED Failure and Disk Recovery Failure of DriveRemovalFailed Event in Drive Replacement Procedure

### DIFF
--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -402,7 +402,7 @@ func (c *Controller) locateDriveLED(ctx context.Context, log *logrus.Entry, driv
 		log.Errorf("Failed to locate LED of drive %s, LED status - %+v, err %v", drive.Spec.SerialNumber, status, err)
 		drive.Spec.Usage = apiV1.DriveUsageFailed
 		// send error level alert
-		eventMsg := fmt.Sprintf("Failed to locale LED, %s", drive.GetDriveDescription())
+		eventMsg := fmt.Sprintf("Failed to locate LED, %s", drive.GetDriveDescription())
 		c.eventRecorder.Eventf(drive, eventing.DriveLocateLEDFailed, eventMsg)
 	} else {
 		// send warning level alert (warning for attention), good level closes issue, need only send message

--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -403,7 +403,7 @@ func (c *Controller) locateDriveLED(ctx context.Context, log *logrus.Entry, driv
 		drive.Spec.Usage = apiV1.DriveUsageFailed
 		// send error level alert
 		eventMsg := fmt.Sprintf("Failed to locale LED, %s", drive.GetDriveDescription())
-		c.eventRecorder.Eventf(drive, eventing.DriveRemovalFailed, eventMsg)
+		c.eventRecorder.Eventf(drive, eventing.DriveLocateLEDFailed, eventMsg)
 	} else {
 		// send warning level alert (warning for attention), good level closes issue, need only send message
 		eventMsg := fmt.Sprintf("Drive successfully removed from CSI, and ready for physical removal, %s", drive.GetDriveDescription())

--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -86,6 +86,11 @@ var (
 		severity:    ErrorType,
 		symptomCode: DriveHealthFailureSymptomCode,
 	}
+	DriveLocateLEDFailed = &EventDescription{
+		reason:      "DriveLocateLEDFailed",
+		severity:    ErrorType,
+		symptomCode: DriveHealthFailureSymptomCode,
+	}
 	DriveRemovedByForce = &EventDescription{
 		reason:      "DriveRemovedByForce",
 		severity:    WarningType,


### PR DESCRIPTION
Signed-off-by: Shi, Crane <crane.shi@emc.com>

## Purpose
### Resolves #962 
Create New Independent Event Type DriveLocateLEDFailed for LED lighting failure during drive replacement procedure

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
We use the CSI image **1.1.0-630.190394f** built from the latest commit of this PR to do the test.
During the manual test using this CSI image, we manually trigger the drive replacement procedure and the drive locate LED failure during drive replacement procedure on an Atlantic (rke2) cluster. And then, from the restful API of listing Kahm events and issues, I've found the following DriveLocateLEDFailed event produced and sent to Kahm as expected:
```
  {
    "id": "csi-baremetal-default-d612ba8b-9a91-4257-b07a-4211537ca060.17439bcb922e26d7",
    "symptomid": "CSI-01",
    "type": "Error",
    "component": "csi-baremetal-node",
    "message": "Failed to locate LED, Drive Details: SN='WSD6YXLR', Model='ATA ST8000NM012A-2KE', Type='HDD', Size='8001000000000', Firmware='CALD', Slot='/dev/sg13-15'",
    "reason": "DriveLocateLEDFailed",
    "appname": "csi-baremetal",
    "namespace": "default",
    "createdon": "2023-02-14T06:06:26Z",
    "remedies": [
      "Refer to www.dell.com/support/objectscale disk replacement procedure document to perform disk replacement",
      "For additional information on this event, go to www.dell.com/support/objectscale and use the SymptomID to search support for the knowledge base article"
    ],
    "updatedon": "2023-02-14T06:06:24Z",
    "resourceID": "Drive/d612ba8b-9a91-4257-b07a-4211537ca060",
    "count": 1
  }
```


Automation Tests:
Custom CI using this CSI image passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-ci/1535/
Custom Acceptance on Openshift 4.12 using this CSI image passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance/655/