### PR TITLE
[ISSUE-1040] fix pip3 install PyYAML failed.

### DIFF
--- a/pkg/scheduler/patcher/requirements.txt
+++ b/pkg/scheduler/patcher/requirements.txt
@@ -8,7 +8,7 @@ oauthlib==3.2.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 requests-oauthlib==1.3.1
 rsa==4.8


### PR DESCRIPTION
## Purpose
### Resolves #1040 

upgrade PyYAML from 6.0 to 6.0.1.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
