### PR TITLE
[Issue-1227] remove and restore patched kube-scheduler manifest

### DIFF
--- a/pkg/scheduler/patcher/main.py
+++ b/pkg/scheduler/patcher/main.py
@@ -238,10 +238,11 @@ class ManifestFile(File):
         copy(self.path, backup_path)
 
     def backup2(self):
-        backup_path2 = join(self.backup_folder,basename(self.path),"2")
-        move(self.path, backup_path2)    
-        move(backup_path2, self.path)
-        log.info('{} copied to {}'.format(self.pathsrc.path, backup_path2))
+        backup_path = join(self.backup_folder,basename(self.path))
+        move(self.path, backup_path)    
+        log.info('{} moved to {}'.format(self.path, backup_path))
+        move(backup_path, self.path)
+        log.info('{} moved to {}'.format(self.path, backup_path))
 
     def restore(self):
         backup_path = join(self.backup_folder,basename(self.path))

--- a/pkg/scheduler/patcher/main.py
+++ b/pkg/scheduler/patcher/main.py
@@ -22,7 +22,7 @@ import time
 from filecmp import clear_cache, cmp
 from os import makedirs, remove
 from os.path import basename, dirname, isfile , join
-from shutil import copy
+from shutil import copy, move
 from signal import SIGINT, SIGTERM, signal
 
 import yaml
@@ -160,6 +160,7 @@ def run():
         if manifest.changed:
             manifest.backup()
             manifest.flush()
+            manifest.backup2()
             log.info('manifest file({}) was patched'.format(manifest.path))
             first_try = False
 
@@ -235,6 +236,12 @@ class ManifestFile(File):
         makedirs(dirname(self.backup_folder), exist_ok=True)
         backup_path = join(self.backup_folder,basename(self.path))
         copy(self.path, backup_path)
+
+    def backup2(self):
+        backup_path2 = join(self.backup_folder,basename(self.path),"2")
+        move(self.path, backup_path2)    
+        move(backup_path2, self.path)
+        log.info('{} copied to {}'.format(self.pathsrc.path, backup_path2))
 
     def restore(self):
         backup_path = join(self.backup_folder,basename(self.path))

--- a/pkg/scheduler/patcher/main.py
+++ b/pkg/scheduler/patcher/main.py
@@ -160,7 +160,7 @@ def run():
         if manifest.changed:
             manifest.backup()
             manifest.moveManifest()
-            manifest.flush2()
+            manifest.flushMovedManifest()
             log.info('manifest file({}) was patched'.format(manifest.copyPath))
             manifest.restoreManifest()
             first_try = False
@@ -245,7 +245,7 @@ class ManifestFile(File):
         
     def restoreManifest(self): 
         move(self.copyPath, self.path)    
-        log.info('{} moved to {}'.format(self.copyPath, self.path))    
+        log.info('{} restored from {}'.format(self.copyPath, self.path))    
 
     def restore(self):
         backup_path = join(self.backup_folder,basename(self.path))
@@ -261,7 +261,7 @@ class ManifestFile(File):
             log.debug('manifest {} loaded'.format(self.path))
             self.changed = False
 
-    def flush2(self):
+    def flushMovedManifest(self):
         with open(self.copyPath, 'w') as f:
             yaml.dump(self.content, f)
             log.debug('manifest {} dumped'.format(self.copyPath))

--- a/pkg/scheduler/patcher/main.py
+++ b/pkg/scheduler/patcher/main.py
@@ -159,10 +159,9 @@ def run():
 
         if manifest.changed:
             manifest.backup()
-            manifest.moveManifest()
-            manifest.flushMovedManifest()
+            manifest.remove()
+            manifest.flush()
             log.info('manifest file({}) was patched'.format(manifest.copyPath))
-            manifest.restoreManifest()
             first_try = False
 
         if first_try:


### PR DESCRIPTION
## Purpose
### Resolves #1227 

Static pod definition for kube-scheduelr has to be removed, patched and next restored  to be detected by kubelet loop.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Full regression
