### PR TITLE
[ISSUE-1178]: Disk Eject, fixed fake attach after node reboot during DR

### DIFF
--- a/pkg/crcontrollers/drive/drivecontroller.go
+++ b/pkg/crcontrollers/drive/drivecontroller.go
@@ -57,8 +57,8 @@ const (
 	fakeAttachVolumeAnnotation = "fake-attach"
 	fakeAttachVolumeKey        = "yes"
 
-	allVolumesFakeAttachedAnnotation = "all-volumes-fake-attached"
-	allVolumesFakeAttachedKey        = "yes"
+	allDRVolumesFakeAttachedAnnotation = "all-dr-volumes-fake-attached"
+	allDRVolumesFakeAttachedKey        = "yes"
 )
 
 // NewController creates new instance of Controller structure
@@ -181,8 +181,8 @@ func (c *Controller) handleDriveUpdate(ctx context.Context, log *logrus.Entry, d
 			break
 		}
 
-		value, foundAllVolFakeAttach := drive.Annotations[allVolumesFakeAttachedAnnotation]
-		fakeAttachDR := !drive.Spec.IsClean && foundAllVolFakeAttach && value == allVolumesFakeAttachedKey
+		value, foundAllDRVolFakeAttach := drive.Annotations[allDRVolumesFakeAttachedAnnotation]
+		fakeAttachDR := !drive.Spec.IsClean && foundAllDRVolFakeAttach && value == allDRVolumesFakeAttachedKey
 		if drive.Spec.IsClean || fakeAttachDR {
 			log.Infof("Initiating automatic removal of drive: %s", drive.GetName())
 		} else {

--- a/pkg/crcontrollers/drive/drivecontroller_test.go
+++ b/pkg/crcontrollers/drive/drivecontroller_test.go
@@ -468,7 +468,7 @@ func TestDriveController_handleDriveUpdate(t *testing.T) {
 		assert.NotNil(t, expectedD)
 		expectedD.Spec.Usage = apiV1.DriveUsageReleased
 		expectedD.Spec.IsClean = false
-		expectedD.Annotations = map[string]string{allVolumesFakeAttachedAnnotation: allVolumesFakeAttachedKey}
+		expectedD.Annotations = map[string]string{allDRVolumesFakeAttachedAnnotation: allDRVolumesFakeAttachedKey}
 		assert.Nil(t, dc.client.CreateCR(testCtx, expectedD.Name, expectedD))
 
 		expectedV := failedVolCR.DeepCopy()
@@ -880,19 +880,19 @@ func TestDriveController_handleDriveUsageRemovingWithLED(t *testing.T) {
 		expectedLedState string
 	}{
 		{
-			name: "Check locate drive state - Success",
-			client: &mocks.MockDriveMgrClient{},
-			currentUsage: apiV1.DriveUsageRemoving,
-			currentLedState: fmt.Sprintf("%d", apiV1.LocateStatusOff),
-			expectedUsage: apiV1.DriveUsageRemoved,
+			name:             "Check locate drive state - Success",
+			client:           &mocks.MockDriveMgrClient{},
+			currentUsage:     apiV1.DriveUsageRemoving,
+			currentLedState:  fmt.Sprintf("%d", apiV1.LocateStatusOff),
+			expectedUsage:    apiV1.DriveUsageRemoved,
 			expectedLedState: fmt.Sprintf("%d", apiV1.LocateStatusOn),
 		},
 		{
-			name: "Check locate drive state - Locate failure",
-			client: &mocks.MockDriveMgrClientFail{},
-			currentUsage: apiV1.DriveUsageRemoving,
-			currentLedState: fmt.Sprintf("%d", apiV1.LocateStatusOff),
-			expectedUsage: apiV1.DriveUsageFailed,
+			name:             "Check locate drive state - Locate failure",
+			client:           &mocks.MockDriveMgrClientFail{},
+			currentUsage:     apiV1.DriveUsageRemoving,
+			currentLedState:  fmt.Sprintf("%d", apiV1.LocateStatusOff),
+			expectedUsage:    apiV1.DriveUsageFailed,
 			expectedLedState: fmt.Sprintf("%d", apiV1.LocateStatusOff),
 		},
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -60,8 +60,8 @@ const (
 	fakeAttachVolumeAnnotation = "fake-attach"
 	fakeAttachVolumeKey        = "yes"
 
-	allVolumesFakeAttachedAnnotation = "all-volumes-fake-attached"
-	allVolumesFakeAttachedKey        = "yes"
+	allDRVolumesFakeAttachedAnnotation = "all-dr-volumes-fake-attached"
+	allDRVolumesFakeAttachedKey        = "yes"
 
 	fakeDeviceVolumeAnnotation = "fake-device"
 	fakeDeviceSrcFileDir       = "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/fake/"
@@ -200,15 +200,21 @@ func (s *CSINodeService) processFakeAttachInNodeStageVolume(
 	return nil
 }
 
-// annotateIfAllVolsFakeAttached checks if all volumes associated with a drive used by a given volume are fake attached.
+// annotateIfAllDRVolsFakeAttached checks if all volumes associated with a drive (under DR) used by a given volume are fake attached.
 //
 // The function takes a context.Context object and a pointer to a volumecrd.Volume object as parameters.
 // It returns an error if there is an error during the process.
-func (s *CSINodeService) annotateIfAllVolsFakeAttached(ctx context.Context, volumeCR *volumecrd.Volume) error {
+func (s *CSINodeService) annotateIfAllDRVolsFakeAttached(ctx context.Context, volumeCR *volumecrd.Volume) error {
 	driveCR, err := s.crHelper.GetDriveCRByVolume(volumeCR)
 	if err != nil {
 		s.log.Errorf("failed to get driveCR by volumeCR %s: %v", volumeCR.Name, err)
 		return err
+	}
+
+	isDR := driveCR.Spec.Status == apiV1.DriveStatusOnline
+	if !isDR {
+		s.log.Debugf("drive %s is not online, no need to annotate", driveCR.Spec.GetUUID())
+		return nil
 	}
 
 	volumes, err := s.crHelper.GetVolumesByLocation(ctx, driveCR.Spec.GetUUID())
@@ -228,7 +234,7 @@ func (s *CSINodeService) annotateIfAllVolsFakeAttached(ctx context.Context, volu
 		driveCR.Annotations = make(map[string]string)
 	}
 
-	driveCR.Annotations[allVolumesFakeAttachedAnnotation] = allVolumesFakeAttachedKey
+	driveCR.Annotations[allDRVolumesFakeAttachedAnnotation] = allDRVolumesFakeAttachedKey
 	if err = s.k8sClient.UpdateCR(ctx, driveCR); err != nil {
 		s.log.Errorf("failed to update driveCR %s: %v", driveCR.Name, err)
 		return err
@@ -259,9 +265,9 @@ func (s *CSINodeService) isFakeAttachNeed(volumeCR *volumecrd.Volume) (bool, boo
 	if value, ok := pvc.Annotations[fakeAttachAnnotation]; ok && value == fakeAttachAllowKey {
 		fakeAttachBasic = true
 		if driveCR, err := s.crHelper.GetDriveCRByVolume(volumeCR); err == nil {
-			value, found := driveCR.Annotations[allVolumesFakeAttachedAnnotation]
+			value, found := driveCR.Annotations[allDRVolumesFakeAttachedAnnotation]
 			// it's required to keep fake-attach during node reboot
-			allVolsPreviouslyFakeAttached := found && value == allVolumesFakeAttachedKey
+			allVolsPreviouslyFakeAttached := found && value == allDRVolumesFakeAttachedKey
 			fakeAttachDR = (driveCR.Spec.Usage == apiV1.DriveUsageReleased && driveCR.Spec.Status == apiV1.DriveStatusOnline) || allVolsPreviouslyFakeAttached
 		}
 	}
@@ -606,7 +612,7 @@ func (s *CSINodeService) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		resp, errToReturn = nil, fmt.Errorf("failed to publish volume: update volume CR error")
 	}
 
-	if err = s.annotateIfAllVolsFakeAttached(ctx, volumeCR); err != nil {
+	if err = s.annotateIfAllDRVolsFakeAttached(ctx, volumeCR); err != nil {
 		ll.Errorf("Failed to annotate drive CR, error: %v", err)
 		resp, errToReturn = nil, fmt.Errorf("failed to publish volume: annotate drive CR error, %s", err.Error())
 	}


### PR DESCRIPTION
## Purpose
### Resolves #1178 

Checked if all volumes were previously fake-attached.

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Provide test details_
