### PR TITLE
[ISSUE-940] To fix CVEs in obs_csi:csi-baremetal-loopbackmgr

### DIFF
--- a/pkg/drivemgr/loopbackmgr/Dockerfile.build
+++ b/pkg/drivemgr/loopbackmgr/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM    ubuntu:22.04
 
-RUN     sed -i -re 's/archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list \
-&&      sed -i -re 's/deb|deb-src/& \[trusted=yes\]/' /etc/apt/sources.list
+# RUN     sed -i -re 's/archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list \
+# &&      sed -i -re 's/deb|deb-src/& \[trusted=yes\]/' /etc/apt/sources.list
 # Remove bash packet to get rid of related CVEs
 RUN     apt update --no-install-recommends -y -q && apt remove --no-install-recommends -y --allow-remove-essential -q bash && apt upgrade --no-install-recommends -y -q 
 

--- a/pkg/drivemgr/loopbackmgr/Dockerfile.build
+++ b/pkg/drivemgr/loopbackmgr/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM    ubuntu:21.04
+FROM    ubuntu:22.04
 
 RUN     sed -i -re 's/archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list \
 &&      sed -i -re 's/deb|deb-src/& \[trusted=yes\]/' /etc/apt/sources.list


### PR DESCRIPTION
## Purpose
To fix CVEs in obs_csi:csi-baremetal-loopbackmgr,
upgrade base image to latest LTS version ubuntu:22.04 and upgrade component in it to latest.
## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [x] All comments are resolved

## Testing
https://asd-ecs-jenkins.isus.emc.com/view/Atlantic/job/csi-custom-ci/1533/
https://asd-ecs-jenkins.isus.emc.com/view/Atlantic/job/csi-custom-acceptance/634/
https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-kind-v1.19.11/8/console

all tests are passed except loopback tests.
