### PR TITLE
[issue-1240] adding rmapbt=0 to allow bigger space allocation

### DIFF
--- a/pkg/base/linuxutils/fs/fs_helper.go
+++ b/pkg/base/linuxutils/fs/fs_helper.go
@@ -50,7 +50,7 @@ const (
 	// MkFSCmdTmpl mkfs command template
 	MkFSCmdTmpl = "mkfs.%s %s %s" // args: 1 - fs type, 2 - device/path, 3 - fs uuid option
 	// XfsUUIDOption option to set uuid for mkfs.xfs
-	XfsUUIDOption = "-m uuid=%s"
+	XfsUUIDOption = "-m uuid=%s -m rmapbt=0"
 	// ExtUUIDOption option to set uuid for mkfs.ext3(4)
 	ExtUUIDOption = "-U %s"
 	// SpeedUpFsCreationOpts options that could be used for speeds up creation of ext3 and ext4 FS


### PR DESCRIPTION
## Purpose
### Resolves #1240 

Adding rmapbt=0 option when  creating file systems to allow bigger space allocation. 

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Full regression
