### PR TITLE
[ISSUE-872] volume stucked PUBLISHED

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/dell/csi-baremetal/pkg/events"
 	"github.com/dell/csi-baremetal/pkg/metrics"
 	"github.com/dell/csi-baremetal/pkg/node"
+	"github.com/dell/csi-baremetal/pkg/node/volumeactualizer"
 	"github.com/dell/csi-baremetal/pkg/node/wbt"
 )
 
@@ -212,6 +213,12 @@ func main() {
 
 	// start to updating Wbt Config
 	wbtWatcher.StartWatch(csiNodeService)
+
+	go func() {
+		logger.Info("Starting VolumeActualizer ...")
+		actualizer := volumeactualizer.NewVolumeActualizer(wrappedK8SClient, nodeID, eventRecorder, &csiNodeService.VolumeManager, logger)
+		actualizer.Start(context.Background(), 60*time.Second)
+	}()
 
 	logger.Info("Starting handle CSI calls ...")
 	if err := csiUDSServer.RunServer(); err != nil && err != grpc.ErrServerStopped {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -216,8 +216,7 @@ func main() {
 
 	go func() {
 		logger.Info("Starting VolumeActualizer ...")
-		actualizer := volumeactualizer.NewVolumeActualizer(wrappedK8SClient, nodeID, eventRecorder, &csiNodeService.VolumeManager, logger)
-		actualizer.Start(context.Background(), 60*time.Second)
+		volumeactualizer.NewVolumeActualizer(wrappedK8SClient, nodeID, eventRecorder, &csiNodeService.VolumeManager, logger).Start(context.Background(), 60*time.Second)
 	}()
 
 	logger.Info("Starting handle CSI calls ...")

--- a/pkg/base/polling/timer.go
+++ b/pkg/base/polling/timer.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package polling implements Timer
 package polling
 
 import (
@@ -5,12 +22,14 @@ import (
 	"time"
 )
 
-type timer struct {
+// Timer is for polling
+type Timer struct {
 	duration time.Duration
 }
 type handle func(context.Context)
 
-func (t *timer) Start(ctx context.Context, handle handle) {
+// Start create new timer and start polling with handle
+func (t *Timer) Start(ctx context.Context, handle handle) {
 	timer := time.NewTimer(t.duration)
 	for {
 		select {
@@ -25,7 +44,8 @@ func (t *timer) Start(ctx context.Context, handle handle) {
 	}
 }
 
-func NewTimer(dur time.Duration) *timer {
-	return &timer{
+// NewTimer construct Timer
+func NewTimer(dur time.Duration) *Timer {
+	return &Timer{
 		duration: dur}
 }

--- a/pkg/base/polling/timer.go
+++ b/pkg/base/polling/timer.go
@@ -1,0 +1,31 @@
+package polling
+
+import (
+	"context"
+	"time"
+)
+
+type timer struct {
+	duration time.Duration
+}
+type handle func(context.Context)
+
+func (t *timer) Start(ctx context.Context, handle handle) {
+	timer := time.NewTimer(t.duration)
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			handle(ctx)
+			timer.Reset(t.duration)
+		}
+
+	}
+}
+
+func NewTimer(dur time.Duration) *timer {
+	return &timer{
+		duration: dur}
+}

--- a/pkg/base/polling/timer.go
+++ b/pkg/base/polling/timer.go
@@ -40,7 +40,6 @@ func (t *Timer) Start(ctx context.Context, handle handle) {
 			handle(ctx)
 			timer.Reset(t.duration)
 		}
-
 	}
 }
 

--- a/pkg/eventing/eventing.go
+++ b/pkg/eventing/eventing.go
@@ -229,4 +229,9 @@ var (
 		severity:    WarningType,
 		symptomCode: NoneSymptomCode,
 	}
+	VolumeStatusActualized = &EventDescription{
+		reason:      "VolumeStatusActualized",
+		severity:    WarningType,
+		symptomCode: NoneSymptomCode,
+	}
 )

--- a/pkg/node/volumeactualizer/actualizer.go
+++ b/pkg/node/volumeactualizer/actualizer.go
@@ -82,9 +82,9 @@ func (a *Actualizer) handle(ctx context.Context) {
 		}
 		a.eventRecorder.Eventf(&volumes.Items[i], eventing.VolumeStatusActualized,
 			"Volume CSIStatus is unexpected. Status: %t. Real: %t. Owner pod removed: %t",
-			volumes.Items[i].Spec.CSIStatus, apiV1.Published, isRemoved)
+			volumes.Items[i].Spec.CSIStatus, volumes.Items[i].Spec.CSIStatus, apiV1.Created, isRemoved)
 
-		volumes.Items[i].Spec.CSIStatus = apiV1.Published
+		volumes.Items[i].Spec.CSIStatus = apiV1.Created
 
 		if err := a.client.Update(ctx, &volumes.Items[i]); err != nil {
 			a.log.Errorf("failed to actualize Volume %s: %s", volumes.Items[i].GetName(), err.Error())

--- a/pkg/node/volumeactualizer/actualizer.go
+++ b/pkg/node/volumeactualizer/actualizer.go
@@ -1,0 +1,113 @@
+package volumeactualizer
+
+import (
+	"context"
+	"time"
+
+	apiV1 "github.com/dell/csi-baremetal/api/v1"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/dell/csi-baremetal/api/v1/volumecrd"
+	"github.com/dell/csi-baremetal/pkg/base/polling"
+	"github.com/dell/csi-baremetal/pkg/eventing"
+	"github.com/dell/csi-baremetal/pkg/events"
+	"github.com/dell/csi-baremetal/pkg/node"
+)
+
+const ctxTimeout = 30 * time.Second
+
+type actualizer struct {
+	client client.Client
+	// kubernetes node ID
+	nodeID        string
+	eventRecorder *events.Recorder
+	vmgr          *node.VolumeManager
+	log           *logrus.Logger
+}
+
+func (a *actualizer) Handle(ctx context.Context) {
+	ctx, cancelFn := context.WithTimeout(ctx, ctxTimeout)
+	defer cancelFn()
+
+	volumes := &volumecrd.VolumeList{}
+	if err := a.client.List(ctx, volumes); err != nil {
+		a.log.Errorf("failed to get Volume List: %s", err.Error())
+		return
+	}
+
+	for i := 0; i < len(volumes.Items); i++ {
+		if volumes.Items[i].Spec.NodeId != a.nodeID {
+			// if volume belongs to another node - then just skip it
+			continue
+		}
+
+		// perform only for volumes in PUBLISHED or VOLUME_READY state
+		if volumes.Items[i].Spec.CSIStatus != apiV1.Published && volumes.Items[i].Spec.CSIStatus != apiV1.VolumeReady {
+			continue
+		}
+
+		isRemoved := a.ownerPodsAreRemoved(ctx, &volumes.Items[i])
+
+		if !isRemoved {
+			continue
+		}
+		a.eventRecorder.Eventf(&volumes.Items[i], eventing.VolumeStatusActualized,
+			"Volume CSIStatus is unexpected. Status: %t. Real: %t. Owner pod removed: %t",
+			volumes.Items[i].Spec.CSIStatus, apiV1.Published, isRemoved)
+
+		volumes.Items[i].Spec.CSIStatus = apiV1.Published
+
+		if err := a.client.Update(ctx, &volumes.Items[i]); err != nil {
+			a.log.Errorf("failed to actualize Volume %s: %s", volumes.Items[i].GetName(), err.Error())
+			continue
+		}
+		a.log.Debugf("Volume %s was successfully actualized", volumes.Items[i].GetName())
+	}
+}
+
+func (a *actualizer) ownerPodsAreRemoved(ctx context.Context, volume *volumecrd.Volume) bool {
+	ownerPods := volume.Spec.GetOwners()
+
+	pod := &corev1.Pod{}
+	for i := 0; i < len(ownerPods); i++ {
+		err := a.client.Get(ctx, client.ObjectKey{Name: ownerPods[i], Namespace: volume.Namespace}, pod)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			a.log.Errorf("failed to get pod %s in %s namespace: %s", ownerPods[i], volume.Namespace, err.Error())
+			return false
+		}
+
+		// Check if pod was deleted
+		if k8serrors.IsNotFound(err) {
+			a.log.Infof("Pod %s with Volume %s in %s ns was removed", ownerPods[i], volume.Namespace, volume.GetName())
+			continue
+		}
+
+		// In case either of owner's pods have not deleted - just return false
+		return false
+	}
+
+	return true
+}
+
+func (a *actualizer) Start(ctx context.Context, dur time.Duration) {
+	polling.NewTimer(dur).Start(ctx, a.Handle)
+}
+
+// NewVolumeActualizer creates new Volume actualizer
+// To fix volume status stucked in PUBLISHED if all pods of a volume is deleted
+// when node is offline, K8s runtime will clean up volume directory and will not call
+// CSI Unpublish interface.
+func NewVolumeActualizer(client client.Client, nodeID string, eventRecorder *events.Recorder,
+	vmgr *node.VolumeManager, log *logrus.Logger) *actualizer {
+	return &actualizer{
+		client:        client,
+		nodeID:        nodeID,
+		eventRecorder: eventRecorder,
+		vmgr:          vmgr,
+		log:           log,
+	}
+}

--- a/pkg/node/volumeactualizer/actualizer_test.go
+++ b/pkg/node/volumeactualizer/actualizer_test.go
@@ -1,0 +1,165 @@
+package volumeactualizer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	coreV1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/dell/csi-baremetal/api/generated/v1"
+	apiV1 "github.com/dell/csi-baremetal/api/v1"
+	vcrd "github.com/dell/csi-baremetal/api/v1/volumecrd"
+	"github.com/dell/csi-baremetal/pkg/base/command"
+	"github.com/dell/csi-baremetal/pkg/base/k8s"
+	"github.com/dell/csi-baremetal/pkg/base/linuxutils/fs"
+	"github.com/dell/csi-baremetal/pkg/eventing"
+	"github.com/dell/csi-baremetal/pkg/mocks"
+	mockprov "github.com/dell/csi-baremetal/pkg/mocks/provisioners"
+	"github.com/dell/csi-baremetal/pkg/node"
+	p "github.com/dell/csi-baremetal/pkg/node/provisioners"
+)
+
+var (
+	testCtx = context.Background()
+
+	volumeCR = vcrd.Volume{
+		TypeMeta: v1.TypeMeta{Kind: "Volume", APIVersion: apiV1.APIV1Version},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      testVolume,
+			Namespace: testNs,
+		},
+		Spec: api.Volume{
+			Id:           testVolume,
+			Size:         1024 * 1024 * 1024 * 150,
+			StorageClass: apiV1.StorageClassHDD,
+			Location:     testLocation,
+			CSIStatus:    apiV1.Creating,
+			NodeId:       nodeID,
+			Mode:         apiV1.ModeFS,
+			Type:         string(fs.XFS),
+		},
+	}
+
+	pod = coreV1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      testVolume,
+			Namespace: testNs,
+		},
+	}
+)
+
+const (
+	testNs   = "test-ns"
+	nodeID   = "test-node-id"
+	nodeName = "test-node-name"
+
+	testVolume   = "test-volume"
+	testLocation = "test-location"
+)
+
+func TestVolumeActualizer_OwnerPodsAreRemoved(t *testing.T) {
+
+	t.Run("owner exists", func(t *testing.T) {
+		var (
+			a   = newActualizer()
+			vol = volumeCR.DeepCopy()
+			po  = pod.DeepCopy()
+		)
+
+		vol.Spec.Owners = []string{po.GetName()}
+		err := a.client.Create(testCtx, vol)
+		assert.Nil(t, err)
+
+		err = a.client.Create(testCtx, po)
+		assert.Nil(t, err)
+
+		isRemoved := a.ownerPodsAreRemoved(testCtx, vol)
+		assert.False(t, isRemoved)
+	})
+
+	t.Run("owner removed", func(t *testing.T) {
+		var (
+			a   = newActualizer()
+			vol = volumeCR.DeepCopy()
+			po  = pod.DeepCopy()
+		)
+
+		vol.Spec.Owners = []string{po.GetName()}
+		err := a.client.Create(testCtx, vol)
+		assert.Nil(t, err)
+
+		isRemoved := a.ownerPodsAreRemoved(testCtx, vol)
+		assert.True(t, isRemoved)
+	})
+
+	t.Run("failed to get pod", func(t *testing.T) {
+		var (
+			a   = newActualizer()
+			vol = volumeCR.DeepCopy()
+			po  = pod.DeepCopy()
+		)
+
+		vol.Spec.Owners = []string{po.GetName()}
+		err := a.client.Create(testCtx, vol)
+		assert.Nil(t, err)
+
+		isRemoved := a.ownerPodsAreRemoved(k8s.GetFailCtx, vol)
+		assert.False(t, isRemoved)
+	})
+}
+
+func TestVolumeActualizer_Handle(t *testing.T) {
+
+	t.Run("change Mount status", func(t *testing.T) {
+		var (
+			a   = newActualizer()
+			vol = volumeCR.DeepCopy()
+		)
+
+		vol.Spec.CSIStatus = apiV1.Published
+		err := a.client.Create(testCtx, vol)
+		assert.Nil(t, err)
+
+		eventRecorder := new(mocks.NoOpRecorder)
+		a.eventRecorder = eventRecorder
+
+		partitionPath := "/partition/path/for/volume1"
+		prov := mockprov.MockProvisioner{}
+		a.vmgr.SetProvisioners(map[p.VolumeType]p.Provisioner{
+			p.DriveBasedVolumeType: &prov,
+		})
+		prov.On("GetVolumePath", &vol.Spec).Return(partitionPath, nil)
+
+		fs := mockprov.MockFsOpts{}
+		fs.On("IsMounted", partitionPath).Return(false, nil)
+
+		a.Handle(testCtx)
+
+		resVol := &vcrd.Volume{}
+		err = a.client.Get(testCtx, client.ObjectKey{Name: testVolume, Namespace: testNs}, resVol)
+		assert.Nil(t, err)
+
+		assert.Equal(t, 1, len(eventRecorder.Calls))
+		assert.Equal(t, eventing.VolumeStatusActualized, eventRecorder.Calls[0].Event)
+	})
+}
+
+func newActualizer() *actualizer {
+	testLogger := logrus.New()
+	testLogger.SetLevel(logrus.DebugLevel)
+
+	client := mocks.NewMockDriveMgrClient(mocks.DriveMgrRespDrives)
+	kubeClient, err := k8s.GetFakeKubeClient(testNs, testLogger)
+	if err != nil {
+		panic(err)
+	}
+
+	e := command.NewExecutor(testLogger)
+	volumeManager := node.NewVolumeManager(client, e, testLogger, kubeClient, kubeClient, new(mocks.NoOpRecorder), nodeID, nodeName)
+
+	return NewVolumeActualizer(kubeClient, nodeID, new(mocks.NoOpRecorder), volumeManager, testLogger)
+}

