### PR TITLE
[ISSUE-1045] Fake Attach Feature for Non-LVM-Block-Mode Volumes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,21 +107,21 @@ jobs:
         make install-controller-gen
         make generate-deepcopy
 
-    - name: Verify Changed files
-      uses: tj-actions/verify-changed-files@v5.5
-      id: changed_files
-      with:
-        files: |
-           api/generated/v1/*.go
-           api/v1/*/*.go
-           '.(go)$'
-           
-    - name: Display changed files
-      if: steps.changed_files.outputs.files_changed == 'true'
-      run: |
-        echo "Changed files: ${{ steps.changed_files.outputs.changed_files }}"
-        
-    - name: Perform action when files change.
-      if: steps.changed_files.outputs.files_changed == 'true'
-      run: |
-        exit 1
+#    - name: Verify Changed files
+#      uses: tj-actions/verify-changed-files@v5.5
+#      id: changed_files
+#      with:
+#        files: |
+#           api/generated/v1/*.go
+#           api/v1/*/*.go
+#           '.(go)$'
+#
+#    - name: Display changed files
+#      if: steps.changed_files.outputs.files_changed == 'true'
+#      run: |
+#        echo "Changed files: ${{ steps.changed_files.outputs.changed_files }}"
+#
+#    - name: Perform action when files change.
+#      if: steps.changed_files.outputs.files_changed == 'true'
+#      run: |
+#        exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,6 +107,8 @@ jobs:
         make install-controller-gen
         make generate-deepcopy
 
+# Temporarily comment out the forbidden 3rd-party action script from our github PR validation workflow
+# to fix our github PR validation startup failure.
 #    - name: Verify Changed files
 #      uses: tj-actions/verify-changed-files@v5.5
 #      id: changed_files

--- a/docs/fake-attach.md
+++ b/docs/fake-attach.md
@@ -37,9 +37,9 @@ When `pv.attach.kubernetes.io/ignore-if-inaccessible: yes` annotation is set CSI
 - ignore NodeStageVolume errors
 - put `fake-attach: yes` annotation on CSI Volume CR if there is stageVolume error and annotation wasn't set before, i.e. the volume turns from healthy to unhealthy
 - if there is stageVolume error on block-mode volume without `fake-device: <device path>` annotation, try to setup a fake loop device mapped to regular file, add `fake-device: <device path>` annotation to volume, and then try to mount this fake device to stagingTargetPath as normal stage volume
-- if there is stageVolume error on block-mode volume with `fake-device: <device path>` annotation, check whether <device path> is really the path of fake device of this volume first. if the check passed, also try to mount this fake device to stagingTargetPath as normal stage volume
+- if there is stageVolume error on block-mode volume with `fake-device: <device path>` annotation, check whether the device is really the path of fake device of this volume first. if the check passed, also try to mount this fake device to stagingTargetPath as normal stage volume
 - delete `fake-attach: yes` annotation on CSI Volume CR if there is no stageVolume error and annotation was set before, i.e. the volume turns from unhealthy back to healthy
-- In this scenario, for block-mode volume with `fake-device: <device path>` annotation, if <device path> is really the path of fake device of this volume, then try to clean this fake device. By the way, the removal of block-mode volume with annotations `fake-attach: yes` and `fake-device: <device path>` will also trigger the clean of fake device.
+- In this scenario, for block-mode volume with `fake-device: <device path>` annotation, if the device is really the path of fake device of this volume, then try to clean this fake device. By the way, the removal of block-mode volume with annotations `fake-attach: yes` and `fake-device: <device path>` will also trigger the clean of fake device.
 
 Event FakeAttachInvolved generated when `fake-attach: yes` annotation is setting.
 

--- a/docs/fake-attach.md
+++ b/docs/fake-attach.md
@@ -37,9 +37,9 @@ When `pv.attach.kubernetes.io/ignore-if-inaccessible: yes` annotation is set CSI
 - ignore NodeStageVolume errors
 - put `fake-attach: yes` annotation on CSI Volume CR if there is stageVolume error and annotation wasn't set before, i.e. the volume turns from healthy to unhealthy
 - if there is stageVolume error on block-mode volume without `fake-device: <device path>` annotation, try to setup a fake loop device mapped to regular file, add `fake-device: <device path>` annotation to volume, and then try to mount this fake device to stagingTargetPath as normal stage volume
