### PR TITLE
[ISSUE-1051] Handle Kubelet's Wrong CSI Call Inconsistent with Real Volume Status for OBS Release 1.3

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -504,7 +504,7 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		if !srcMounted {
 			nodeStageReq := &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
-				StagingTargetPath: stagePath,
+				StagingTargetPath: req.GetStagingTargetPath(),
 				VolumeCapability:  req.GetVolumeCapability(),
 			}
 			nodeStageResp, err := s.NodeStageVolume(ctx, nodeStageReq)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -631,6 +631,9 @@ func (s *CSINodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeU
 	volumeCR.Spec.Owners = owners
 	if len(volumeCR.Spec.Owners) == 0 {
 		volumeCR.Spec.CSIStatus = apiV1.VolumeReady
+	} else {
+		// ensure the Published status of volume in the successful processing
+		volumeCR.Spec.CSIStatus = apiV1.Published
 	}
 	if updateErr := s.k8sClient.UpdateCR(ctxWithID, volumeCR); updateErr != nil {
 		ll.Errorf("Unable to set volume CR status to VolumeReady: %v", updateErr)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -353,12 +353,15 @@ func (s *CSINodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 	}
 
 	currStatus := volumeCR.Spec.CSIStatus
-	if currStatus == apiV1.Failed {
+	switch currStatus {
+	case apiV1.Failed:
 		ll.Warningf("Volume status: %s. Need to retry.", currStatus)
-	} else if currStatus == apiV1.Created {
+	case apiV1.Created:
 		ll.Info("Volume has been already unstaged")
 		return &csi.NodeUnstageVolumeResponse{}, nil
-	} else if currStatus != apiV1.VolumeReady {
+	case apiV1.VolumeReady:
+		ll.Infof("Expected volume status: %s", currStatus)
+	default:
 		msg := fmt.Sprintf("current volume CR status - %s, expected to be in [%s, %s]",
 			currStatus, apiV1.Created, apiV1.VolumeReady)
 		ll.Error(msg)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -353,7 +353,9 @@ func (s *CSINodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 	}
 
 	currStatus := volumeCR.Spec.CSIStatus
-	if currStatus == apiV1.Created {
+	if currStatus == apiV1.Failed {
+		ll.Warningf("Volume status: %s. Need to retry.", currStatus)
+	} else if currStatus == apiV1.Created {
 		ll.Info("Volume has been already unstaged")
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	} else if currStatus != apiV1.VolumeReady {
@@ -468,8 +470,9 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 	}
 
 	currStatus := volumeCR.Spec.CSIStatus
-	// if currStatus not in [VolumeReady, Published]
-	if currStatus != apiV1.VolumeReady && currStatus != apiV1.Published {
+	if currStatus == apiV1.Failed {
+		ll.Warningf("Volume status: %s. Need to retry.", currStatus)
+	} else if currStatus != apiV1.VolumeReady && currStatus != apiV1.Published {
 		msg := fmt.Sprintf("current volume CR status - %s, expected to be in [%s, %s]",
 			currStatus, apiV1.VolumeReady, apiV1.Published)
 		ll.Error(msg)
@@ -554,8 +557,9 @@ func (s *CSINodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeU
 	}
 
 	currStatus := volumeCR.Spec.CSIStatus
-	// if currStatus not in [VolumeReady, Published]
-	if currStatus != apiV1.VolumeReady && currStatus != apiV1.Published {
+	if currStatus == apiV1.Failed {
+		ll.Warningf("Volume status: %s. Need to retry.", currStatus)
+	} else if currStatus != apiV1.VolumeReady && currStatus != apiV1.Published {
 		msg := fmt.Sprintf("current volume CR status - %s, expected to be in [%s, %s]",
 			currStatus, apiV1.VolumeReady, apiV1.Published)
 		ll.Error(msg)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -526,6 +526,12 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 				ll.Error(errMsg)
 				return nil, fmt.Errorf("failed to publish volume: %s", errMsg)
 			}
+
+			// update the content of volume
+			volumeCR, err = s.crHelper.GetVolumeByID(volumeID)
+			if err != nil {
+				return nil, status.Error(codes.Internal, fmt.Sprintf("unable to get updated volume %s", volumeID))
+			}
 		}
 
 		_, isBlock := req.GetVolumeCapability().GetAccessType().(*csi.VolumeCapability_Block)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -502,6 +502,7 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 			return nil, fmt.Errorf("failed to publish volume: %s", errMsg)
 		}
 		if !srcMounted {
+			ll.Warnf("staging path %s is not mounted! need to redo NodeStageVolume!", srcPath)
 			nodeStageReq := &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
 				StagingTargetPath: req.GetStagingTargetPath(),

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -160,6 +160,19 @@ var _ = Describe("CSINodeService NodePublish()", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).To(ContainSubstring("Staging Path missing in request"))
 		})
+		It("Should fail, because Volume has failed status", func() {
+			req := getNodePublishRequest(testV1ID, targetPath, *testVolumeCap)
+			vol1 := &vcrd.Volume{}
+			err := node.k8sClient.ReadCR(testCtx, testVolume1.Id, testNs, vol1)
+			Expect(err).To(BeNil())
+			vol1.Spec.CSIStatus = apiV1.Failed
+			err = node.k8sClient.UpdateCR(testCtx, vol1)
+			Expect(err).To(BeNil())
+
+			resp, err := node.NodePublishVolume(testCtx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
 		It("Should fail, because of volume CR isn't exist", func() {
 			req := getNodePublishRequest(testV1ID, targetPath, *testVolumeCap)
 			err := node.k8sClient.DeleteCR(testCtx, &testVolumeCR1)

--- a/variables.mk
+++ b/variables.mk
@@ -9,7 +9,7 @@ CRD_OPTIONS ?= crd
 
 ### version
 MAJOR            := 1
-MINOR            := 4
+MINOR            := 3
 PATCH            := 0
 PRODUCT_VERSION  ?= ${MAJOR}.${MINOR}.${PATCH}
 BUILD_REL_A      := $(shell git rev-list HEAD |wc -l)


### PR DESCRIPTION
## Purpose
### Resolves #1051

1) Handle Kubelet's Wrong CSI Call Inconsistent with Real Volume Status
2) Proceed Kubelet's CSI call also on Failed Volume

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