--- a/pkg/node/volumeactualizer/actualizer_test.go
+++ b/pkg/node/volumeactualizer/actualizer_test.go
@@ -137,7 +137,7 @@ func TestVolumeActualizer_Handle(t *testing.T) {
 		fs := mockprov.MockFsOpts{}
 		fs.On("IsMounted", partitionPath).Return(false, nil)
 
-		a.Handle(testCtx)
+		a.handle(testCtx)
 
 		resVol := &vcrd.Volume{}
 		err = a.client.Get(testCtx, client.ObjectKey{Name: testVolume, Namespace: testNs}, resVol)
@@ -148,7 +148,7 @@ func TestVolumeActualizer_Handle(t *testing.T) {
 	})
 }
 
-func newActualizer() *actualizer {
+func newActualizer() *Actualizer {
 	testLogger := logrus.New()
 	testLogger.SetLevel(logrus.DebugLevel)
 


### PR DESCRIPTION
## Purpose
Resolves https://github.com/dell/csi-baremetal/issues/872
* Add volume actualizer to validate and fix mount status
* Allow to delete VOLUME_READY and PUBLISHED volumes with no mount

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```# reboot hostname8
hostname8:~ # sudo reboot
Connection to 10.236.126.125 closed by remote host.
Connection to 10.236.126.125 closed.

# wait until NotReady
hostname1:~ # kubectl get node
NAME        STATUS     ROLES                       AGE   VERSION
hostname1   Ready      control-plane,etcd,master   27d   v1.24.7+rke2r1
hostname2   Ready      control-plane,etcd,master   27d   v1.24.7+rke2r1
hostname3   Ready      control-plane,etcd,master   27d   v1.24.7+rke2r1
hostname4   Ready      <none>                      27d   v1.24.7+rke2r1
hostname5   Ready      <none>                      27d   v1.24.7+rke2r1
hostname6   Ready      <none>                      27d   v1.24.7+rke2r1
hostname7   Ready      <none>                      27d   v1.24.7+rke2r1
hostname8   NotReady   <none>                      27d   v1.24.7+rke2r1


hostname1:~ # kubectl delete sts csi-demo-hdd
statefulset.apps "csi-demo-hdd" deleted

# check pod status until it is removed.

# first check

hostname1:~ # kubectl get po
NAME                                             READY   STATUS        RESTARTS   AGE
csi-baremetal-controller-8fff7bc59-d9h8h         4/4     Running       0          5m29s
csi-baremetal-node-6fddw                         4/4     Running       0          5m29s
csi-baremetal-node-94jhs                         4/4     Running       0          5m29s
csi-baremetal-node-controller-77c4d75f8c-ms7pm   1/1     Running       0          5m29s
csi-baremetal-node-j68nz                         4/4     Running       0          5m29s
csi-baremetal-node-txpbn                         4/4     Running       0          5m29s
csi-baremetal-node-w8whr                         4/4     Running       0          5m29s
csi-baremetal-node-wb7kz                         4/4     Running       0          5m29s
csi-baremetal-node-wtlh5                         4/4     Running       0          5m29s
csi-baremetal-node-zspnr                         4/4     Running       0          5m29s
csi-baremetal-operator-f896b6f48-6v8rx           1/1     Running       0          5m51s
csi-baremetal-se-gjqj7                           1/1     Running       0          5m29s
csi-baremetal-se-ktdfq                           1/1     Running       0          5m29s
csi-baremetal-se-patcher-45sqd                   1/1     Running       0          5m29s
csi-baremetal-se-patcher-4z4h7                   1/1     Running       0          5m29s
csi-baremetal-se-patcher-jxg2d                   1/1     Running       0          5m29s
csi-baremetal-se-sqg6w                           1/1     Running       0          5m29s
csi-demo-hdd-0                                   1/1     Terminating   0          5m12s


# removed.

hostname1:~ # kubectl get po
NAME                                             READY   STATUS    RESTARTS        AGE
csi-baremetal-controller-8fff7bc59-d9h8h         4/4     Running   0               16m
csi-baremetal-node-6fddw                         4/4     Running   0               16m
csi-baremetal-node-94jhs                         4/4     Running   0               16m
csi-baremetal-node-controller-77c4d75f8c-ss5lg   1/1     Running   0               6m21s
csi-baremetal-node-j68nz                         4/4     Running   0               16m
csi-baremetal-node-txpbn                         4/4     Running   0               16m
csi-baremetal-node-w8whr                         4/4     Running   0               16m
csi-baremetal-node-wb7kz                         4/4     Running   0               16m
csi-baremetal-node-wtlh5                         4/4     Running   0               16m
csi-baremetal-node-zspnr                         4/4     Running   4 (5m39s ago)   16m
csi-baremetal-operator-f896b6f48-6v8rx           1/1     Running   0               16m
csi-baremetal-se-gjqj7                           1/1     Running   0               16m
csi-baremetal-se-ktdfq                           1/1     Running   0               16m
csi-baremetal-se-patcher-45sqd                   1/1     Running   0               16m
csi-baremetal-se-patcher-4z4h7                   1/1     Running   0               16m
csi-baremetal-se-patcher-jxg2d                   1/1     Running   0               16m
csi-baremetal-se-sqg6w                           1/1     Running   0               16m

# check CSI Status

Spec:
  CSI Status:          CREATED
  Health:              GOOD
  Id:                  pvc-feceb1dc-83b3-41e3-96a7-1b9ea6166dfd
  Location:            9952457b-5b12-4554-acb8-f6388b53c020
  Location Type:       DRIVE
  Mode:                FS
  Node Id:             2e8b73e3-e367-4472-b56d-70cdae4cd445
  Operational Status:  OPERATIVE
  Owners:
    csi-demo-hdd-0
  Size:           8000999784448
  Storage Class:  HDD
  Type:           xfs
  Usage:          IN_USE
Events:
  Type     Reason                  Age    From                Message
  ----     ------                  ----   ----                -------
  Warning  VolumeStatusActualized  3m10s  csi-baremetal-node  Volume CSIStatus is unexpected. Status: %!t(string=PUBLISHED). Real: %!t(string=PUBLISHED). Owner pod removed: %!t(string=CREATED)%!(EXTRA bool=true)

# check volume deletion

hostname1:~ # kubectl delete pvc demo-csi-demo-hdd-0
persistentvolumeclaim "demo-csi-demo-hdd-0" deleted

hostname1:~ # kubectl get volume
No resources found in default namespace.```