-- if there is stageVolume error on block-mode volume with `fake-device: <device path>` annotation, check whether the device is really the path of fake device of this volume first. if the check passed, also try to mount this fake device to stagingTargetPath as normal stage volume
+- if there is stageVolume error on block-mode volume with `fake-device: <device path>` annotation, check whether this device is really the fake device of this volume first. if the check passed, also try to mount this fake device to stagingTargetPath as normal stage volume
 - delete `fake-attach: yes` annotation on CSI Volume CR if there is no stageVolume error and annotation was set before, i.e. the volume turns from unhealthy back to healthy
-- In this scenario, for block-mode volume with `fake-device: <device path>` annotation, if the device is really the path of fake device of this volume, then try to clean this fake device. By the way, the removal of block-mode volume with annotations `fake-attach: yes` and `fake-device: <device path>` will also trigger the clean of fake device.
+- In this scenario, for block-mode volume with `fake-device: <device path>` annotation, if this device is really the fake device of this volume, then try to clean this fake device. By the way, the removal of block-mode volume with annotations `fake-attach: yes` and `fake-device: <device path>` will also trigger the clean of fake device.
 
 Event FakeAttachInvolved generated when `fake-attach: yes` annotation is setting.
 

--- a/docs/fake-attach.md
+++ b/docs/fake-attach.md
@@ -35,22 +35,25 @@ If fake-attach volume is successfully created, CSI Volume CR will be annotated w
 ### NodeStageVolume
 When `pv.attach.kubernetes.io/ignore-if-inaccessible: yes` annotation is set CSI must:
 - ignore NodeStageVolume errors
-- put `fake-attach: yes` annotation on CSI Volume CR if error is and annotation wasn't set before
-- delete `fake-attach: yes` annotation on CSI Volume CR if error is not and annotation was set before
+- put `fake-attach: yes` annotation on CSI Volume CR if there is stageVolume error and annotation wasn't set before, i.e. the volume turns from healthy to unhealthy
+- if there is stageVolume error on block-mode volume without `fake-device: <device path>` annotation, try to setup a fake loop device mapped to regular file, add `fake-device: <device path>` annotation to volume, and then try to mount this fake device to stagingTargetPath as normal stage volume
+- if there is stageVolume error on block-mode volume with `fake-device: <device path>` annotation, check whether <device path> is really the path of fake device of this volume first. if the check passed, also try to mount this fake device to stagingTargetPath as normal stage volume
+- delete `fake-attach: yes` annotation on CSI Volume CR if there is no stageVolume error and annotation was set before, i.e. the volume turns from unhealthy back to healthy
+- In this scenario, for block-mode volume with `fake-device: <device path>` annotation, if <device path> is really the path of fake device of this volume, then try to clean this fake device. By the way, the removal of block-mode volume with annotations `fake-attach: yes` and `fake-device: <device path>` will also trigger the clean of fake device.
 
 Event FakeAttachInvolved generated when `fake-attach: yes` annotation is setting.
 
 Event FakeAttachCleared generated when `fake-attach: yes` annotation is deleting.
 
 ### NodePublishVolume 
-CSI must check `fake-attach` annotation and mount tmpfs volume in read-write mode.
+CSI must check `fake-attach` annotation and mount tmpfs volume in read-write mode for fs-mode volume
 
 Command to mount tmpfs volume: `mount -t tmpfs -o size=1M,rw <volumeID> <destination folder>`
 
 rw option is used as workaround for issue-906 (OpenShift 4.8)
 
 ### NodeUnpublishVolume 
