### PR TITLE
[ISSUE-1110] Vendor name not present in lsblk

### DIFF
--- a/pkg/base/linuxutils/lsblk/lsblk.go
+++ b/pkg/base/linuxutils/lsblk/lsblk.go
@@ -174,7 +174,7 @@ func (l *LSBLK) SearchDrivePath(drive *api.Drive) (string, error) {
 		lvid := strings.TrimSpace(l.Vendor)
 		// The hasPrefixIgnoreSpaces function is used to compare pid and lsblk model, accounting for drives that may have
 		// multiple spaces in their pid, and situations where pid is truncated or limited to 16 digits compared to lsblk model.
-		if strings.EqualFold(l.Serial, sn) && strings.EqualFold(lvid, vid) &&
+		if strings.EqualFold(l.Serial, sn) && (lvid == "" || strings.EqualFold(lvid, vid)) &&
 			hasPrefixIgnoreSpaces(l.Model, pid) {
 			device = l.Name
 			break

--- a/pkg/base/linuxutils/lsblk/lsblk_test.go
+++ b/pkg/base/linuxutils/lsblk/lsblk_test.go
@@ -150,6 +150,27 @@ func TestLSBLK_SearchDrivePath(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestLSBLK_SearchDrivePath_EmptyVendor_Success(t *testing.T) {
+	l := NewLSBLK(testLogger)
+	e := &mocks.GoMockExecutor{}
+
+	e.On("RunCmd", allDevicesCmd).Return(mocks.LsblkDevNullVendor, "", nil)
+	l.e = e
+
+	sn := "PHLJ043300VY4P0DGN"
+	pid := "Dell Express Flash NVMe P4510 4TB SFF"
+	vendor := "0x8086"
+	expectedDevice := "/dev/sdc"
+	d2CR := testDriveCR
+	d2CR.Spec.SerialNumber = sn
+	d2CR.Spec.VID = vendor
+	d2CR.Spec.PID = pid
+
+	res, err := l.SearchDrivePath(&d2CR.Spec)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedDevice, res)
+}
+
 func TestLSBLK_GetBlockDevicesV2_Success(t *testing.T) {
 	l := NewLSBLK(testLogger)
 	e := &mocks.GoMockExecutor{}

--- a/pkg/mocks/commands.go
+++ b/pkg/mocks/commands.go
@@ -170,6 +170,22 @@ var LsblkDevV2 = `{
 				"partuuid":null
 			}]}`
 
+// LsblkDevNullVendor provides output for lsblk with null vendor
+var LsblkDevNullVendor = `{
+			"blockdevices": [{
+				"name":"/dev/sdc",
+				"type":"disk",
+				"size":8001563222016,
+				"rota":true,
+				"serial":"PHLJ043300VY4P0DGN",
+				"vendor":null,
+				"model":"Dell Express Flash NVMe P4510 4TB SFF",
+				"rev":"RT04",
+				"mountpoint":null,
+				"fstype":null,
+				"partuuid":null
+			}]}`
+
 var (
 	// HDDBlockDeviceName contains name of HDD device
 	HDDBlockDeviceName = "/dev/sdb"


### PR DESCRIPTION
## Purpose
### Resolves #1110 

Matches drives in case vendor is null from lsblk. Only based on SN and PID.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Full regression
