### PR TITLE
[Issue-1088] Drive status is not set to OFFLINE when health is changed to BAD

### DIFF
--- a/pkg/node/volumemgr.go
+++ b/pkg/node/volumemgr.go
@@ -645,7 +645,6 @@ func (m *VolumeManager) updateDrivesCRs(ctx context.Context, drivesFromMgr []*ap
 				}
 				if value, ok := driveCR.GetAnnotations()[driveHealthOverrideAnnotation]; ok {
 					m.overrideDriveHealth(drivePtr, value, driveCR.Name)
-					m.overrideDriveStatusWhenHealthBad(drivePtr, value, driveCR.Name)
 				}
 				if driveCR.Equals(drivePtr) {
 					updates.AddNotChanged(&driveCR)
@@ -1311,6 +1310,7 @@ func (m *VolumeManager) overrideDriveHealth(drive *api.Drive, overriddenHealth, 
 		m.log.Warnf("Drive %s has health annotation. Health %s has been overridden with %s.",
 			driveCRName, drive.Health, overriddenHealth)
 		drive.Health = overriddenHealth
+		m.overrideDriveStatusWhenHealthBad(drive, overriddenHealth, driveCRName)
 	} else {
 		m.log.Errorf("Drive %s has health annotation, but value %s is not %s/%s/%s/%s. Health is not overridden.",
 			driveCRName, overriddenHealth, apiV1.HealthGood, apiV1.HealthSuspect, apiV1.HealthBad, apiV1.HealthUnknown)

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -831,10 +831,7 @@ func TestVolumeManager_updatesDrivesCRs_Success(t *testing.T) {
 		assert.Nil(t, vm.k8sClient.ReadCR(testCtx, drive.Name, "", actualDrive))
 		assert.Nil(t, err)
 		assert.Equal(t, actualDrive.Spec.Health, apiV1.HealthBad)
-
-		updatedDrive := &drivecrd.Drive{}
-		assert.Nil(t, vm.k8sClient.ReadCR(testCtx, drive.Name, "", updatedDrive))
-		assert.Equal(t, apiV1.DriveStatusOffline, updatedDrive.Spec.Status)
+		assert.Equal(t, apiV1.DriveStatusOffline, actualDrive.Spec.Status)
 	})
 
 	t.Run("new drive", func(t *testing.T) {

--- a/pkg/node/volumemgr_test.go
+++ b/pkg/node/volumemgr_test.go
@@ -831,6 +831,10 @@ func TestVolumeManager_updatesDrivesCRs_Success(t *testing.T) {
 		assert.Nil(t, vm.k8sClient.ReadCR(testCtx, drive.Name, "", actualDrive))
 		assert.Nil(t, err)
 		assert.Equal(t, actualDrive.Spec.Health, apiV1.HealthBad)
+
+		updatedDrive := &drivecrd.Drive{}
+		assert.Nil(t, vm.k8sClient.ReadCR(testCtx, drive.Name, "", updatedDrive))
+		assert.Equal(t, apiV1.DriveStatusOffline, updatedDrive.Spec.Status)
 	})
 
 	t.Run("new drive", func(t *testing.T) {


### PR DESCRIPTION


## Purpose
### Resolves #1088 

Drive status is not set to OFFLINE when health is changed to BAD

## PR checklist
- [X] Add link to the issue
- [X] Choose Project
- [X] Choose PR label
- [ ] New unit tests added
- [X] Modified code has meaningful comments
- [X] All TODOs are linked with the issues
- [X] All comments are resolved

## Testing
_Provide test details_