-tmpfs volume must be unmounted usually.
+tmpfs volume must be unmounted usually for fs-mode volume.
 
 ### NodeUnstageVolume 
 Do nothing.

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -356,9 +356,9 @@ func (h *WrapFSImpl) GetFSUUID(device string) (string, error) {
 // Receives the file path and size in MB unit
 // Returns error if something went wrong
 func (h *WrapFSImpl) CreateFileWithSizeInMB(filePath string, sizeMB int) error {
-	err := h.MkFile(filePath)
+	err := h.MkDir(path.Dir(filePath))
 	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+		return fmt.Errorf("failed to create parent dir of file %s: %w", filePath, err)
 	}
 
 	cmd := fmt.Sprintf(CreateFileByDDCmdTmpl, filePath, strconv.Itoa(sizeMB))

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -75,8 +75,9 @@ const (
 	BindOption = "--bind"
 	// MountOptionsFlag flag to set mount options
 	MountOptionsFlag = "-o"
-
-	CreateFileByDDCmdTmpl      = "dd if=/dev/zero of=%s bs=1M count=%s"
+	// CreateFileByDDCmdTmpl cmd for creating file with specified size by dd command
+	CreateFileByDDCmdTmpl = "dd if=/dev/zero of=%s bs=1M count=%s"
+	// SetupLoopBackDeviceCmdTmpl cmd for loopback device setup
 	SetupLoopBackDeviceCmdTmpl = "losetup -f --show %s"
 )
 
@@ -372,7 +373,7 @@ func (h *WrapFSImpl) CreateFileWithSize(filePath, sizeStr string) error {
 // Receives the file path of the specificed src, whether a regular file or block device
 // Returns the loopback device's file path or empty string and error if something went wrong
 func (h *WrapFSImpl) CreateLoopDevice(src string) (string, error) {
-	cmd := fmt.Sprintf(fmt.Sprintf(SetupLoopBackDeviceCmdTmpl, src))
+	cmd := fmt.Sprintf(SetupLoopBackDeviceCmdTmpl, src)
 	stdout, _, err := h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(strings.TrimSpace(fmt.Sprintf(SetupLoopBackDeviceCmdTmpl, ""))))

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -391,7 +391,7 @@ func (h *WrapFSImpl) ReadLoopDevice(device string) (string, error) {
 	}
 
 	lines := strings.Split(stdout, "\n")
-	if len(lines) != 2 || len(lines[1]) == 0 {
+	if len(lines) < 2 || len(lines[1]) == 0 {
 		return "", fmt.Errorf("%s: invalid command stdout", errPrefix)
 	}
 	dataFields := strings.SplitN(lines[1], " ", 2)

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -96,7 +96,7 @@ type WrapFS interface {
 	FindMountPoint(target string) (string, error)
 	Mount(src, dst string, opts ...string) error
 	Unmount(src string) error
-	CreateFileWithSize(filePath, sizeStr string) error
+	CreateFileWithSizeInMB(filePath string, sizeMB int) error
 	CreateLoopDevice(src string) (string, error)
 }
 
@@ -344,22 +344,16 @@ func (h *WrapFSImpl) GetFSUUID(device string) (string, error) {
 	return strings.TrimSpace(stdout), err
 }
 
-// CreateFileWithSize create file with specified size by dd command
-// Receives the file path and size in string format
+// CreateFileWithSizeInMB creates file with specified size in MB unit by dd command
+// Receives the file path and size in MB unit
 // Returns error if something went wrong
-func (h *WrapFSImpl) CreateFileWithSize(filePath, sizeStr string) error {
+func (h *WrapFSImpl) CreateFileWithSizeInMB(filePath string, sizeMB int) error {
 	err := h.MkFile(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", filePath, err)
 	}
 
-	sizeBytes, err := util.StrToBytes(sizeStr)
-	if err != nil {
-		return fmt.Errorf("failed to convert %s to bytes", sizeStr)
-	}
-	sizeMB, _ := util.ToSizeUnit(sizeBytes, util.BYTE, util.MBYTE)
-
-	cmd := fmt.Sprintf(CreateFileByDDCmdTmpl, filePath, strconv.FormatInt(sizeMB, 10))
+	cmd := fmt.Sprintf(CreateFileByDDCmdTmpl, filePath, strconv.Itoa(sizeMB))
 	_, _, err = h.e.RunCmd(cmd,
 		command.UseMetrics(true),
 		command.CmdName(fmt.Sprintf(CreateFileByDDCmdTmpl, "", "")))

--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -384,7 +384,7 @@ func (h *WrapFSImpl) ReadLoopDevice(device string) (string, error) {
 		command.CmdName(strings.TrimSpace(fmt.Sprintf(ReadLoopBackDeviceMappingCmd, ""))))
 
 	if err != nil {
-		if strings.HasSuffix(stderr, noSuchDeviceErrMsgSuffix) {
+		if strings.Contains(stderr, noSuchDeviceErrMsgSuffix) {
 			return "", nil
 		}
 		return "", fmt.Errorf("%s: %w", errPrefix, err)

--- a/pkg/mocks/linuxutils/fs_helper.go
+++ b/pkg/mocks/linuxutils/fs_helper.go
@@ -111,16 +111,23 @@ func (m *MockWrapFS) Unmount(src string) error {
 	return args.Error(0)
 }
 
-// CreateFileWithSizeInMB is a mock implementations
+// CreateFileWithSizeInMB is a mock implementation
 func (m *MockWrapFS) CreateFileWithSizeInMB(filePath string, sizeMB int) error {
 	args := m.Mock.Called(filePath, sizeMB)
 
 	return args.Error(0)
 }
 
-// CreateLoopDevice is a mock implementations
+// CreateLoopDevice is a mock implementation
 func (m *MockWrapFS) CreateLoopDevice(src string) (string, error) {
 	args := m.Mock.Called(src)
 
 	return args.String(0), args.Error(1)
+}
+
+// RemoveLoopDevice is a mock implementation
+func (m *MockWrapFS) RemoveLoopDevice(device string) error {
+	args := m.Mock.Called(device)
+
+	return args.Error(0)
 }

--- a/pkg/mocks/linuxutils/fs_helper.go
+++ b/pkg/mocks/linuxutils/fs_helper.go
@@ -110,3 +110,17 @@ func (m *MockWrapFS) Unmount(src string) error {
 
 	return args.Error(0)
 }
+
+// CreateFileWithSize is a mock implementations
+func (m *MockWrapFS) CreateFileWithSize(filePath, sizeStr string) error {
+	args := m.Mock.Called(filePath, sizeStr)
+
+	return args.Error(0)
+}
+
+// CreateLoopDevice is a mock implementations
+func (m *MockWrapFS) CreateLoopDevice(src string) (string, error) {
+	args := m.Mock.Called(src)
+
+	return args.String(0), args.Error(1)
+}

--- a/pkg/mocks/linuxutils/fs_helper.go
+++ b/pkg/mocks/linuxutils/fs_helper.go
@@ -111,9 +111,9 @@ func (m *MockWrapFS) Unmount(src string) error {
 	return args.Error(0)
 }
 
-// CreateFileWithSize is a mock implementations
-func (m *MockWrapFS) CreateFileWithSize(filePath, sizeStr string) error {
-	args := m.Mock.Called(filePath, sizeStr)
+// CreateFileWithSizeInMB is a mock implementations
+func (m *MockWrapFS) CreateFileWithSizeInMB(filePath string, sizeMB int) error {
+	args := m.Mock.Called(filePath, sizeMB)
 
 	return args.Error(0)
 }

--- a/pkg/mocks/linuxutils/fs_helper.go
+++ b/pkg/mocks/linuxutils/fs_helper.go
@@ -118,6 +118,13 @@ func (m *MockWrapFS) CreateFileWithSizeInMB(filePath string, sizeMB int) error {
 	return args.Error(0)
 }
 
+// ReadLoopDevice is a mock implementation
+func (m *MockWrapFS) ReadLoopDevice(device string) (string, error) {
+	args := m.Mock.Called(device)
+
+	return args.String(0), args.Error(1)
+}
+
 // CreateLoopDevice is a mock implementation
 func (m *MockWrapFS) CreateLoopDevice(src string) (string, error) {
 	args := m.Mock.Called(src)

--- a/pkg/mocks/provisioners/fs_operations.go
+++ b/pkg/mocks/provisioners/fs_operations.go
@@ -53,3 +53,10 @@ func (m *MockFsOpts) CreateFSIfNotExist(fsType fs.FileSystem, device, uuid strin
 
 	return args.Error(0)
 }
+
+// CreateFakeDevice is a mock implementation
+func (m *MockFsOpts) CreateFakeDevice(src string) (string, error) {
+	args := m.Mock.Called(src)
+
+	return args.String(0), args.Error(1)
+}

--- a/pkg/node/common_test_data.go
+++ b/pkg/node/common_test_data.go
@@ -60,10 +60,12 @@ var (
 	testCtx    = context.Background()
 	disk1      = api.Drive{UUID: uuid.New().String(), SerialNumber: "hdd1", Size: 1024 * 1024 * 1024 * 500, NodeId: nodeID, Path: "/dev/sda"}
 	disk2      = api.Drive{UUID: uuid.New().String(), SerialNumber: "hdd2", Size: 1024 * 1024 * 1024 * 200, NodeId: nodeID, Path: "/dev/sda"}
+	disk4      = api.Drive{UUID: uuid.New().String(), SerialNumber: "hdd4", Size: 1024 * 1024 * 1024 * 500, NodeId: nodeID, Path: "/dev/sdb"}
 	// volumes
 	testV1ID = "volume-1-id"
 	testV2ID = "volume-2-id"
 	testV3ID = "volume-3-id"
+	testV4ID = "volume-4-id"
 
 	testVolume1 = api.Volume{
 		Id:           testV1ID,
@@ -81,6 +83,14 @@ var (
 		CSIStatus:    apiV1.Created,
 	}
 	testVolume3 = api.Volume{Id: testV3ID, NodeId: nodeID, Location: ""}
+	testVolume4 = api.Volume{
+		Id:           testV4ID,
+		NodeId:       nodeID,
+		Location:     disk4.UUID,
+		StorageClass: apiV1.StorageClassHDD,
+		CSIStatus:    apiV1.VolumeReady,
+		Mode:         apiV1.ModeRAWPART,
+	}
 
 	testVolumeCR1 = vcrd.Volume{
 		TypeMeta: k8smetav1.TypeMeta{Kind: "Volume", APIVersion: apiV1.APIV1Version},
@@ -108,6 +118,15 @@ var (
 			CreationTimestamp: k8smetav1.Time{Time: time.Now()},
 		},
 		Spec: testVolume3,
+	}
+	testVolumeCR4 = vcrd.Volume{
+		TypeMeta: k8smetav1.TypeMeta{Kind: "Volume", APIVersion: apiV1.APIV1Version},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name:              testVolume4.Id,
+			Namespace:         testNs,
+			CreationTimestamp: k8smetav1.Time{Time: time.Now()},
+		},
+		Spec: testVolume4,
 	}
 
 	testVolumeCap = &csi.VolumeCapability{

--- a/pkg/node/common_test_data.go
+++ b/pkg/node/common_test_data.go
@@ -71,6 +71,7 @@ var (
 		Location:     disk1.UUID,
 		StorageClass: apiV1.StorageClassHDD,
 		CSIStatus:    apiV1.VolumeReady,
+		Mode:         apiV1.ModeFS,
 	}
 	testVolume2 = api.Volume{
 		Id:           testV2ID,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -176,6 +176,11 @@ func (s *CSINodeService) processFakeAttachInNodeStageVolume(ll *logrus.Entry, vo
 		ll.Warningf("Removing fake-attach annotation for volume %s", volumeID)
 		s.VolumeManager.recorder.Eventf(volumeCR, eventing.FakeAttachCleared,
 			"Fake-attach cleared for volume with ID %s", volumeID)
+		// clean fake device in the non-fs mode
+		if volumeCR.Spec.Mode != apiV1.ModeFS {
+			s.VolumeManager.cleanFakeDevice(ll, volumeCR)
+			delete(volumeCR.Annotations, fakeDeviceVolumeAnnotation)
+		}
 	}
 	return nil
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -453,9 +453,16 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 	)
 
 	if volumeCR.Annotations[fakeAttachVolumeAnnotation] == fakeAttachVolumeKey {
-		if err := s.fsOps.MountFakeTmpfs(volumeID, dstPath); err != nil {
-			newStatus = apiV1.Failed
-			resp, errToReturn = nil, fmt.Errorf("failed to publish volume: fake attach error %s", err.Error())
+		if volumeCR.Spec.Mode == apiV1.ModeRAWPART {
+			if err := s.fsOps.MountFakeDevice(volumeID, dstPath); err != nil {
+				newStatus = apiV1.Failed
+				resp, errToReturn = nil, fmt.Errorf("failed to publish volume: fake attach error %s", err.Error())
+			}
+		} else {
+			if err := s.fsOps.MountFakeTmpfs(volumeID, dstPath); err != nil {
+				newStatus = apiV1.Failed
+				resp, errToReturn = nil, fmt.Errorf("failed to publish volume: fake attach error %s", err.Error())
+			}
 		}
 	} else {
 		_, isBlock := req.GetVolumeCapability().GetAccessType().(*csi.VolumeCapability_Block)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -452,17 +452,10 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		errToReturn error
 	)
 
-	if volumeCR.Annotations[fakeAttachVolumeAnnotation] == fakeAttachVolumeKey {
-		if volumeCR.Spec.Mode == apiV1.ModeRAWPART {
-			if err := s.fsOps.MountFakeDevice(volumeID, dstPath); err != nil {
-				newStatus = apiV1.Failed
-				resp, errToReturn = nil, fmt.Errorf("failed to publish volume: fake attach error %s", err.Error())
-			}
-		} else {
-			if err := s.fsOps.MountFakeTmpfs(volumeID, dstPath); err != nil {
-				newStatus = apiV1.Failed
-				resp, errToReturn = nil, fmt.Errorf("failed to publish volume: fake attach error %s", err.Error())
-			}
+	if volumeCR.Annotations[fakeAttachVolumeAnnotation] == fakeAttachVolumeKey && volumeCR.Spec.Mode == apiV1.ModeFS {
+		if err := s.fsOps.MountFakeTmpfs(volumeID, dstPath); err != nil {
+			newStatus = apiV1.Failed
+			resp, errToReturn = nil, fmt.Errorf("failed to publish volume: fake attach error %s", err.Error())
 		}
 	} else {
 		_, isBlock := req.GetVolumeCapability().GetAccessType().(*csi.VolumeCapability_Block)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -160,9 +160,9 @@ func (s *CSINodeService) processFakeAttachInNodeStageVolume(ll *logrus.Entry, vo
 		}
 		// mount fake device in the non-fs mode
 		if volumeCR.Spec.Mode != apiV1.ModeFS {
-			fakeDevice, err := s.VolumeManager.createFakeDeviceIfNotExist(ll, volumeCR)
+			fakeDevice, err := s.VolumeManager.createFakeDeviceIfNecessary(ll, volumeCR)
 			if err != nil {
-				ll.Errorf("failed to create fake device with error: %v", err)
+				ll.Errorf("unable to create fake device in stage volume request with error: %v", err)
 				return status.Error(codes.Internal, fmt.Sprintf("failed to create fake device in stage volume: %s", err.Error()))
 			}
 			volumeCR.Annotations[fakeDeviceVolumeAnnotation] = fakeDevice

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -59,7 +59,7 @@ const (
 	fakeAttachVolumeAnnotation = "fake-attach"
 	fakeAttachVolumeKey        = "yes"
 
-	fakeAttachVolumeBlockModeFakeDeviceAnnotation = "fake-device"
+	// fakeAttachVolumeBlockModeFakeDeviceAnnotation = "fake-device"
 
 	wbtChangedVolumeAnnotation = "wbt-changed"
 	wbtChangedVolumeKey        = "yes"

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -59,6 +59,8 @@ const (
 	fakeAttachVolumeAnnotation = "fake-attach"
 	fakeAttachVolumeKey        = "yes"
 
+	fakeAttachVolumeBlockModeFakeDeviceAnnotation = "fake-device"
+
 	wbtChangedVolumeAnnotation = "wbt-changed"
 	wbtChangedVolumeKey        = "yes"
 )

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -61,7 +61,7 @@ const (
 	fakeAttachVolumeKey        = "yes"
 
 	fakeDeviceVolumeAnnotation = "fake-device"
-	fakeDeviceFileDir          = "/hostroot/host/fakeDevices/"
+	fakeDeviceSrcFileDir       = "/hostroot/host/fakeDevices/"
 
 	wbtChangedVolumeAnnotation = "wbt-changed"
 	wbtChangedVolumeKey        = "yes"

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -61,7 +61,7 @@ const (
 	fakeAttachVolumeKey        = "yes"
 
 	fakeDeviceVolumeAnnotation = "fake-device"
-	fakeDeviceSrcFileDir       = "/hostroot/host/fakeDevices/"
+	fakeDeviceSrcFileDir       = "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/fake/"
 
 	wbtChangedVolumeAnnotation = "wbt-changed"
 	wbtChangedVolumeKey        = "yes"

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -195,12 +195,12 @@ func (fsOp *FSOperationsImpl) MountFakeDevice(volumeID, dst string) error {
 		return err
 	}
 
-	//loopDev, err := fsOp.CreateLoopDevice(imagePath)
-	//if err != nil {
-	//	ll.Error(err)
-	//	return err
-	//}
-	//ll.Infof("loopback devcie created: %s", loopDev)
+	loopDev, err := fsOp.CreateLoopDevice(imagePath)
+	if err != nil {
+		ll.Error(err)
+		return err
+	}
+	ll.Infof("loopback devcie created: %s", loopDev)
 
 	if _, err := os.Stat(dst); err != nil {
 		if !os.IsNotExist(err) {
@@ -211,7 +211,7 @@ func (fsOp *FSOperationsImpl) MountFakeDevice(volumeID, dst string) error {
 			return err
 		}
 	}
-	return fsOp.Mount(imagePath, dst, "--bind")
+	return fsOp.Mount(loopDev, dst, "--bind")
 }
 
 // CreateFSIfNotExist checks FS and creates one if not exist

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -187,7 +187,7 @@ func (fsOp *FSOperationsImpl) CreateFakeDevice(src string) (string, error) {
 		"method": "CreateFakeDevice",
 	})
 
-	err := fsOp.CreateFileWithSize(src, "1M")
+	err := fsOp.CreateFileWithSizeInMB(src, 1)
 	if err != nil {
 		ll.Error(err)
 		return "", err

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -245,6 +245,8 @@ func (fsOp *FSOperationsImpl) CreateFakeDevice(src string) (string, error) {
 		ll.Error(err)
 		return "", err
 	}
+
+	ll.Warnf("fake device %s created on regular file %s", loopDev, src)
 	return loopDev, nil
 }
 

--- a/pkg/node/provisioners/utilwrappers/fs_operations.go
+++ b/pkg/node/provisioners/utilwrappers/fs_operations.go
@@ -236,13 +236,13 @@ func (fsOp *FSOperationsImpl) CreateFakeDevice(src string) (string, error) {
 
 	err := fsOp.CreateFileWithSizeInMB(src, 1)
 	if err != nil {
-		ll.Error(err)
+		ll.Errorf("call fsOp.CreateFileWithSizeInMB with error: %v", err)
 		return "", err
 	}
 
 	loopDev, err := fsOp.CreateLoopDevice(src)
 	if err != nil {
-		ll.Error(err)
+		ll.Errorf("call fsOp.CreateLoopDevice with error: %v", err)
 		return "", err
 	}
 

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1384,14 +1384,14 @@ func (m *VolumeManager) checkWbtChangingEnable(ctx context.Context, vol *volumec
 	return true
 }
 
-func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, volumeCR *volumecrd.Volume) (string, error) {
-	fakeDevice, ok := volumeCR.Annotations[fakeDeviceVolumeAnnotation]
-	fakeDeviceFilePath := fakeDeviceFileDir + volumeCR.Name
+func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, vol *volumecrd.Volume) (string, error) {
+	fakeDevice, ok := vol.Annotations[fakeDeviceVolumeAnnotation]
+	fakeDeviceFilePath := fakeDeviceFileDir + vol.Name
 	var err error
 	if !ok {
 		fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceFilePath)
 		if err != nil {
-			return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", volumeCR.Name, err)
+			return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
 		}
 	} else {
 		if _, err = os.Stat(fakeDevice); err != nil {
@@ -1399,7 +1399,7 @@ func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, volumeCR *
 				log.Warnf("re-create non-existing device %s", fakeDevice)
 				fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceFilePath)
 				if err != nil {
-					return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", volumeCR.Name, err)
+					return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
 				}
 			} else {
 				return "", fmt.Errorf("failed to get info of device %s with error: %v", fakeDevice, err)

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -1399,15 +1398,15 @@ func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, vol *volum
 			return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
 		}
 	} else {
-		if _, err = os.Stat(fakeDevice); err != nil {
-			if os.IsNotExist(err) {
-				log.Warnf("re-create non-existing device %s", fakeDevice)
-				fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceSrcFilePath)
-				if err != nil {
-					return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
-				}
-			} else {
-				return "", fmt.Errorf("failed to get info of device %s with error: %v", fakeDevice, err)
+		blockDevices, err := m.listBlk.GetBlockDevices(fakeDevice)
+		if err != nil {
+			return "", fmt.Errorf("failed to get info of fake device %s of volume %s with error: %v", fakeDevice, vol.Name, err)
+		}
+		if len(blockDevices) == 0 {
+			log.Warnf("re-create non-existing fake device %s", fakeDevice)
+			fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceSrcFilePath)
+			if err != nil {
+				return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
 			}
 		}
 	}

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -502,7 +502,7 @@ func (m *VolumeManager) performVolumeRemoving(ctx context.Context, volume *volum
 	})
 
 	// For non-fs mode volume still in fake-attach status, we need to clean fake device
-	if volume.Annotations[fakeAttachVolumeAnnotation] == fakeAttachVolumeKey && volume.Spec.Mode == apiV1.ModeFS {
+	if volume.Annotations[fakeAttachVolumeAnnotation] == fakeAttachVolumeKey && volume.Spec.Mode != apiV1.ModeFS {
 		m.cleanFakeDevice(ll, volume)
 	}
 
@@ -1399,8 +1399,8 @@ func (m *VolumeManager) createFakeDeviceIfNecessary(log *logrus.Entry, vol *volu
 			return "", err
 		}
 	} else {
-		blockDevices, err := m.listBlk.GetBlockDevices(fakeDevice)
-		if err != nil || len(blockDevices) == 0 {
+		devices, err := m.listBlk.GetBlockDevices(fakeDevice)
+		if err != nil || len(devices) == 0 {
 			var warnMsg string
 			if err != nil {
 				warnMsg = fmt.Sprintf("failed to get info of fake device %s with error: %s.", fakeDevice, err.Error())

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1386,10 +1386,10 @@ func (m *VolumeManager) checkWbtChangingEnable(ctx context.Context, vol *volumec
 
 func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, vol *volumecrd.Volume) (string, error) {
 	fakeDevice, ok := vol.Annotations[fakeDeviceVolumeAnnotation]
-	fakeDeviceFilePath := fakeDeviceFileDir + vol.Name
+	fakeDeviceSrcFilePath := fakeDeviceSrcFileDir + vol.Name
 	var err error
 	if !ok {
-		fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceFilePath)
+		fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceSrcFilePath)
 		if err != nil {
 			return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
 		}
@@ -1397,7 +1397,7 @@ func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, vol *volum
 		if _, err = os.Stat(fakeDevice); err != nil {
 			if os.IsNotExist(err) {
 				log.Warnf("re-create non-existing device %s", fakeDevice)
-				fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceFilePath)
+				fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceSrcFilePath)
 				if err != nil {
 					return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)
 				}

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1409,7 +1409,7 @@ func (m *VolumeManager) createFakeDeviceIfNecessary(log *logrus.Entry, vol *volu
 			if backFile == "" {
 				warnMsg = fmt.Sprintf("fake device %s doesn't exist.", fakeDevice)
 			} else {
-				warnMsg = fmt.Sprintf("fake device %s maps to other source", fakeDevice)
+				warnMsg = fmt.Sprintf("fake device %s maps to other source.", fakeDevice)
 			}
 			log.Warnf("%s re-create the fake device", warnMsg)
 			fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceSrcFilePath)

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -1403,7 +1403,7 @@ func (m *VolumeManager) createFakeDeviceIfNotExist(log *logrus.Entry, vol *volum
 			return "", fmt.Errorf("failed to get info of fake device %s of volume %s with error: %v", fakeDevice, vol.Name, err)
 		}
 		if len(blockDevices) == 0 {
-			log.Warnf("re-create non-existing fake device %s", fakeDevice)
+			log.Warnf("fake device %s doesn't exist! re-create the fake device for volume %s", fakeDevice, vol.Name)
 			fakeDevice, err = m.fsOps.CreateFakeDevice(fakeDeviceSrcFilePath)
 			if err != nil {
 				return "", fmt.Errorf("failed to create fake device for volume %s with error: %v", vol.Name, err)


### PR DESCRIPTION
## Purpose
### Resolves #1045 

1. Implement the fake attach feature for non-LVM-block-mode volumes.
2. Temporarily remove the forbidden 3rd-party action script from our github PR validation workflow to fix our github PR validation startup failure.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
We have manually verified that this fake attach solution for non-LVM-block-mode volumes can work both on HDD and NVME disks.
custom-ci passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-ci/1561/
custom-acceptance on Atlantic passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-tar_b_ona/38/
custom-acceptance on Openshift passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-oil_bd/254/
