### PR TITLE
[ISSUE-1045] Fake Attach Feature for Non-LVM-Block-Mode Volumes for OBS Release 1.3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,21 +107,23 @@ jobs:
         make install-controller-gen
         make generate-deepcopy
 
-    - name: Verify Changed files
-      uses: tj-actions/verify-changed-files@v5.5
-      id: changed_files
-      with:
-        files: |
-           api/generated/v1/*.go
-           api/v1/*/*.go
-           '.(go)$'
-           
-    - name: Display changed files
-      if: steps.changed_files.outputs.files_changed == 'true'
-      run: |
-        echo "Changed files: ${{ steps.changed_files.outputs.changed_files }}"
-        
-    - name: Perform action when files change.
-      if: steps.changed_files.outputs.files_changed == 'true'
-      run: |
-        exit 1
+# Temporarily comment out the forbidden 3rd-party action script from our github PR validation workflow
+# to fix our github PR validation startup failure.
+#    - name: Verify Changed files
+#      uses: tj-actions/verify-changed-files@v5.5
+#      id: changed_files
+#      with:
+#        files: |
+#           api/generated/v1/*.go
+#           api/v1/*/*.go
+#           '.(go)$'
+#
+#    - name: Display changed files
+#      if: steps.changed_files.outputs.files_changed == 'true'
+#      run: |
+#        echo "Changed files: ${{ steps.changed_files.outputs.changed_files }}"
+#
+#    - name: Perform action when files change.
+#      if: steps.changed_files.outputs.files_changed == 'true'
+#      run: |
+#        exit 1

--- a/pkg/mocks/linuxutils/fs_helper.go
+++ b/pkg/mocks/linuxutils/fs_helper.go
@@ -110,3 +110,31 @@ func (m *MockWrapFS) Unmount(src string) error {
 
 	return args.Error(0)
 }
+
+// CreateFileWithSizeInMB is a mock implementation
+func (m *MockWrapFS) CreateFileWithSizeInMB(filePath string, sizeMB int) error {
+	args := m.Mock.Called(filePath, sizeMB)
+
+	return args.Error(0)
+}
+
+// ReadLoopDevice is a mock implementation
+func (m *MockWrapFS) ReadLoopDevice(device string) (string, error) {
+	args := m.Mock.Called(device)
+
+	return args.String(0), args.Error(1)
+}
+
+// CreateLoopDevice is a mock implementation
+func (m *MockWrapFS) CreateLoopDevice(src string) (string, error) {
+	args := m.Mock.Called(src)
+
+	return args.String(0), args.Error(1)
+}
+
+// RemoveLoopDevice is a mock implementation
+func (m *MockWrapFS) RemoveLoopDevice(device string) error {
+	args := m.Mock.Called(device)
+
+	return args.Error(0)
+}

--- a/pkg/mocks/provisioners/fs_operations.go
+++ b/pkg/mocks/provisioners/fs_operations.go
@@ -53,3 +53,10 @@ func (m *MockFsOpts) CreateFSIfNotExist(fsType fs.FileSystem, device, uuid strin
 
 	return args.Error(0)
 }
+
+// CreateFakeDevice is a mock implementation
+func (m *MockFsOpts) CreateFakeDevice(src string) (string, error) {
+	args := m.Mock.Called(src)
+
+	return args.String(0), args.Error(1)
+}

--- a/pkg/node/common_test_data.go
+++ b/pkg/node/common_test_data.go
@@ -60,10 +60,12 @@ var (
 	testCtx    = context.Background()
 	disk1      = api.Drive{UUID: uuid.New().String(), SerialNumber: "hdd1", Size: 1024 * 1024 * 1024 * 500, NodeId: nodeID, Path: "/dev/sda"}
 	disk2      = api.Drive{UUID: uuid.New().String(), SerialNumber: "hdd2", Size: 1024 * 1024 * 1024 * 200, NodeId: nodeID, Path: "/dev/sda"}
+	disk4      = api.Drive{UUID: uuid.New().String(), SerialNumber: "hdd4", Size: 1024 * 1024 * 1024 * 500, NodeId: nodeID, Path: "/dev/sdb"}
 	// volumes
 	testV1ID = "volume-1-id"
 	testV2ID = "volume-2-id"
 	testV3ID = "volume-3-id"
+	testV4ID = "volume-4-id"
 
 	testVolume1 = api.Volume{
 		Id:           testV1ID,
@@ -71,6 +73,7 @@ var (
 		Location:     disk1.UUID,
 		StorageClass: apiV1.StorageClassHDD,
 		CSIStatus:    apiV1.VolumeReady,
+		Mode:         apiV1.ModeFS,
 	}
 	testVolume2 = api.Volume{
 		Id:           testV2ID,
@@ -80,6 +83,14 @@ var (
 		CSIStatus:    apiV1.Created,
 	}
 	testVolume3 = api.Volume{Id: testV3ID, NodeId: nodeID, Location: ""}
+	testVolume4 = api.Volume{
+		Id:           testV4ID,
+		NodeId:       nodeID,
+		Location:     disk4.UUID,
+		StorageClass: apiV1.StorageClassHDD,
+		CSIStatus:    apiV1.VolumeReady,
+		Mode:         apiV1.ModeRAWPART,
+	}
 
 	testVolumeCR1 = vcrd.Volume{
 		TypeMeta: k8smetav1.TypeMeta{Kind: "Volume", APIVersion: apiV1.APIV1Version},
@@ -107,6 +118,15 @@ var (
 			CreationTimestamp: k8smetav1.Time{Time: time.Now()},
 		},
 		Spec: testVolume3,
+	}
+	testVolumeCR4 = vcrd.Volume{
+		TypeMeta: k8smetav1.TypeMeta{Kind: "Volume", APIVersion: apiV1.APIV1Version},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name:              testVolume4.Id,
+			Namespace:         testNs,
+			CreationTimestamp: k8smetav1.Time{Time: time.Now()},
+		},
+		Spec: testVolume4,
 	}
 
 	testVolumeCap = &csi.VolumeCapability{


### PR DESCRIPTION
## Purpose
### Resolves #1045

1. Implement the fake attach feature for non-LVM-block-mode volumes.
2. Temporarily remove the forbidden 3rd-party action script from our github PR validation workflow to fix our github PR validation startup failure.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
We have manually verified that this fake attach solution for non-LVM-block-mode volumes can work both on HDD and NVME disks.
custom-ci passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-ci/1561/
custom-acceptance on Atlantic passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-tar_b_ona/38/
custom-acceptance on Openshift passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-oil_bd/254/
