### PR TITLE
[Issue-1104] model mismatch

### DIFF
--- a/pkg/base/linuxutils/lsblk/lsblk.go
+++ b/pkg/base/linuxutils/lsblk/lsblk.go
@@ -174,8 +174,10 @@ func (l *LSBLK) SearchDrivePath(drive *api.Drive) (string, error) {
 	pid := drive.PID
 	for _, l := range lsblkOut {
 		lvid := strings.TrimSpace(l.Vendor)
+		// The hasPrefixIgnoreSpaces function is used to compare pid and lsblk model, accounting for drives that may have
+		// multiple spaces in their pid, and situations where pid is truncated or limited to 16 digits compared to lsblk model.
 		if strings.EqualFold(l.Serial, sn) && strings.EqualFold(lvid, vid) &&
-			strings.HasPrefix(l.Model, pid) {
+			hasPrefixIgnoreSpaces(l.Model, pid) {
 			device = l.Name
 			break
 		}
@@ -187,4 +189,13 @@ func (l *LSBLK) SearchDrivePath(drive *api.Drive) (string, error) {
 	}
 
 	return device, nil
+}
+
+func hasPrefixIgnoreSpaces(s, prefix string) bool {
+	empty := ""
+	emptySpace := " "
+	s = strings.ReplaceAll(s, emptySpace, empty)
+	prefix = strings.ReplaceAll(prefix, emptySpace, empty)
+
+	return strings.HasPrefix(s, prefix)
 }

--- a/pkg/base/linuxutils/lsblk/lsblk_test.go
+++ b/pkg/base/linuxutils/lsblk/lsblk_test.go
@@ -97,6 +97,26 @@ func TestLSBLK_SearchDrivePath_Success(t *testing.T) {
 	assert.Equal(t, expectedDevice, res)
 }
 
+func TestLSBLK_SearchDrivePath_ModelWithEmptySpaces_Success(t *testing.T) {
+	l := NewLSBLK(testLogger)
+	e := &mocks.GoMockExecutor{}
+	e.On("RunCmd", allDevicesCmd).Return(mocks.LsblkDevV2, "", nil)
+	l.e = e
+
+	sn := "5000cca0bbce17ff"
+	pid := "HGS  THUS728T8TA"
+	vendor := "ATA"
+	expectedDevice := "/dev/sdc"
+	d2CR := testDriveCR
+	d2CR.Spec.SerialNumber = sn
+	d2CR.Spec.VID = vendor
+	d2CR.Spec.PID = pid
+
+	res, err := l.SearchDrivePath(&d2CR.Spec)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedDevice, res)
+}
+
 func TestLSBLK_SearchDrivePath(t *testing.T) {
 	e := &mocks.GoMockExecutor{}
 	l := NewLSBLK(testLogger)

--- a/pkg/mocks/commands.go
+++ b/pkg/mocks/commands.go
@@ -163,7 +163,7 @@ var LsblkDevV2 = `{
 				"serial":"5000cca0bbce17ff",
 				"wwn":"0x5000cca0bbce17ff",
 				"vendor":"ATA     ",
-				"model":"HGST_HUS728T8TAL",
+				"model":"HGS THUS728T8TAL",
 				"rev":"RT04",
 				"mountpoint":null,
 				"fstype":null,


### PR DESCRIPTION
## Purpose
### Resolves https://github.com/dell/csi-baremetal/issues/1104 (https://github.com/dell/csi-baremetal/issues/1104)

Correctly match drives when hal mgr returns model with double empty spaces inside model name

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Full regression
