### PR TITLE
[ISSUE-1076] Race condition between volume reconstructor and volume d…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,7 @@ linters-settings:
           - k8s.io/apimachinery/pkg/apis/meta/v1
           - k8s.io/apimachinery/pkg/runtime
           - k8s.io/apimachinery/pkg/types
+          - k8s.io/apimachinery/pkg/util/wait
           - k8s.io/client-go/kubernetes
           - k8s.io/client-go/plugin/pkg/client/auth/gcp
           - k8s.io/client-go/rest

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -66,7 +66,7 @@ import (
 const (
 	componentName = "csi-baremetal-node"
 	// on loaded system drive manager might response with the delay
-	numberOfRetries  = 20
+	numberOfRetries  = 40
 	delayBeforeRetry = 5
 )
 

--- a/pkg/base/error/k8s.go
+++ b/pkg/base/error/k8s.go
@@ -8,3 +8,7 @@ func IsSafeReturnError(err error) bool {
 		k8sError.IsTimeout(err) ||
 		k8sError.IsTooManyRequests(err)
 }
+
+func AlwaysSafeReturnError(err error) bool {
+	return true
+}

--- a/pkg/base/error/k8s.go
+++ b/pkg/base/error/k8s.go
@@ -9,6 +9,7 @@ func IsSafeReturnError(err error) bool {
 		k8sError.IsTooManyRequests(err)
 }
 
+// AlwaysSafeReturnError returns true for all errors
 func AlwaysSafeReturnError(err error) bool {
 	return true
 }

--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -48,6 +48,7 @@ import (
 	"github.com/dell/csi-baremetal/api/v1/volumecrd"
 	"github.com/dell/csi-baremetal/pkg/base"
 	"github.com/dell/csi-baremetal/pkg/base/command"
+	checkErr "github.com/dell/csi-baremetal/pkg/base/error"
 	"github.com/dell/csi-baremetal/pkg/base/k8s"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/datadiscover"
 	"github.com/dell/csi-baremetal/pkg/base/linuxutils/datadiscover/types"
@@ -63,7 +64,6 @@ import (
 	"github.com/dell/csi-baremetal/pkg/node/provisioners/utilwrappers"
 	wbtconf "github.com/dell/csi-baremetal/pkg/node/wbt/common"
 	wbtops "github.com/dell/csi-baremetal/pkg/node/wbt/operations"
-	checkErr "github.com/dell/csi-baremetal/pkg/base/error"
 )
 
 const (
@@ -669,12 +669,12 @@ func (m *VolumeManager) updateDrivesCRs(ctx context.Context, drivesFromMgr []*ap
 						Jitter:   0,
 					}
 					if err := retry.OnError(updateRetry, checkErr.AlwaysSafeReturnError, func() error {
-							if err1 := m.k8sClient.UpdateCR(ctx, &toUpdate) ; err1 != nil {
-								ll.Infof("Failed to update drive CR (health/status) retrying, error %v", err1)
-								return err1
-							}
-							return nil
-						}); err != nil {
+						if err1 := m.k8sClient.UpdateCR(ctx, &toUpdate); err1 != nil {
+							ll.Infof("Failed to update drive CR (health/status) retrying, error %v", err1)
+							return err1
+						}
+						return nil
+					}); err != nil {
 						ll.Errorf("Failed to update drive CR (health/status) %v, error %v", toUpdate, err)
 						updates.AddNotChanged(previousState)
 					} else {


### PR DESCRIPTION
…iscovery

## Purpose
### Resolves #<!--- insert your issue number here -->

Fix retries updateDrivesCRs procedure multiple times in case of apiserver being inaccessible. At the same time readiness status remains in false state blocking Volume Reconstruction phase

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
